### PR TITLE
WIP: support for persisting objects in compiletime expressions

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
@@ -98,7 +98,7 @@ public class WurstCompilerJassImpl implements WurstCompiler {
             // compile & inject object-editor data
             // TODO run optimizations later?
             gui.sendProgress("Running compiletime functions");
-            CompiletimeFunctionRunner ctr = new CompiletimeFunctionRunner(getImProg(), getMapFile(), getMapfileMpqEditor(), gui,
+            CompiletimeFunctionRunner ctr = new CompiletimeFunctionRunner(imTranslator, getImProg(), getMapFile(), getMapfileMpqEditor(), gui,
                     CompiletimeFunctions);
             ctr.setInjectObjects(runArgs.isInjectObjects());
             ctr.setOutputStream(new PrintStream(System.err));

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunTests.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunTests.java
@@ -136,7 +136,7 @@ public class RunTests extends UserRequest<Object> {
     public TestResult runTests(ImProg imProg, @Nullable FuncDef funcToTest, @Nullable CompilationUnit cu) {
         WurstGui gui = new TestGui();
 
-        CompiletimeFunctionRunner cfr = new CompiletimeFunctionRunner(imProg, null, null, gui, CompiletimeFunctions);
+        CompiletimeFunctionRunner cfr = new CompiletimeFunctionRunner(null, imProg, null, null, gui, CompiletimeFunctions);
         ILInterpreter interpreter = cfr.getInterpreter();
         ProgramState globalState = cfr.getGlobalState();
         if (globalState == null) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/ILconstObject.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/ILconstObject.java
@@ -1,0 +1,85 @@
+package de.peeeq.wurstscript.intermediatelang;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import de.peeeq.wurstscript.ast.Element;
+import de.peeeq.wurstscript.jassIm.ImClass;
+import de.peeeq.wurstscript.jassIm.ImClassType;
+import de.peeeq.wurstscript.jassIm.ImVar;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ILconstObject extends ILconstAbstract {
+    private final ImClassType classType;
+    private final int objectId;
+    private final Table<ImVar, List<Integer>, ILconst> attributes = HashBasedTable.create();
+    private boolean destroyed = false;
+    private final Element trace;
+
+    public ILconstObject(ImClassType classType, int objectId, Element trace) {
+        this.classType = classType;
+        this.objectId = objectId;
+        this.trace = trace;
+    }
+
+    public int getObjectId() {
+        return objectId;
+    }
+
+    @Override
+    public String print() {
+        return classType + "_" + hashCode() + "{"
+                + attributes.rowMap().entrySet()
+                .stream()
+                .map(e -> e.getKey() + " = " + e.getValue())
+                .collect(Collectors.joining(", "))
+                + "}";
+    }
+
+
+
+    @Override
+    public boolean isEqualTo(ILconst other) {
+        return other == this;
+    }
+
+    public void set(ImVar attr, List<Integer> indexes, ILconst value) {
+        System.out.println("setting " + this + "." + attr + " " +indexes +  " = " + value);
+        attributes.put(attr, indexes, value);
+    }
+
+    public Optional<ILconst> get(ImVar attr, List<Integer> indexes) {
+        return Optional.ofNullable(attributes.get(attr, indexes));
+    }
+
+
+    public boolean isDestroyed() {
+        return destroyed;
+    }
+
+    public void destroy() {
+        destroyed = true;
+    }
+
+    public ImClass getImClass() {
+        return classType.getClassDef();
+    }
+
+    public Element getTrace() {
+        return trace;
+    }
+
+    public ImClassType getType() {
+        return classType;
+    }
+
+    @Override
+    public int hashCode() {
+        return objectId;
+    }
+
+    public Table<ImVar, List<Integer>, ILconst> getAttributes() {
+        return attributes;
+    }
+}

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/ILconstObject.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/ILconstObject.java
@@ -29,12 +29,7 @@ public class ILconstObject extends ILconstAbstract {
 
     @Override
     public String print() {
-        return classType + "_" + hashCode() + "{"
-                + attributes.rowMap().entrySet()
-                .stream()
-                .map(e -> e.getKey() + " = " + e.getValue())
-                .collect(Collectors.joining(", "))
-                + "}";
+        return classType + "_" + hashCode();
     }
 
 
@@ -45,7 +40,6 @@ public class ILconstObject extends ILconstAbstract {
     }
 
     public void set(ImVar attr, List<Integer> indexes, ILconst value) {
-        System.out.println("setting " + this + "." + attr + " " +indexes +  " = " + value);
         attributes.put(attr, indexes, value);
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/EvaluateExpr.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/EvaluateExpr.java
@@ -42,6 +42,11 @@ public class EvaluateExpr {
         for (int i = 0; i < args2.size(); i++) {
             args[i] = args2.get(i).evaluate(globalState, localState);
         }
+        return evaluateFunc(globalState, f, trace, args);
+    }
+
+    @Nullable
+    private static ILconst evaluateFunc(ProgramState globalState, ImFunction f, Element trace, ILconst[] args) {
         LocalState r = ILInterpreter.runFunc(globalState, f, trace, args);
         return r.getReturnVal();
     }
@@ -171,13 +176,12 @@ public class EvaluateExpr {
 
     public static @Nullable ILconst eval(ImMethodCall mc,
                                          ProgramState globalState, LocalState localState) {
-        ILconstInt receiver = (ILconstInt) mc.getReceiver().evaluate(globalState, localState);
+        ILconstObject receiver = (ILconstObject) mc.getReceiver().evaluate(globalState, localState);
 
-        globalState.assertAllocated(receiver.getVal(), mc.attrTrace());
+        globalState.assertAllocated(receiver, mc.attrTrace());
 
 
-        ArrayList<ImExpr> args = Lists.newArrayList(mc.getArguments());
-        args.add(0, JassIm.ImIntVal(receiver.getVal()));
+        List<ImExpr> args = mc.getArguments();
 
 
         ImMethod mostPrecise = mc.getMethod();
@@ -186,14 +190,19 @@ public class EvaluateExpr {
         for (ImMethod m : mc.getMethod().getSubMethods()) {
 
             if (m.attrClass().isSubclassOf(mostPrecise.attrClass())) {
-                if (globalState.isInstanceOf(receiver.getVal(), m.attrClass(), mc.attrTrace())) {
+                if (globalState.isInstanceOf(receiver, m.attrClass(), mc.attrTrace())) {
                     // found more precise method
                     mostPrecise = m;
                 }
             }
         }
         // execute most precise method
-        return evaluateFunc(globalState, localState, mostPrecise.getImplementation(), args, mc);
+        ILconst[] eargs = new ILconst[args.size() + 1];
+        eargs[0] = receiver;
+        for (int i = 0; i < args.size(); i++) {
+            eargs[i+1] = args.get(i).evaluate(globalState, localState);
+        }
+        return evaluateFunc(globalState, mostPrecise.getImplementation(), mc, eargs);
     }
 
     public static ILconst eval(ImMemberAccess ma, ProgramState globalState, LocalState localState) {
@@ -211,20 +220,20 @@ public class EvaluateExpr {
 
     public static ILconst eval(ImAlloc imAlloc, ProgramState globalState,
                                LocalState localState) {
-        return new ILconstInt(globalState.allocate(imAlloc.getClazz().getClassDef(), imAlloc.attrTrace()));
+        return globalState.allocate(imAlloc.getClazz(), imAlloc.attrTrace());
     }
 
     public static ILconst eval(ImDealloc imDealloc, ProgramState globalState,
                                LocalState localState) {
-        ILconstInt obj = (ILconstInt) imDealloc.getObj().evaluate(globalState, localState);
-        globalState.deallocate(obj.getVal(), imDealloc.getClazz().getClassDef(), imDealloc.attrTrace());
+        ILconstObject obj = (ILconstObject) imDealloc.getObj().evaluate(globalState, localState);
+        globalState.deallocate(obj, imDealloc.getClazz().getClassDef(), imDealloc.attrTrace());
         return ILconstNull.instance();
     }
 
     public static ILconst eval(ImInstanceof e, ProgramState globalState,
                                LocalState localState) {
-        ILconstInt obj = (ILconstInt) e.getObj().evaluate(globalState, localState);
-        return ILconstBool.instance(globalState.isInstanceOf(obj.getVal(), e.getClazz().getClassDef(), e.attrTrace()));
+        ILconstObject obj = (ILconstObject) e.getObj().evaluate(globalState, localState);
+        return ILconstBool.instance(globalState.isInstanceOf(obj, e.getClazz().getClassDef(), e.attrTrace()));
     }
 
     public static ILconst eval(ImTypeIdOfClass e,
@@ -234,8 +243,8 @@ public class EvaluateExpr {
 
     public static ILconst eval(ImTypeIdOfObj e,
                                ProgramState globalState, LocalState localState) {
-        ILconstInt obj = (ILconstInt) e.getObj().evaluate(globalState, localState);
-        return new ILconstInt(globalState.getTypeId(obj.getVal(), e.attrTrace()));
+        ILconstObject obj = (ILconstObject) e.getObj().evaluate(globalState, localState);
+        return new ILconstInt(globalState.getTypeId(obj, e.attrTrace()));
     }
 
 
@@ -336,25 +345,23 @@ public class EvaluateExpr {
 
     public static ILaddress evaluateLvalue(ImMemberAccess va, ProgramState globalState, LocalState localState) {
         ImVar v = va.getVar();
-        int receiver = ((ILconstInt) va.getReceiver().evaluate(globalState, localState)).getVal();
+        ILconstObject receiver = ((ILconstObject) va.getReceiver().evaluate(globalState, localState));
         State state;
         state = globalState;
         List<Integer> indexes =
-                Stream.concat(
-                        Stream.of(receiver),
                         va.getIndexes().stream()
                                 .map(ie -> ((ILconstInt) ie.evaluate(globalState, localState)).getVal())
-                )
                 .collect(Collectors.toList());
         return new ILaddress() {
             @Override
             public void set(ILconst value) {
-                state.setArrayVal(v, indexes, value);
+                receiver.set(v, indexes, value);
             }
 
             @Override
             public ILconst get() {
-                return state.getArrayVal(v, indexes);
+                return receiver.get(v, indexes)
+                        .orElseGet(() -> v.getType().defaultValue());
             }
         };
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/EvaluateExpr.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/EvaluateExpr.java
@@ -11,6 +11,7 @@ import de.peeeq.wurstscript.intermediatelang.*;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.translation.imtranslation.EliminateGenerics;
 import de.peeeq.wurstscript.translation.imtranslation.ImPrinter;
+import de.peeeq.wurstscript.types.TypesHelper;
 import org.eclipse.jdt.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -398,6 +399,17 @@ public class EvaluateExpr {
     }
 
     public static ILconst eval(ImCast imCast, ProgramState globalState, LocalState localState) {
-        return imCast.getExpr().evaluate(globalState, localState);
+        ILconst res = imCast.getExpr().evaluate(globalState, localState);
+        if (TypesHelper.isIntType(imCast.getToType())) {
+            if (res instanceof ILconstObject) {
+                return ILconstInt.create(((ILconstObject) res).getObjectId());
+            }
+        }
+        if (imCast.getToType() instanceof ImClassType) {
+            if (res instanceof ILconstInt) {
+                return globalState.getObjectByIndex(((ILconstInt) res).getVal());
+            }
+        }
+        return res;
     }
 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/EvaluateExpr.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/EvaluateExpr.java
@@ -345,8 +345,6 @@ public class EvaluateExpr {
     public static ILaddress evaluateLvalue(ImMemberAccess va, ProgramState globalState, LocalState localState) {
         ImVar v = va.getVar();
         ILconstObject receiver = ((ILconstObject) va.getReceiver().evaluate(globalState, localState));
-        State state;
-        state = globalState;
         List<Integer> indexes =
                         va.getIndexes().stream()
                                 .map(ie -> ((ILconstInt) ie.evaluate(globalState, localState)).getVal())
@@ -360,7 +358,7 @@ public class EvaluateExpr {
             @Override
             public ILconst get() {
                 return receiver.get(v, indexes)
-                        .orElseGet(() -> v.getType().defaultValue());
+                        .orElseGet(() -> va.attrTyp().defaultValue());
             }
         };
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
@@ -2,13 +2,13 @@ package de.peeeq.wurstscript.intermediatelang.interpreter;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import de.peeeq.wurstio.jassinterpreter.InterpreterException;
 import de.peeeq.wurstscript.ast.Element;
 import de.peeeq.wurstscript.attributes.CompileError;
 import de.peeeq.wurstscript.gui.WurstGui;
 import de.peeeq.wurstscript.intermediatelang.ILconst;
 import de.peeeq.wurstscript.intermediatelang.ILconstArray;
+import de.peeeq.wurstscript.intermediatelang.ILconstObject;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.parser.WPos;
 import de.peeeq.wurstscript.utils.LineOffsets;
@@ -26,7 +26,7 @@ public class ProgramState extends State {
     private List<NativesProvider> nativeProviders = Lists.newArrayList();
     private ImProg prog;
     private int objectIdCounter;
-    private Map<Integer, Object> objectToClassKey = Maps.newLinkedHashMap();
+    private WeakHashMap<Integer, ILconstObject> indexToObject = new WeakHashMap<>();
     private Deque<ILStackFrame> stackFrames = new ArrayDeque<>();
     private Deque<de.peeeq.wurstscript.jassIm.Element> lastStatements = new ArrayDeque<>();
     private boolean isCompiletime;
@@ -84,43 +84,40 @@ public class ProgramState extends State {
         return prog;
     }
 
-    public int allocate(ImClass clazz, Element trace) {
+    public ILconstObject allocate(ImClassType clazz, Element trace) {
         objectIdCounter++;
-        objectToClassKey.put(objectIdCounter, classKey(clazz));
-        return objectIdCounter;
+        ILconstObject res = new ILconstObject(clazz, objectIdCounter, trace);
+        indexToObject.put(objectIdCounter, res);
+        return res;
     }
 
     protected Object classKey(ImClass clazz) {
         return clazz;
     }
 
-    public void deallocate(int obj, ImClass clazz, Element trace) {
+    public void deallocate(ILconstObject obj, ImClass clazz, Element trace) {
         assertAllocated(obj, trace);
-        objectToClassKey.remove(obj);
+        obj.destroy();
         // TODO recycle ids
     }
 
-    public void assertAllocated(int obj, Element trace) {
-        if (obj == 0) {
+    public void assertAllocated(ILconstObject obj, Element trace) {
+        if (obj == null) {
             throw new InterpreterException(trace, "Null pointer dereference");
         }
-        if (!objectToClassKey.containsKey(obj)) {
+        if (obj.isDestroyed()) {
             throw new InterpreterException(trace, "Object already destroyed");
         }
     }
 
-    public boolean isInstanceOf(int obj, ImClass clazz, Element trace) {
+    public boolean isInstanceOf(ILconstObject obj, ImClass clazz, Element trace) {
         assertAllocated(obj, trace);
-        return getObjectClass(obj).isSubclassOf(clazz); // TODO more efficient check
+        return obj.getImClass().isSubclassOf(clazz); // TODO more efficient check
     }
 
-    public int getTypeId(int obj, Element trace) {
+    public int getTypeId(ILconstObject obj, Element trace) {
         assertAllocated(obj, trace);
-        return getObjectClass(obj).attrTypeId();
-    }
-
-    private ImClass getObjectClass(int obj) {
-        return findClazz(objectToClassKey.get(obj));
+        return obj.getImClass().attrTypeId();
     }
 
     private ImClass findClazz(Object key) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
@@ -8,6 +8,7 @@ import de.peeeq.wurstscript.attributes.CompileError;
 import de.peeeq.wurstscript.gui.WurstGui;
 import de.peeeq.wurstscript.intermediatelang.ILconst;
 import de.peeeq.wurstscript.intermediatelang.ILconstArray;
+import de.peeeq.wurstscript.intermediatelang.ILconstNull;
 import de.peeeq.wurstscript.intermediatelang.ILconstObject;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.parser.WPos;
@@ -176,6 +177,10 @@ public class ProgramState extends State {
         for (ILStackFrame sf : Utils.iterateReverse(getStackFrames().getStackFrames())) {
             getGui().sendError(sf.makeCompileError());
         }
+    }
+
+    public ILconst getObjectByIndex(int val) {
+        return indexToObject.get(val);
     }
 
     public static class StackTrace {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImAttrType.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImAttrType.java
@@ -1,12 +1,10 @@
 package de.peeeq.wurstscript.translation.imtojass;
 
 import com.google.common.collect.Lists;
-import de.peeeq.wurstscript.attributes.CompileError;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.types.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ImAttrType {
 
@@ -156,6 +154,18 @@ public class ImAttrType {
                     typeArgs = receiverType.getTypeArguments();
                 }
                 t = substituteType(t, typeArgs, receiverType.getClassDef().getTypeVariables());
+
+                if (!e.getIndexes().isEmpty()) {
+                    if (t instanceof ImArrayType) {
+                        ImArrayType at = (ImArrayType) t;
+                        t = at.getEntryType();
+                    } else if (t instanceof ImArrayTypeMulti) {
+                        ImArrayTypeMulti at = (ImArrayTypeMulti) t;
+                        t = at.getEntryType();
+                    } else {
+                        throw new RuntimeException("unhandled case: " + t);
+                    }
+                }
                 return t;
             } catch (Exception ex) {
                 throw new RuntimeException("Could not determine type of " + e + " with receiverType " + receiverType, ex);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImAttributes.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImAttributes.java
@@ -46,7 +46,11 @@ public class ImAttributes {
 
 
     public static boolean isGlobal(ImVar imVar) {
-        return imVar.getParent().getParent() instanceof ImProg;
+        Element parent = imVar.getParent();
+        if (parent == null) {
+            throw new RuntimeException("Variable " + imVar + " not attached.");
+        }
+        return parent.getParent() instanceof ImProg;
     }
 
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateClasses.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateClasses.java
@@ -54,9 +54,21 @@ public class EliminateClasses {
         }
 
         for (Map.Entry<ImVar, List<ImExpr>> entry : prog.getGlobalInits().entrySet()) {
-            ImExprs newValue = JassIm.ImExprs(entry.getValue());
-            eliminateClassRelatedExprs(newValue);
-            entry.setValue(newValue.removeAll());
+            ImExprs exprs = JassIm.ImExprs();
+            List<ImExpr> value = entry.getValue();
+            for (int i = 0, valueSize = value.size(); i < valueSize; i++) {
+                ImExpr e = value.get(i);
+                List<ImExpr> newValues = new ArrayList<>();
+                if (e.getParent() == null) {
+                    exprs.add(e);
+                    eliminateClassRelatedExprs(exprs);
+                    newValues.add(exprs.remove(0));
+                } else {
+                    eliminateClassRelatedExprs(exprs);
+                    newValues.add(e);
+                }
+                entry.setValue(newValues);
+            }
         }
 
         prog.getClasses().clear();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateClasses.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateClasses.java
@@ -9,7 +9,6 @@ import de.peeeq.wurstscript.attributes.CompileError;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.translation.imtojass.TypeRewriteMatcher;
 import de.peeeq.wurstscript.translation.imtojass.TypeRewriter;
-import de.peeeq.wurstscript.types.TypesHelper;
 import de.peeeq.wurstscript.utils.Pair;
 
 import java.util.ArrayList;
@@ -51,7 +50,13 @@ public class EliminateClasses {
         }
 
         for (ImFunction f : prog.getFunctions()) {
-            eliminateClassRelatedExprs(f);
+            eliminateClassRelatedExprs(f.getBody());
+        }
+
+        for (Map.Entry<ImVar, List<ImExpr>> entry : prog.getGlobalInits().entrySet()) {
+            ImExprs newValue = JassIm.ImExprs(entry.getValue());
+            eliminateClassRelatedExprs(newValue);
+            entry.setValue(newValue.removeAll());
         }
 
         prog.getClasses().clear();
@@ -295,7 +300,7 @@ public class EliminateClasses {
         }
     }
 
-    private void eliminateClassRelatedExprs(ImFunction f) {
+    private void eliminateClassRelatedExprs(de.peeeq.wurstscript.jassIm.Element body) {
         final List<ImMemberAccess> mas = Lists.newArrayList();
         final List<ImMethodCall> mcs = Lists.newArrayList();
         final List<ImAlloc> allocs = Lists.newArrayList();
@@ -303,7 +308,7 @@ public class EliminateClasses {
         final List<ImInstanceof> instaneofs = Lists.newArrayList();
         final List<ImTypeIdOfObj> typeIdObjs = Lists.newArrayList();
         final List<ImTypeIdOfClass> typeIdClasses = Lists.newArrayList();
-        f.getBody().accept(new ImStmts.DefaultVisitor() {
+        body.accept(new de.peeeq.wurstscript.jassIm.Element.DefaultVisitor() {
             @Override
             public void visit(ImMemberAccess e) {
                 super.visit(e);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImPrinter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImPrinter.java
@@ -15,6 +15,20 @@ public class ImPrinter {
             append(sb, "\n");
         }
         append(sb, "\n\n");
+        p.getGlobalInits().forEach((v,es) -> {
+            append(sb, v.getName());
+            append(sb, " = ");
+            boolean first = true;
+            for (ImExpr e : es) {
+                if (!first) {
+                    append(sb, ", ");
+                }
+                e.print(sb, indent);
+                first = false;
+            }
+            append(sb, "\n");
+        });
+        append(sb, "\n\n");
         for (ImFunction f : p.getFunctions()) {
             f.print(sb, indent);
             append(sb, "\n");

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypesHelper.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypesHelper.java
@@ -48,6 +48,12 @@ public class TypesHelper {
                 || vt instanceof ImArrayTypeMulti && typeContainsTuples(((ImArrayTypeMulti) vt).getEntryType());
     }
 
+    public static boolean isIntType(ImType t) {
+        if (t instanceof ImSimpleType) {
+            return ((ImSimpleType) t).getTypename().equals("integer");
+        }
+        return false;
+    }
 
 
 //	public static boolean checkTypeArgs(InstanceDef iDef, List<PscriptType> classParams, List<PscriptType> interfaceParams) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypesHelper.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypesHelper.java
@@ -30,6 +30,10 @@ public class TypesHelper {
         return WurstTypeBool.instance().imTranslateType();
     }
 
+    public static ImType imHashTable() {
+        return JassIm.ImSimpleType("hashtable");
+    }
+
     public static ImArrayType imIntArray() {
         return JassIm.ImArrayType(imInt());
     }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -158,6 +158,32 @@ public class CompiletimeTests extends WurstScriptTest {
                         "        testSuccess()");
     }
 
+    @Test
+    public void testPersistCompiletimeClassCycle() {
+        test().executeProg(true)
+                .runCompiletimeFunctions(true)
+                .executeProgOnlyAfterTransforms()
+                .lines("package Test",
+                        "native testSuccess()",
+                        "class A",
+                        "    A x",
+                        "    int y",
+                        "function compiletime<T:>(T t) returns T",
+                        "    return t",
+                        "let a = compiletime(new A)",
+                        "@compiletime",
+                        "function foo()",
+                        "    a.x = new A",
+                        "    a.x.x = new A",
+                        "    a.x.x.x = a",
+                        "    a.y = 42",
+                        "    a.x.y = 43",
+                        "    a.x.x.y = 43",
+                        "init",
+                        "    if a.x.x.x.y == 42",
+                        "        testSuccess()");
+    }
+
 
     @Test
     public void checkCompiletimeAnnotation1() {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -186,6 +186,28 @@ public class CompiletimeTests extends WurstScriptTest {
 
 
     @Test
+    public void testPersistCompiletimeClassTuple() {
+        test().executeProg(true)
+                .runCompiletimeFunctions(true)
+                .executeProgOnlyAfterTransforms()
+                .lines("package Test",
+                        "native testSuccess()",
+                        "class A",
+                        "    int y",
+                        "function compiletime<T:>(T t) returns T",
+                        "    return t",
+                        "tuple pair(A a, A b)",
+                        "let a = compiletime(pair(new A, new A))",
+                        "@compiletime",
+                        "function foo()",
+                        "    a.a.y = 42",
+                        "    a.b.y = 43",
+                        "init",
+                        "    if a.a.y == 42 and a.b.y == 43",
+                        "        testSuccess()");
+    }
+
+    @Test
     public void checkCompiletimeAnnotation1() {
         testAssertErrorsLines(false, "Functions annotated '@compiletime' may not take parameters.",
                 "package test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -137,6 +137,29 @@ public class CompiletimeTests extends WurstScriptTest {
     }
 
     @Test
+    public void testPersistCompiletimeClass() {
+        test().executeProg(true)
+                .runCompiletimeFunctions(true)
+                .executeProgOnlyAfterTransforms()
+                .lines("package Test",
+                        "native testSuccess()",
+                        "class A",
+                        "    string x",
+                        "    int y",
+                        "function compiletime(A a) returns A",
+                        "    return a",
+                        "let a = compiletime(new A)",
+                        "@compiletime",
+                        "function foo()",
+                        "    a.x = \"schwardemage\"",
+                        "    a.y = 42",
+                        "init",
+                        "    if a.x == \"schwardemage\" and a.y == 42",
+                        "        testSuccess()");
+    }
+
+
+    @Test
     public void checkCompiletimeAnnotation1() {
         testAssertErrorsLines(false, "Functions annotated '@compiletime' may not take parameters.",
                 "package test",


### PR DESCRIPTION
Currently trying if this works ...

- [ ] Initialization order: first allocate all objects, then initialize their fields, then reference in compiletime expressions