### PR TITLE
Fix compiletime implementation of FirstOfGroup

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/providers/GroupProvider.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/providers/GroupProvider.java
@@ -41,10 +41,7 @@ public class GroupProvider extends Provider {
             WLogger.warning("Trying to get FoG of empty group");
             return ILconstNull.instance();
         }
-        Iterator<IlConstHandle> iterator = groupList.iterator();
-        IlConstHandle next = iterator.next();
-        iterator.remove();
-        return next;
+        return groupList.iterator().next();
     }
 
     public void ForGroup(IlConstHandle group, ILconstFuncRef funcRef) {


### PR DESCRIPTION
It no longer removes the unit from the group - just like it's jass counterpart

Minimal example:

```
function foo() returns bool
    let u = createUnit(players[0], 'hfoo', vec2(0, 0), angle(0))
    let g = CreateGroup()
    g.addUnit(u)
    FirstOfGroup(g)
    return not g.isEmpty()

@test function test_foo()
    assertTrue(foo())

init
    print(foo())
```

Used to print True in game, but the unit test failed