### PR TITLE
Win files fix

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/BufferManager.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/BufferManager.java
@@ -21,7 +21,7 @@ public class BufferManager {
         return getBuffer(uri);
     }
 
-    private String getBuffer(WFile uri) {
+    public String getBuffer(WFile uri) {
         StringBuilder sb = currentBuffer.get(uri);
         if (sb == null) {
             return "";

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/LanguageWorker.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/LanguageWorker.java
@@ -144,7 +144,8 @@ public class LanguageWorker implements Runnable {
                     try {
                         work.run();
                     } catch (Throwable e) {
-                        languageClient.showMessage(new MessageParams(MessageType.Error, "Request '" + work + "' could not be processed (see log for details): " + e.toString()));
+                        languageClient.showMessage(new MessageParams(MessageType.Error, "Request '" + work + "' could not be processed (see log for details):" +
+                                " " + e.toString()));
                         WLogger.severe(e);
                         System.err.println("Error in request '" + work + "' (see log for details): " + e.getMessage());
                     }
@@ -243,8 +244,8 @@ public class LanguageWorker implements Runnable {
 
     public void handleChange(DidChangeTextDocumentParams params) {
         synchronized (lock) {
-            bufferManager.handleChange(params);
             WFile file = WFile.create(params.getTextDocument().getUri());
+            bufferManager.handleChange(params);
 
             changes.put(file, new FileReconcile(file, bufferManager.getBuffer(file)));
             lock.notifyAll();
@@ -272,7 +273,7 @@ public class LanguageWorker implements Runnable {
                     request.handleException(languageClient, err, resFut);
                 } else if (res == null) {
                     System.err.println("Request returned null: " + request);
-                    if(!(request instanceof HoverInfo)) {
+                    if (!(request instanceof HoverInfo)) {
                         languageClient.showMessage(new MessageParams(MessageType.Error, "Request returned null: " + request));
                     }
                     resFut.completeExceptionally(new RuntimeException("Request returned null: " + request));

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/LanguageWorker.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/LanguageWorker.java
@@ -246,7 +246,7 @@ public class LanguageWorker implements Runnable {
             bufferManager.handleChange(params);
             WFile file = WFile.create(params.getTextDocument().getUri());
 
-            changes.put(file, new FileReconcile(file, bufferManager.getBuffer(params.getTextDocument())));
+            changes.put(file, new FileReconcile(file, bufferManager.getBuffer(file)));
             lock.notifyAll();
         }
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManager.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManager.java
@@ -39,7 +39,7 @@ public interface ModelManager {
 
     void syncCompilationUnitContent(WFile filename, String contents);
 
-    CompilationUnit replaceCompilationUnitContent(WFile filename, String buffer, boolean reportErrors);
+    CompilationUnit replaceCompilationUnitContent(WFile filename, boolean reportErrors);
 
     /**
      * get all wurst files in dependency folders

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManager.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManager.java
@@ -39,7 +39,7 @@ public interface ModelManager {
 
     void syncCompilationUnitContent(WFile filename, String contents);
 
-    CompilationUnit replaceCompilationUnitContent(WFile filename, boolean reportErrors);
+    CompilationUnit replaceCompilationUnitContent(WFile filename, String contents, boolean reportErrors);
 
     /**
      * get all wurst files in dependency folders

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManagerImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManagerImpl.java
@@ -468,7 +468,7 @@ public class ModelManagerImpl implements ModelManager {
                     wFile = WFile.create(new File(projectPath, projectPath.toPath().relativize(wFile.getPath()).toString()));
                     contents = new String(Files.readAllBytes(wFile.getPath()));
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/WFile.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/WFile.java
@@ -1,5 +1,7 @@
 package de.peeeq.wurstio.languageserver;
 
+import de.peeeq.wurstscript.WLogger;
+
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -35,25 +37,31 @@ public class WFile {
         try {
             return new WFile(new File(f));
         } catch (IllegalArgumentException e) {
-            throw new RuntimeException("URI " + f + " is not a vald file", e);
+            throw new RuntimeException("URI " + f + " is not a valid file", e);
         }
     }
 
     public static WFile create(String uri) {
+        WLogger.info("create WFile from uri: " + uri);
+        WFile result = null;
         try {
             URI u = new URI(uri);
-            if (u.isAbsolute()) {
-                return create(u);
-            }
+            result = WFile.create(u);
         } catch (URISyntaxException e) {
             // ignore
         }
-        // if it is not a valid absolute URI, maybe it is a valid path?
-        try {
-            return create(Paths.get(uri));
-        } catch (InvalidPathException e2) {
-            throw new RuntimeException("URI string '" + uri + "' is neither a correct URI nor a correct path.", e2);
+        if (result == null) {
+            // if it is not a valid absolute URI, maybe it is a valid path?
+            try {
+                result = create(Paths.get(uri));
+            } catch (InvalidPathException e2) {
+                throw new RuntimeException("URI string '" + uri + "' is neither a correct URI nor a correct path.", e2);
+            }
         }
+        if (!result.getFile().exists()) {
+            throw new RuntimeException("File from uri '" + uri + "' points to inexistent file.");
+        }
+        return result;
     }
 
     public File getFile() {
@@ -70,7 +78,7 @@ public class WFile {
 
     @Override
     public int hashCode() {
-        return Objects.hash(file);
+        return file.hashCode();
     }
 
     @Override

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/CodeActionRequest.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/CodeActionRequest.java
@@ -24,8 +24,7 @@ import static de.peeeq.wurstio.languageserver.WurstCommands.WURST_PERFORM_CODE_A
  */
 public class CodeActionRequest extends UserRequest<List<? extends Command>> {
     private final CodeActionParams params;
-    private final WFile filename;
-    private final String buffer;
+    private final WFile wFile;
     private final int line;
     private final int column;
 
@@ -33,8 +32,7 @@ public class CodeActionRequest extends UserRequest<List<? extends Command>> {
         this.params = params;
 
         TextDocumentIdentifier textDocument = params.getTextDocument();
-        this.filename = WFile.create(textDocument.getUri());
-        this.buffer = bufferManager.getBuffer(textDocument);
+        this.wFile = WFile.create(textDocument.getUri());
         this.line = params.getRange().getStart().getLine() + 1;
         this.column = params.getRange().getStart().getCharacter() + 1;
     }
@@ -46,7 +44,7 @@ public class CodeActionRequest extends UserRequest<List<? extends Command>> {
             // we don't have to compute possible code actions
             return Collections.emptyList();
         }
-        CompilationUnit cu = modelManager.replaceCompilationUnitContent(filename, buffer, false);
+        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, false);
         // get element under cursor
         Element e = Utils.getAstElementAtPos(cu, line, column, false);
 
@@ -169,7 +167,7 @@ public class CodeActionRequest extends UserRequest<List<? extends Command>> {
         String title = "Import package " + imp;
         List<Object> arguments = Collections.singletonList(
                 PerformCodeActionRequest.importPackageAction(
-                        filename.getUriString(),
+                        wFile.getUriString(),
                         imp)
         );
         return new Command(title, WURST_PERFORM_CODE_ACTION, arguments);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/CodeActionRequest.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/CodeActionRequest.java
@@ -44,7 +44,7 @@ public class CodeActionRequest extends UserRequest<List<? extends Command>> {
             // we don't have to compute possible code actions
             return Collections.emptyList();
         }
-        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, false);
+        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, null,false);
         // get element under cursor
         Element e = Utils.getAstElementAtPos(cu, line, column, false);
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetCompletions.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetCompletions.java
@@ -32,7 +32,7 @@ public class GetCompletions extends UserRequest<CompletionList> {
 
 
     private static final int MAX_COMPLETIONS = 100;
-    private final WFile filename;
+    private final WFile wFile;
     private final String buffer;
     private final String[] lines;
     private final int line;
@@ -47,8 +47,8 @@ public class GetCompletions extends UserRequest<CompletionList> {
 
 
     public GetCompletions(TextDocumentPositionParams position, BufferManager bufferManager) {
-        this.filename = WFile.create(position.getTextDocument().getUri());
-        this.buffer = bufferManager.getBuffer(position.getTextDocument());
+        this.wFile = WFile.create(position.getTextDocument().getUri());
+        this.buffer = bufferManager.getBuffer(wFile);
         this.line = position.getPosition().getLine() + 1;
         this.column = position.getPosition().getCharacter();
         this.lines = buffer.split("\\n|\\r\\n");
@@ -67,7 +67,7 @@ public class GetCompletions extends UserRequest<CompletionList> {
     @Override
     public CompletionList execute(ModelManager modelManager) {
         this.modelManager = modelManager;
-        CompilationUnit cu = modelManager.replaceCompilationUnitContent(filename, buffer, false);
+        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, false);
         List<CompletionItem> result = computeCompletionProposals(cu);
         // sort: highest rating first, then sort by label
         if (result != null) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetCompletions.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetCompletions.java
@@ -67,7 +67,7 @@ public class GetCompletions extends UserRequest<CompletionList> {
     @Override
     public CompletionList execute(ModelManager modelManager) {
         this.modelManager = modelManager;
-        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, false);
+        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, null,false);
         List<CompletionItem> result = computeCompletionProposals(cu);
         // sort: highest rating first, then sort by label
         if (result != null) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetDefinition.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetDefinition.java
@@ -16,15 +16,13 @@ import java.util.List;
 
 public class GetDefinition extends UserRequest<List<? extends Location>> {
 
-    private final WFile filename;
-    private final String buffer;
+    private final WFile wFile;
     private final int line;
     private final int column;
 
 
     public GetDefinition(TextDocumentPositionParams position, BufferManager bufferManager) {
-        this.filename = WFile.create(position.getTextDocument().getUri());
-        this.buffer = bufferManager.getBuffer(position.getTextDocument());
+        this.wFile = WFile.create(position.getTextDocument().getUri());
         this.line = position.getPosition().getLine() + 1;
         this.column = position.getPosition().getCharacter() + 1;
     }
@@ -32,7 +30,7 @@ public class GetDefinition extends UserRequest<List<? extends Location>> {
 
     @Override
     public List<? extends Location> execute(ModelManager modelManager) {
-        CompilationUnit cu = modelManager.replaceCompilationUnitContent(filename, buffer, false);
+        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, false);
         Element e = Utils.getAstElementAtPos(cu, line, column, false);
         WLogger.info("get definition at: " + e.getClass().getSimpleName());
         if (e instanceof FuncRef) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetDefinition.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetDefinition.java
@@ -30,7 +30,7 @@ public class GetDefinition extends UserRequest<List<? extends Location>> {
 
     @Override
     public List<? extends Location> execute(ModelManager modelManager) {
-        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, false);
+        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, null,false);
         Element e = Utils.getAstElementAtPos(cu, line, column, false);
         WLogger.info("get definition at: " + e.getClass().getSimpleName());
         if (e instanceof FuncRef) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetUsages.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetUsages.java
@@ -34,7 +34,7 @@ public class GetUsages extends UserRequest<List<GetUsages.UsagesData>> {
 
     @Override
     public List<UsagesData> execute(ModelManager modelManager) {
-        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, false);
+        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, null, false);
         Element astElem = Utils.getAstElementAtPos(cu, line, column, false);
         NameDef nameDef = astElem.tryGetNameDef();
         List<UsagesData> usages = new ArrayList<>();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetUsages.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/GetUsages.java
@@ -17,8 +17,7 @@ import java.util.List;
 
 public class GetUsages extends UserRequest<List<GetUsages.UsagesData>> {
 
-    private final WFile filename;
-    private final String buffer;
+    private final WFile wFile;
     private final int line;
     private final int column;
     private final boolean global;
@@ -26,8 +25,7 @@ public class GetUsages extends UserRequest<List<GetUsages.UsagesData>> {
 
 
     public GetUsages(TextDocumentPositionParams position, BufferManager bufferManager, boolean global) {
-        this.filename = WFile.create(position.getTextDocument().getUri());
-        this.buffer = bufferManager.getBuffer(position.getTextDocument());
+        this.wFile = WFile.create(position.getTextDocument().getUri());
         this.line = position.getPosition().getLine() + 1;
         this.column = position.getPosition().getCharacter() + 1;
         this.global = global;
@@ -36,13 +34,13 @@ public class GetUsages extends UserRequest<List<GetUsages.UsagesData>> {
 
     @Override
     public List<UsagesData> execute(ModelManager modelManager) {
-        CompilationUnit cu = modelManager.replaceCompilationUnitContent(filename, buffer, false);
+        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, false);
         Element astElem = Utils.getAstElementAtPos(cu, line, column, false);
         NameDef nameDef = astElem.tryGetNameDef();
         List<UsagesData> usages = new ArrayList<>();
         if (nameDef != null) {
 
-            if (global || nameDef.getSource().getFile().equals(filename)) {
+            if (global || nameDef.getSource().getFile().equals(wFile)) {
                 // add declaration
                 usages.add(new UsagesData(Convert.posToLocation(nameDef.attrErrorPos()), DocumentHighlightKind.Write));
             }
@@ -75,7 +73,7 @@ public class GetUsages extends UserRequest<List<GetUsages.UsagesData>> {
 
     public static class UsagesData {
         private Location location;
-//        private String filename;
+//        private String wFile;
 //        private Range range;
         private DocumentHighlightKind kind;
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/HoverInfo.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/HoverInfo.java
@@ -35,7 +35,7 @@ public class HoverInfo extends UserRequest<Hover> {
 
     @Override
     public Hover execute(ModelManager modelManager) {
-        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, false);
+        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, null,false);
         Element e = Utils.getAstElementAtPos(cu, line, column, false);
         WLogger.info("hovering over " + Utils.printElement(e));
         Hover res = new Hover(e.match(new Description()));

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/HoverInfo.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/HoverInfo.java
@@ -23,21 +23,19 @@ import java.util.List;
 public class HoverInfo extends UserRequest<Hover> {
 
 
-    private final WFile filename;
-    private final String buffer;
+    private final WFile wFile;
     private final int line;
     private final int column;
 
     public HoverInfo(TextDocumentPositionParams position, BufferManager bufferManager) {
-        this.filename = WFile.create(position.getTextDocument().getUri());
-        this.buffer = bufferManager.getBuffer(position.getTextDocument());
+        this.wFile = WFile.create(position.getTextDocument().getUri());
         this.line = position.getPosition().getLine() + 1;
         this.column = position.getPosition().getCharacter() + 1;
     }
 
     @Override
     public Hover execute(ModelManager modelManager) {
-        CompilationUnit cu = modelManager.replaceCompilationUnitContent(filename, buffer, false);
+        CompilationUnit cu = modelManager.replaceCompilationUnitContent(wFile, false);
         Element e = Utils.getAstElementAtPos(cu, line, column, false);
         WLogger.info("hovering over " + Utils.printElement(e));
         Hover res = new Hover(e.match(new Description()));

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/AutoCompleteTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/AutoCompleteTests.java
@@ -3,11 +3,11 @@ package tests.wurstscript.tests;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
 import de.peeeq.wurstio.WurstCompilerJassImpl;
+import de.peeeq.wurstio.languageserver.BufferManager;
 import de.peeeq.wurstio.languageserver.ModelManager;
 import de.peeeq.wurstio.languageserver.ModelManagerImpl;
 import de.peeeq.wurstio.languageserver.WFile;
 import de.peeeq.wurstio.languageserver.requests.GetCompletions;
-import de.peeeq.wurstio.languageserver.BufferManager;
 import de.peeeq.wurstscript.RunArgs;
 import de.peeeq.wurstscript.WLogger;
 import de.peeeq.wurstscript.ast.WurstModel;
@@ -175,12 +175,11 @@ public class AutoCompleteTests extends WurstScriptTest {
     }
 
     private void testCompletions(CompletionTestData testData, List<String> expectedCompletions) {
-
         BufferManager bufferManager = new BufferManager();
         ModelManager modelManager = new ModelManagerImpl(new File("."), bufferManager);
-        String uri = "file:///tmp/test.wurst";
-        bufferManager.updateFile(WFile.create(uri), testData.buffer);
-        TextDocumentIdentifier textDocument = new TextDocumentIdentifier(uri);
+        File path = new File(getClass().getClassLoader().getResource("test.wurst").getFile());
+        bufferManager.updateFile(WFile.create(path), testData.buffer);
+        TextDocumentIdentifier textDocument = new TextDocumentIdentifier(path.getAbsolutePath());
         Position pos = new Position(testData.line, testData.column);
         TextDocumentPositionParams position = new TextDocumentPositionParams(textDocument, pos);
         GetCompletions getCompletions = new GetCompletions(position, bufferManager);

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ModelManagerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ModelManagerTests.java
@@ -26,7 +26,7 @@ public class ModelManagerTests {
 
     @Test
     public void test() throws IOException {
-        File projectFolder = new File("./temp/testProject/");
+        File projectFolder = new File("temp/testProject/").toPath().toAbsolutePath().toFile();
         File wurstFolder = new File(projectFolder, "wurst");
         wurstFolder.mkdirs();
 

--- a/de.peeeq.wurstscript/src/test/resources/test.wurst
+++ b/de.peeeq.wurstscript/src/test/resources/test.wurst
@@ -1,0 +1,1 @@
+package Test


### PR DESCRIPTION
This fixes https://github.com/wurstscript/WurstScript/issues/582 for me, however I'm not sure if it is elegant. JumpToDecl now keeps working and the errors don't appear.
I debugged and found out that the problem was that ModelManagerImpl caches e.g. common.j in build folder with empty content, i.e. hash 0. I think this is due to ModelManager & BufferManager having independent caching, but I'm not sure.
Also there was some "didOpen" "didClose" right after each other in the log, indicating some file being opened and closed, idk why, but it's gone now as well.

In general the whole file/model handling should probably be refactored at some point.
Things like WurstWorkspaceService which work solely on BufferManager and not ModelManager seem to not even be used?

This still isn't perfect of course. Another thing I noticed now if jumping into common.j, then back, modifying and saving the original file, many warnings are being swallowed and only return after reload.