### PR TITLE
Update TimerUtils.wurst

### DIFF
--- a/Wurstpack/wurstscript/lib/small helpers/TimerUtils.wurst
+++ b/Wurstpack/wurstscript/lib/small helpers/TimerUtils.wurst
@@ -55,6 +55,9 @@ public function timer.resume()
 	
 public function timer.getElapsed() returns real
 	return TimerGetElapsed(this)
+	
+public function timer.getRemaining() returns real
+	return TimerGetRemaining(this)
 
 public function timer.start(real time, code timerCallBack)
 	TimerStart(this, time, false, timerCallBack)


### PR DESCRIPTION
just added getRemaining() to timer utils since I need it and getElapsed() is also available.
