### PR TITLE
fix ascii-int parsing (#585)

### DIFF
--- a/de.peeeq.wurstscript/src/main/antlr/de/peeeq/wurstscript/antlr/Wurst.g4
+++ b/de.peeeq.wurstscript/src/main/antlr/de/peeeq/wurstscript/antlr/Wurst.g4
@@ -568,7 +568,13 @@ ANNOTATION: '@' [a-zA-Z0-9_]+;
 
 STRING: '"' ( EscapeSequence | ~('\\'|'"'|'\r'|'\n') )* '"';
 REAL: [0-9]+ '.' [0-9]* | '.'[0-9]+;
-INT: [0-9]+ | '$'[0-9a-fA-F]+ | '0'[xX][0-9a-fA-F]+ | '\'' . . . . '\'' | '\'' . '\'';
+
+fragment HexInt: '$'[0-9a-fA-F]+ | '0'[xX][0-9a-fA-F]+;
+
+fragment CharIntPart: ('\\' [btrnf"\\]) | ~[\\'];
+fragment CharInt: '\'' CharIntPart+ '\'';
+
+INT: [0-9]+ | HexInt | CharInt;
 
 fragment EscapeSequence: '\\' [abfnrtvz"'\\];
 

--- a/de.peeeq.wurstscript/src/main/antlr/de/peeeq/wurstscript/antlr/Wurst.g4
+++ b/de.peeeq.wurstscript/src/main/antlr/de/peeeq/wurstscript/antlr/Wurst.g4
@@ -572,7 +572,7 @@ REAL: [0-9]+ '.' [0-9]* | '.'[0-9]+;
 fragment HexInt: '$'[0-9a-fA-F]+ | '0'[xX][0-9a-fA-F]+;
 
 fragment CharIntPart: ('\\' [btrnf"\\]) | ~[\\'];
-fragment CharInt: '\'' CharIntPart+ '\'';
+fragment CharInt: '\'' CharIntPart+ '\'' | '\'' [\\'] '\'';
 
 INT: [0-9]+ | HexInt | CharInt;
 

--- a/de.peeeq.wurstscript/src/main/antlr/de/peeeq/wurstscript/jurst/antlr/Jurst.g4
+++ b/de.peeeq.wurstscript/src/main/antlr/de/peeeq/wurstscript/jurst/antlr/Jurst.g4
@@ -618,7 +618,13 @@ ANNOTATION: '@' [a-zA-Z0-9_]+;
 
 STRING: '"' ( EscapeSequence | ~('\\'|'"'|'\r'|'\n') | NL )* '"';
 REAL: [0-9]+ '.' [0-9]* | '.'[0-9]+;
-INT: [0-9]+ | '$'[0-9a-fA-F]+ | '0'[xX][0-9a-fA-F]+ | '\'' . . . . '\'' | '\'' . '\'';
+
+fragment HexInt: '$'[0-9a-fA-F]+ | '0'[xX][0-9a-fA-F]+;
+
+fragment CharIntPart: ('\\' [btrnf"\\]) | ~[\\'];
+fragment CharInt: '\'' CharIntPart+ '\'';
+
+INT: [0-9]+ | HexInt | CharInt;
 
 fragment EscapeSequence: '\\' [abfnrtvz"'\\];
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/IntVal.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/IntVal.java
@@ -15,12 +15,11 @@ public class IntVal {
             } else if (raw.startsWith("$")) {
                 return Utils.parseHexInt(raw, 1);
             } else if (raw.startsWith("'")) {
-                if (raw.length() == 1 + 2) {
-                    return Utils.parseAsciiInt1(raw);
-                } else if (raw.length() == 4 + 2) {
-                    return Utils.parseAsciiInt4(raw);
-                } else {
-                    i.addError("Asii ints must have 4 or 1 characters but fount " + (raw.length() - 2) + " characters.");
+                try {
+                    return Utils.parseAsciiInt(raw);
+                } catch (NumberFormatException e) {
+                    i.addError(e.getMessage());
+                    return 0;
                 }
             }
         } catch (NumberFormatException e) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/utils/Utils.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/utils/Utils.java
@@ -93,22 +93,23 @@ public class Utils {
         }
     }
 
-    public static int parseAsciiInt1(String yytext) {
-        return yytext.charAt(1);
-    }
-
-    /**
-     * parse an integer like 'Hfoo'
-     */
-    public static int parseAsciiInt4(String yytext) {
+    public static int parseAsciiInt(String yytext) throws NumberFormatException {
         int result = 0;
-        int power = 1;
-        for (int i = 4; i > 0; i--) {
-            result += yytext.charAt(i) * power;
-            power *= 256;
+        int i = 1;
+        int chars = 0;
+        for (; i < yytext.length() - 1; i++) {
+            if (yytext.charAt(i) == '\\') {
+                i++;
+            }
+            result = result * 256 + yytext.charAt(i);
+            chars++;
+        }
+        if (chars != 1 && chars != 4) {
+            throw new NumberFormatException("Ascii ints must have 4 or 1 characters but this one has " + chars + " characters.");
         }
         return result;
     }
+
 
     public static int parseHexInt(String yytext, int offset) {
         return (int) Long.parseLong(yytext.substring(offset), 16);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/utils/Utils.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/utils/Utils.java
@@ -94,6 +94,10 @@ public class Utils {
     }
 
     public static int parseAsciiInt(String yytext) throws NumberFormatException {
+        if (yytext.length() == 3) {
+            // 'x' can directly return
+            return yytext.charAt(1);
+        }
         int result = 0;
         int i = 1;
         int chars = 0;

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/JurstTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/JurstTests.java
@@ -2,6 +2,7 @@ package tests.wurstscript.tests;
 
 import com.google.common.collect.ImmutableMap;
 import de.peeeq.wurstscript.utils.Utils;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -15,6 +16,76 @@ public class JurstTests extends WurstScriptTest {
                 "package test",
                 "let s = \"12345678",
                 "90\"",
+                ""));
+    }
+
+    @Test
+    public void hexInt1() {
+        testJurst(true, false, Utils.string(
+                "package test",
+                "native testSuccess()",
+                "int a = $10",
+                "init",
+                "  if a == 16 then",
+                "    testSuccess()",
+                "  end",
+                "end",
+                ""));
+    }
+
+    @Test
+    public void hexInt2() {
+        testJurst(true, false, Utils.string(
+                "package test",
+                "native testSuccess()",
+                "int a = 0x10",
+                "init",
+                "  if a == 16 then",
+                "    testSuccess()",
+                "  end",
+                "end",
+                ""));
+    }
+
+    @Test
+    public void asciiChars1() {
+        testJurst(true, false, Utils.string(
+                "package test",
+                "native testSuccess()",
+                "int a = 'b'- 'a'",
+                "init",
+                "  if a == 1 then",
+                "    testSuccess()",
+                "  end",
+                "end",
+                ""));
+    }
+
+    @Test
+    public void asciiChars2() {
+        testJurst(true, false, Utils.string(
+                "package test",
+                "native testSuccess()",
+                "int a = 'hfoo'",
+                "init",
+                "  if a == 1751543663 then",
+                "    testSuccess()",
+                "  end",
+                "end",
+                ""));
+    }
+
+    @Test
+    public void asciiChars3() {
+        testJurst(true, false, Utils.string(
+                "package test",
+                "native testSuccess()",
+                "int a = 'h\\\\oo'",
+                "init",
+                "  if a == 1750888303 then",
+                "    testSuccess()",
+                "  end",
+                "end",
                 ""));
     }
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ParserTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ParserTests.java
@@ -95,6 +95,17 @@ public class ParserTests extends WurstScriptTest {
     }
 
     @Test
+    public void charAndFourChar() {
+        testAssertOkLines(false,
+                "package Test",
+                "function bar(int a0,int a1)",
+                "",
+                "function foo()",
+                "    bar((']'),'hfoo')",
+                "");
+    }
+
+    @Test
     public void positionsNormalLineBreaks() {
         CompilationUnit cu = parse(
                 "package Test\n" +


### PR DESCRIPTION
I think this would parse ascii-chars (as in #585) correctly, but it is not backwards-compatible (`'\'` was a valid char before, but it is no longer valid.
@Frotty I let you decide if you want to merge this breaking change. If you merge it, you have to fix the StdLib as well.


I tried to follow the [rules in Pjass](https://github.com/lep/pjass/blob/master/token.l), so I hope it is compatible with Jass now.