### PR TITLE
Fix missing i = i warning for locals

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -769,7 +769,7 @@ public class WurstValidator {
     private void checkIfNoEffectAssignment(StmtSet s) {
         if (refersToSameVar(s.getUpdatedExpr(), s.getRight())) {
             s.addWarning("The assignment to " + Utils.printElement(s.getUpdatedExpr().attrNameDef())
-                    + "  probably has no effect.");
+                    + " probably has no effect.");
         }
 
     }
@@ -784,7 +784,7 @@ public class WurstValidator {
         if (a instanceof NameRef && b instanceof NameRef) {
             NameRef va = (NameRef) a;
             NameRef vb = (NameRef) b;
-            if (va.attrNameLink() == vb.attrNameLink()
+            if (va.attrNameLink().getDef() == vb.attrNameLink().getDef()
                     && refersToSameVar(va.attrImplicitParameter(), vb.attrImplicitParameter())) {
                 if (va instanceof AstElementWithIndexes && vb instanceof AstElementWithIndexes) {
                     AstElementWithIndexes vai = (AstElementWithIndexes) va;

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/BugTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/BugTests.java
@@ -1233,4 +1233,52 @@ public class BugTests extends WurstScriptTest {
         );
     }
 
+	@Test
+	public void testSelfAssignmentWarning() {
+		testAssertErrorsLines(false, "The assignment to variable i probably has no effect",
+			"package test",
+			"@extern native I2S(int x) returns string",
+			"native testSuccess()",
+			"init",
+			"	var i = 5",
+			"	I2S(i)",
+			"	i = i",
+			"	I2S(i)",
+			"	testSuccess()"
+		);
+	}
+
+	@Test
+	public void testSelfAssignmentWarningDot() {
+		testAssertErrorsLines(false, "The assignment to variable i probably has no effect",
+			"package test",
+			"@extern native I2S(int x) returns string",
+			"native testSuccess()",
+			"class A",
+			"	var i = 5",
+			"	construct()",
+			"		this.i = i",
+			"init",
+			"	new A()",
+			"	testSuccess()"
+		);
+	}
+
+	@Test
+	public void testSelfAssignmentNoWarning() {
+		testAssertOkLines(true,
+			"package test",
+			"@extern native I2S(int x) returns string",
+			"native testSuccess()",
+			"class A",
+			"	var i = 5",
+			"	construct(int i)",
+			"		this.i = i",
+			"init",
+			"	new A(1)",
+			"	testSuccess()"
+		);
+	}
+
+
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/BugTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/BugTests.java
@@ -1235,7 +1235,7 @@ public class BugTests extends WurstScriptTest {
 
 	@Test
 	public void testSelfAssignmentWarning() {
-		testAssertErrorsLines(false, "The assignment to variable i probably has no effect",
+		testAssertErrorsLines(false, "The assignment to local variable i probably has no effect",
 			"package test",
 			"@extern native I2S(int x) returns string",
 			"native testSuccess()",


### PR DESCRIPTION
Right now this throws a warning:

```wurst
class A
  var i = 0
  construct()
    this.i = this.i // warning
```

However this will not:

```wurst
init
  var i = 0
  i = i // no warning
  print(i)
```

It works for class members, but not locals. By debugging I found out that in the [validator](https://github.com/wurstscript/WurstScript/compare/fix-assignment-no-effect-warning?expand=1#diff-1876af8b02722f4f9605e5b2450570d6R787) the namelinks for the local scenario don't have the same identity and thus the `==` check failed. It seems to work with the defs tho. 
But idk if this is the 'correct' fix @peq 🤷‍♂️ 