### PR TITLE
Changed order of compiletime execution (WIP)

### DIFF
--- a/de.peeeq.wurstscript/parserspec/jass_im.parseq
+++ b/de.peeeq.wurstscript/parserspec/jass_im.parseq
@@ -84,7 +84,7 @@ ImFlatExpr =
 	| ImClassRelatedExpr
 	| ImConst
 	| ImGetStackTrace()
-	| ImCompiletimeExpr(de.peeeq.wurstscript.ast.Element trace, ImExpr expr)
+	| ImCompiletimeExpr(de.peeeq.wurstscript.ast.Element trace, ImExpr expr, int executionOrderIndex)
 	
 ImClassRelatedExpr = 
 	  ImMethodCall(de.peeeq.wurstscript.ast.Element trace, ref ImMethod method, ImExpr receiver, ImExprs arguments, boolean tuplesEliminated)

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/Main.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/Main.java
@@ -44,6 +44,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.SimpleFormatter;
 
+import static de.peeeq.wurstio.CompiletimeFunctionRunner.FunctionFlagToRun.CompiletimeFunctions;
 import static javax.swing.SwingConstants.CENTER;
 
 public class Main {
@@ -386,7 +387,7 @@ public class Main {
 
             // compiletime functions
             gui.sendProgress("Running compiletime functions");
-            CompiletimeFunctionRunner ctr = new CompiletimeFunctionRunner(compiler.getImProg(), mapFile, mpqEditor, gui, FunctionFlagEnum.IS_COMPILETIME);
+            CompiletimeFunctionRunner ctr = new CompiletimeFunctionRunner(compiler.getImProg(), mapFile, mpqEditor, gui, CompiletimeFunctions);
             ctr.setInjectObjects(runArgs.isInjectObjects());
             ctr.run();
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/BuildMap.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/BuildMap.java
@@ -42,6 +42,8 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import static de.peeeq.wurstio.CompiletimeFunctionRunner.FunctionFlagToRun.CompiletimeFunctions;
+
 /**
  * Created by peter on 16.05.16.
  */
@@ -278,7 +280,7 @@ public class BuildMap extends UserRequest<Object> {
                 // TODO run optimizations later?
                 gui.sendProgress("Running compiletime functions");
                 CompiletimeFunctionRunner ctr = new CompiletimeFunctionRunner(compiler.getImProg(), compiler.getMapFile(), compiler.getMapfileMpqEditor(), gui,
-                        FunctionFlagEnum.IS_COMPILETIME);
+                        CompiletimeFunctions);
                 ctr.setInjectObjects(runArgs.isInjectObjects());
                 ctr.setOutputStream(new PrintStream(System.err));
                 ctr.run();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
@@ -46,6 +46,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static de.peeeq.wurstio.CompiletimeFunctionRunner.FunctionFlagToRun.CompiletimeFunctions;
+
 /**
  * Created by peter on 16.05.16.
  */
@@ -286,7 +288,7 @@ public class RunMap extends UserRequest<Object> {
                 // TODO run optimizations later?
                 gui.sendProgress("Running compiletime functions");
                 CompiletimeFunctionRunner ctr = new CompiletimeFunctionRunner(compiler.getImProg(), compiler.getMapFile(), compiler.getMapfileMpqEditor(), gui,
-                        FunctionFlagEnum.IS_COMPILETIME);
+                        CompiletimeFunctions);
                 ctr.setInjectObjects(runArgs.isInjectObjects());
                 ctr.setOutputStream(new PrintStream(System.err));
                 ctr.run();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
@@ -7,10 +7,7 @@ import de.peeeq.wurstio.jassinterpreter.InterpreterException;
 import de.peeeq.wurstscript.ast.Element;
 import de.peeeq.wurstscript.gui.WurstGui;
 import de.peeeq.wurstscript.intermediatelang.ILconst;
-import de.peeeq.wurstscript.jassIm.ImClass;
-import de.peeeq.wurstscript.jassIm.ImFunction;
-import de.peeeq.wurstscript.jassIm.ImProg;
-import de.peeeq.wurstscript.jassIm.ImStmt;
+import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.parser.WPos;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -202,6 +199,24 @@ public class ProgramState extends State {
 
     public boolean isCompiletime() {
         return isCompiletime;
+    }
+
+    protected Map<Integer, ILconst> getArray(ImVar v) {
+        Map<Integer, ILconst> r = arrayValues.get(v);
+        if (r == null) {
+            r = Maps.newLinkedHashMap();
+            arrayValues.put(v, r);
+            ImExpr e = prog.getGlobalInits().get(v);
+            if (e instanceof ImTupleExpr) {
+                ImTupleExpr te = (ImTupleExpr) e;
+                LocalState ls = new LocalState();
+                for (int i = 0; i < te.getExprs().size(); i++) {
+                    ILconst val = te.getExprs().get(i).evaluate(this, ls);
+                    r.put(i, val);
+                }
+            }
+        }
+        return r;
     }
 
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/State.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/State.java
@@ -11,7 +11,7 @@ import java.util.Map.Entry;
 public abstract class State {
 
     private Map<ImVar, ILconst> values = Maps.newLinkedHashMap();
-    private Map<ImVar, Map<Integer, ILconst>> arrayValues = Maps.newLinkedHashMap();
+    protected Map<ImVar, Map<Integer, ILconst>> arrayValues = Maps.newLinkedHashMap();
 
 
     public void setVal(ImVar v, ILconst val) {
@@ -22,7 +22,7 @@ public abstract class State {
         return values.get(v);
     }
 
-    private Map<Integer, ILconst> getArray(ImVar v) {
+    protected Map<Integer, ILconst> getArray(ImVar v) {
         Map<Integer, ILconst> r = arrayValues.get(v);
         if (r == null) {
             r = Maps.newLinkedHashMap();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImAttributes.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImAttributes.java
@@ -4,6 +4,7 @@ import de.peeeq.wurstscript.ast.Ast;
 import de.peeeq.wurstscript.attributes.CompileError;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.translation.imtranslation.FunctionFlag;
+import de.peeeq.wurstscript.translation.imtranslation.FunctionFlagCompiletime;
 import de.peeeq.wurstscript.translation.imtranslation.FunctionFlagEnum;
 
 public class ImAttributes {
@@ -64,7 +65,8 @@ public class ImAttributes {
     }
 
     public static boolean isCompiletime(ImFunction f) {
-        return f.getFlags().contains(FunctionFlagEnum.IS_COMPILETIME);
+        return f.getFlags().stream()
+                .anyMatch(flag -> flag instanceof FunctionFlagCompiletime);
     }
 
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
@@ -395,7 +395,7 @@ public class ExprTranslation {
                 && e.attrImplicitParameter() instanceof NoExpr
                 && e.getArgs().size() == 1) {
             // special compiletime-expression
-            return JassIm.ImCompiletimeExpr(e, e.getArgs().get(0).imTranslateExpr(t, f));
+            return JassIm.ImCompiletimeExpr(e, e.getArgs().get(0).imTranslateExpr(t, f), t.getCompiletimeExpressionsOrder(e));
         }
 
         List<Expr> arguments = Lists.newArrayList(e.getArgs());

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/FunctionFlagCompiletime.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/FunctionFlagCompiletime.java
@@ -1,0 +1,18 @@
+package de.peeeq.wurstscript.translation.imtranslation;
+
+/**
+ * function with @compiletime
+ */
+public class FunctionFlagCompiletime implements FunctionFlag {
+    /** index, which specifies order in which functions are executed
+     * Compiletime functions with smaller index are executed first */
+    private int index;
+
+    public FunctionFlagCompiletime(int index) {
+        this.index = index;
+    }
+
+    public int getOrderIndex() {
+        return index;
+    }
+}

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/FunctionFlagEnum.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/FunctionFlagEnum.java
@@ -3,7 +3,6 @@ package de.peeeq.wurstscript.translation.imtranslation;
 public enum FunctionFlagEnum implements FunctionFlag {
     IS_BJ,
     IS_NATIVE,
-    IS_COMPILETIME,
     IS_TEST,
     IS_COMPILETIME_NATIVE,
     IS_EXTERN

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstScriptTest.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstScriptTest.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import static de.peeeq.wurstio.CompiletimeFunctionRunner.FunctionFlagToRun.Tests;
+
 public class WurstScriptTest {
 
     private static final String TEST_OUTPUT_PATH = "./test-output/";
@@ -404,7 +406,7 @@ public class WurstScriptTest {
     }
 
     private void executeTests(WurstGui gui, ImProg imProg) {
-        CompiletimeFunctionRunner cfr = new CompiletimeFunctionRunner(imProg, null, null, gui, FunctionFlagEnum.IS_TEST);
+        CompiletimeFunctionRunner cfr = new CompiletimeFunctionRunner(imProg, null, null, gui, Tests);
         cfr.run();
         WLogger.info("Successfull tests: " + cfr.getSuccessTests().size());
         int failedTestCount = cfr.getFailTests().size();


### PR DESCRIPTION
Old rule:

- first all compiletime expressions are executed
- then compiletime functions
- no other order contraints specified

New rule:
- compiletime expressions and functions interleaved
- guaranteed that compiletime stuff in imported packages is executed first
- inside a package it should be top down (according to AST order)


Still untested, so do not merge before testing it.