### PR TITLE
Add inliner annotations and threshold modifier for funcs with constant args

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
@@ -13,6 +13,10 @@ import static de.peeeq.wurstscript.jassIm.JassIm.ImStatementExpr;
 import static de.peeeq.wurstscript.jassIm.JassIm.ImStmts;
 
 public class ImInliner {
+    private static final String FORCEINLINE = "@forceinline";
+    private static final String NOINLINE = "@noinline";
+
+    private static final double THRESHOLD_MODIFIER_CONSTANT_ARG = 2;
 
     private static final Set<String> dontInline = Sets.newLinkedHashSet();
     private ImTranslator translator;
@@ -182,9 +186,10 @@ public class ImInliner {
 
         for (FunctionFlag flag : f.getFlags()) {
             if (flag instanceof FunctionFlagAnnotation) {
-                if (((FunctionFlagAnnotation) flag).getAnnotation().equals("@forceinline")) {
+
+                if (((FunctionFlagAnnotation) flag).getAnnotation().equals(FORCEINLINE)) {
                     return 1;
-                } else if (((FunctionFlagAnnotation) flag).getAnnotation().equals("@noinline")) {
+                } else if (((FunctionFlagAnnotation) flag).getAnnotation().equals(NOINLINE)) {
                     return Double.MAX_VALUE;
                 }
             }
@@ -193,9 +198,6 @@ public class ImInliner {
 
         double callCount = getCallCount(f);
         double rating = size * (callCount - 1);
-        if (f.getName().equals("printLog")) {
-            WLogger.info("getRating() " + f.getName() + " size: " + size + " callCount: " + callCount + "rating:  " + rating);
-        }
         return rating;
     }
 
@@ -216,7 +218,7 @@ public class ImInliner {
         double treshold = inlineTreshold;
         for (ImExpr arg : call.getArguments()) {
             if (arg instanceof ImConst) {
-                treshold *= 2;
+                treshold *= THRESHOLD_MODIFIER_CONSTANT_ARG;
                 break;
             }
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
@@ -176,21 +176,20 @@ public class ImInliner {
             return Double.MAX_VALUE;
         }
 
-        double size = getFuncSize(f);
-        if (size < 20) {
-            // always inline small functions
-            return 1;
-        }
-
         for (FunctionFlag flag : f.getFlags()) {
             if (flag instanceof FunctionFlagAnnotation) {
-
                 if (((FunctionFlagAnnotation) flag).getAnnotation().equals(FORCEINLINE)) {
                     return 1;
                 } else if (((FunctionFlagAnnotation) flag).getAnnotation().equals(NOINLINE)) {
                     return Double.MAX_VALUE;
                 }
             }
+        }
+
+        double size = getFuncSize(f);
+        if (size < 20) {
+            // always inline small functions
+            return 1;
         }
 
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
@@ -12,7 +12,7 @@ import static de.peeeq.wurstscript.jassIm.JassIm.ImStatementExpr;
 import static de.peeeq.wurstscript.jassIm.JassIm.ImStmts;
 
 public class ImInliner {
-    private static final String FORCEINLINE = "@forceinline";
+    private static final String FORCEINLINE = "@inline";
     private static final String NOINLINE = "@noinline";
 
     private static final double THRESHOLD_MODIFIER_CONSTANT_ARG = 2;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
@@ -3,7 +3,6 @@ package de.peeeq.wurstscript.translation.imoptimizer;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import de.peeeq.wurstscript.WLogger;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.translation.imtranslation.*;
 
@@ -100,7 +99,6 @@ public class ImInliner {
     }
 
     private void inlineCall(ImFunction f, Element parent, int parentI, ImFunctionCall call) {
-        WLogger.info("inlineCall() " + f.getName() + " call: " + call);
         ImFunction called = call.getFunc();
         if (called == f) {
             throw new Error("cannot inline self.");
@@ -215,10 +213,10 @@ public class ImInliner {
             return false;
         }
 
-        double treshold = inlineTreshold;
+        double threshold = inlineTreshold;
         for (ImExpr arg : call.getArguments()) {
             if (arg instanceof ImConst) {
-                treshold *= THRESHOLD_MODIFIER_CONSTANT_ARG;
+                threshold *= THRESHOLD_MODIFIER_CONSTANT_ARG;
                 break;
             }
         }
@@ -226,7 +224,7 @@ public class ImInliner {
 //		WLogger.info("	ininable: " + inlinableFunctions.contains(f));
 //		WLogger.info("	rating: " + getRating(f));
         return inlinableFunctions.contains(f)
-                && getRating(f) < treshold
+                && getRating(f) < threshold
                 && !isRecursive(f);
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
@@ -192,7 +192,6 @@ public class ImInliner {
             return 1;
         }
 
-
         double callCount = getCallCount(f);
         double rating = size * (callCount - 1);
         return rating;

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
@@ -738,4 +738,38 @@ public class OptimizerTests extends WurstScriptTest {
         assertEquals(compiledAndOptimized.indexOf("u = null"), compiledAndOptimized.lastIndexOf("u = null"));
     }
 
+    @Test
+    public void testInlineAnnotation() throws IOException {
+        testAssertOkLinesWithStdLib(false,
+                "package Test",
+                "@forceinline function over9000(int i, boolean b, real r)",
+                "	var s = \"\"",
+                "	s += r.toString()",
+                "	s += i.toString()",
+                "	s += b.toString()",
+                "	if s.length() > 5",
+                "		print(s)",
+                "	print(\"end\")",
+                "function over9001(int i, boolean b, real r)",
+                "	var s = \"\"",
+                "	s += r.toString()",
+                "	s += i.toString()",
+                "	s += b.toString()",
+                "	if s.length() > 5",
+                "		print(s)",
+                "	print(\"end\")",
+                "function foo()",
+                "	over9000(141, true and true, 12315.233)",
+                "	over9001(141, true and true, 12315.233)",
+                "init",
+                "	over9000(12412411, true and true, 12315.233)",
+                "	over9001(12412411, true and true, 12315.233)",
+                "	foo()"
+
+        );
+        String inlined = Files.toString(new File("test-output/OptimizerTests_testInlineAnnotation_inl.j"), Charsets.UTF_8);
+        assertFalse(inlined.contains("function over9000"));
+        assertTrue(inlined.contains("function over9001"));
+    }
+
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
@@ -761,15 +761,23 @@ public class OptimizerTests extends WurstScriptTest {
                 "function foo()",
                 "	over9000(141, true and true, 12315.233)",
                 "	over9001(141, true and true, 12315.233)",
+                "function bar()",
+                "	print(\"end\")",
+                "@noinline function noot()",
+                "	print(\"end\")",
                 "init",
                 "	over9000(12412411, true and true, 12315.233)",
                 "	over9001(12412411, true and true, 12315.233)",
-                "	foo()"
+                "	foo()",
+                "	bar()",
+                "	noot()"
 
         );
         String inlined = Files.toString(new File("test-output/OptimizerTests_testInlineAnnotation_inl.j"), Charsets.UTF_8);
+        assertFalse(inlined.contains("function bar"));
         assertFalse(inlined.contains("function over9000"));
         assertTrue(inlined.contains("function over9001"));
+        assertTrue(inlined.contains("function noot"));
     }
 
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
@@ -742,7 +742,7 @@ public class OptimizerTests extends WurstScriptTest {
     public void testInlineAnnotation() throws IOException {
         testAssertOkLinesWithStdLib(false,
                 "package Test",
-                "@forceinline function over9000(int i, boolean b, real r)",
+                "@inline function over9000(int i, boolean b, real r)",
                 "	var s = \"\"",
                 "	s += r.toString()",
                 "	s += i.toString()",


### PR DESCRIPTION
Adds `@inline` and `@noinline` for customizing the inliner behavior.

Additionally, calls with constant arguments have a x2 Threshold for being inlined.

Also added `error` to functions which shouldn't be inlined.

**Note:** No errors or feedback if added on uninlinable func yet.

https://github.com/wurstscript/WurstScript/issues/300