### PR TITLE
Create Trackable.wurst

### DIFF
--- a/Trackable.wurst
+++ b/Trackable.wurst
@@ -1,6 +1,6 @@
 package Trackable
 
-  /* 
+	/* 
 	If you need invisible Trackable models here are a few downloadlinks:
 	8x8 	"https://dl.dropbox.com/u/103859688/Trackables/8x8Track.mdx"
 	16x16	"https://dl.dropbox.com/u/103859688/Trackables/16x16Track.mdx"
@@ -51,14 +51,21 @@ package Trackable
 	public function trackable.getOwner() returns player
 		int hID = GetHandleId(this)
 		return trackData.loadPlayerHandle(hID, 4)
+	
+	/** Returns the right handle if you use the "registerTrackableHit/TrackEventForAllPlayers" function */
+	public function trackable.getZentralHandleId() returns int
+		return trackData.loadInt(GetHandleId(this), 5)
 		
 	/** This function creates 12 trackables (one for each player) so you can get the triggering player: GetTriggeringTrackable.getOwner()
 	Keep in mind, that this function is not realy performant!!! */
 	public function trigger.registerTrackableTrackEventForAllPlayers(trackable t)
 		vec2 pos = t.getPosition()
 		string path = t.getPath()
+		int zentralHID = GetHandleId(t)
 		for int i = 0 to 11
 			trackable tempT = createTrackableForPlayer(path, pos, Player(i))
+			int hID = GetHandleId(tempT)
+			trackData.saveInt(hID, 5, zentralHID)
 			this.registerTrackableTrackEvent(tempT)
 			
 	/** This function creates 12 trackables (one for each player) so you can get the triggering player: GetTriggeringTrackable.getOwner()
@@ -66,8 +73,11 @@ package Trackable
 	public function trigger.registerTrackableHitEventForAllPlayers(trackable t)
 		vec2 pos = t.getPosition()
 		string path = t.getPath()
+		int zentralHID = GetHandleId(t)
 		for int i = 0 to 11
 			trackable tempT = createTrackableForPlayer(path, pos, Player(i))
+			int hID = GetHandleId(tempT)
+			trackData.saveInt(hID, 5, zentralHID)
 			this.registerTrackableHitEvent(tempT)
 			
 	


### PR DESCRIPTION
Little package with easy functions, and some features:
- Create a trackable for some specific player
- Get the current trackable position
- Get the model path of the trackable
- Get the owner of the trackable, if created just for one player  
  This package is maybe a bit to special, but in my eyes the natives are just to limited, so i added the features.
  I know there is a problem with the last function, because if u write in the trigger action:
  GetHandleID(GetTriggeringTrackable()) the ID you get is wrong.
  I will add a extra function for getting the right one.
