### PR TITLE
WIP: Jhcr integration

### DIFF
--- a/de.peeeq.wurstscript/parserspec/wurstscript.parseq
+++ b/de.peeeq.wurstscript/parserspec/wurstscript.parseq
@@ -313,6 +313,7 @@ Modifier =
 HasModifier = NameDef | TypeDef | ModuleDef | ConstructorDef | GlobalVarDef | FunctionDefinition
 HasTypeArgs =  ExprNewObject | FunctionCall | ModuleUse | StmtCall | TypeExprSimple
 
+AstElementWithFuncName = ExprFunctionCall | ExprMemberMethod | ExprFuncRefc
 
 AstElementWithBody = ExtensionFuncDef | InitBlock | ConstructorDef | OnDestroyDef | FuncDef | WBlock 
 	| LoopStatement | ExprStatementsBlock | FunctionLike

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
@@ -11,23 +11,25 @@ import de.peeeq.wurstio.utils.FileReading;
 import de.peeeq.wurstio.utils.FileUtils;
 import de.peeeq.wurstscript.*;
 import de.peeeq.wurstscript.ast.*;
+import de.peeeq.wurstscript.ast.Element;
 import de.peeeq.wurstscript.attributes.CompileError;
 import de.peeeq.wurstscript.attributes.ErrorHandler;
 import de.peeeq.wurstscript.gui.WurstGui;
 import de.peeeq.wurstscript.jassAst.JassProg;
-import de.peeeq.wurstscript.jassIm.ImCompiletimeExpr;
-import de.peeeq.wurstscript.jassIm.ImProg;
+import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.jassprinter.JassPrinter;
 import de.peeeq.wurstscript.parser.WPos;
 import de.peeeq.wurstscript.translation.imoptimizer.ImOptimizer;
 import de.peeeq.wurstscript.translation.imtojass.ImToJassTranslator;
 import de.peeeq.wurstscript.translation.imtranslation.*;
+import de.peeeq.wurstscript.types.TypesHelper;
 import de.peeeq.wurstscript.utils.LineOffsets;
 import de.peeeq.wurstscript.utils.NotNullList;
 import de.peeeq.wurstscript.utils.TempDir;
 import de.peeeq.wurstscript.utils.Utils;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.lsp4j.MessageType;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.*;
 import java.util.*;
@@ -478,6 +480,10 @@ public class WurstCompilerJassImpl implements WurstCompiler {
 
         printDebugImProg("./test-output/im " + stage++ + "_afterremoveGarbage1.im");
 
+        if (runArgs.isHotStartmap() || runArgs.isHotReload()) {
+            addJassHotCodeReloadCode();
+        }
+
         if (runArgs.isOptimize()) {
             beginPhase(12, "froptimize");
             optimizer.optimize();
@@ -501,6 +507,43 @@ public class WurstCompilerJassImpl implements WurstCompiler {
         }
         timeTaker.endPhase();
         return prog;
+    }
+
+    private void addJassHotCodeReloadCode() {
+        Preconditions.checkNotNull(imTranslator);
+        Preconditions.checkNotNull(imProg);
+        ImFunction mainFunc = imTranslator.getMainFunc();
+        Preconditions.checkNotNull(mainFunc);
+        Element trace = imProg.getTrace();
+
+        List<ImStmt> stmts = new ArrayList<>();
+
+        // add call to JHCR_Init_init in main
+        stmts.add(callExtern(trace, CallType.EXECUTE, "JHCR_Init_init"));
+
+
+        // add reload trigger for pressing escape
+        ImStmts reloadBody = JassIm.ImStmts(
+                callExtern(trace, CallType.EXECUTE, "JHCR_Init_parse")
+        );
+        ImFunction jhcr_reload = JassIm.ImFunction(trace, "jhcr_reload_on_escape", JassIm.ImTypeVars(), JassIm.ImVars(), JassIm.ImVoid(), JassIm.ImVars(), reloadBody, Collections.emptyList());
+
+
+        ImVar trig = JassIm.ImVar(trace, TypesHelper.imTrigger(), "trig", false);
+        mainFunc.getLocals().add(trig);
+        // TriggerRegisterPlayerEventEndCinematic(trig, Player(0))
+        stmts.add(callExtern(trace, CallType.NORMAL, "TriggerRegisterPlayerEventEndCinematic", JassIm.ImVarAccess(trig),
+                callExtern(trace, CallType.NORMAL, "Player", JassIm.ImIntVal(0))));
+        stmts.add(callExtern(trace, CallType.NORMAL, "TriggerAddAction", JassIm.ImVarAccess(trig),
+                JassIm.ImFuncRef(trace, jhcr_reload)));
+
+        mainFunc.getBody().addAll(0, stmts);
+    }
+
+    @NotNull
+    private ImFunctionCall callExtern(Element trace, CallType callType, String functionName, ImExpr... arguments) {
+        ImFunction jhcrinit = JassIm.ImFunction(trace, functionName, JassIm.ImTypeVars(), JassIm.ImVars(), JassIm.ImVoid(), JassIm.ImVars(), JassIm.ImStmts(), Collections.singletonList(FunctionFlagEnum.IS_EXTERN));
+        return JassIm.ImFunctionCall(trace, jhcrinit, JassIm.ImTypeArguments(), JassIm.ImExprs(arguments), true, callType);
     }
 
     public void checkNoCompiletimeExpr(ImProg prog) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
@@ -532,6 +532,7 @@ public class WurstCompilerJassImpl implements WurstCompiler {
         ImVar trig = JassIm.ImVar(trace, TypesHelper.imTrigger(), "trig", false);
         mainFunc.getLocals().add(trig);
         // TriggerRegisterPlayerEventEndCinematic(trig, Player(0))
+        stmts.add(JassIm.ImSet(trace, JassIm.ImVarAccess(trig), callExtern(trace, CallType.NORMAL, "CreateTrigger")));
         stmts.add(callExtern(trace, CallType.NORMAL, "TriggerRegisterPlayerEventEndCinematic", JassIm.ImVarAccess(trig),
                 callExtern(trace, CallType.NORMAL, "Player", JassIm.ImIntVal(0))));
         stmts.add(callExtern(trace, CallType.NORMAL, "TriggerAddAction", JassIm.ImVarAccess(trig),

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ConfigProvider.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ConfigProvider.java
@@ -1,0 +1,45 @@
+package de.peeeq.wurstio.languageserver;
+
+import de.peeeq.wurstscript.WLogger;
+import org.eclipse.lsp4j.ConfigurationItem;
+import org.eclipse.lsp4j.ConfigurationParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ *
+ */
+public class ConfigProvider {
+private final LanguageClient languageClient;
+
+    public ConfigProvider(LanguageClient languageClient) {
+        this.languageClient = languageClient;
+    }
+
+    public String getConfig(String key) {
+        ConfigurationItem ci = new ConfigurationItem();
+        ci.setSection("wurst");
+        CompletableFuture<List<Object>> res = languageClient.configuration(new ConfigurationParams(Collections.singletonList(ci)));
+        try {
+            List<Object> config = res.get();
+            return "ok";
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getJhcrExe() {
+        try {
+            return getConfig("wurst.jhcrExe");
+        } catch (Exception e) {
+            WLogger.info(e);
+            return "jhcr.exe";
+        }
+    }
+}
+
+

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ConfigProvider.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ConfigProvider.java
@@ -5,6 +5,7 @@ import org.eclipse.lsp4j.ConfigurationItem;
 import org.eclipse.lsp4j.ConfigurationParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 
+import javax.json.JsonObject;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -20,25 +21,26 @@ private final LanguageClient languageClient;
         this.languageClient = languageClient;
     }
 
-    public String getConfig(String key) {
+    public String getConfig(String key, String defaultValue) {
         ConfigurationItem ci = new ConfigurationItem();
         ci.setSection("wurst");
         CompletableFuture<List<Object>> res = languageClient.configuration(new ConfigurationParams(Collections.singletonList(ci)));
         try {
             List<Object> config = res.get();
-            return "ok";
+            for (Object c : config) {
+                if (c instanceof JsonObject) {
+                    JsonObject cfg = (JsonObject) c;
+                    return cfg.getString(key, defaultValue);
+                }
+            }
+            return defaultValue;
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         }
     }
 
     public String getJhcrExe() {
-        try {
-            return getConfig("wurst.jhcrExe");
-        } catch (Exception e) {
-            WLogger.info(e);
-            return "jhcr.exe";
-        }
+        return getConfig("wurst.jhcrExe", "jhcr.exe");
     }
 }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/WurstCommands.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/WurstCommands.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  *
@@ -25,6 +26,8 @@ public class WurstCommands {
     public static final String WURST_RESTART = "wurst.restart";
     public static final String WURST_CLEAN = "wurst.clean";
     public static final String WURST_STARTMAP = "wurst.startmap";
+    public static final String WURST_HOTSTARTMAP = "wurst.hotstartmap";
+    public static final String WURST_HOTRELOAD = "wurst.hotreload";
     public static final String WURST_BUILDMAP = "wurst.buildmap";
     public static final String WURST_STARTLAST = "wurst.startlast";
     public static final String WURST_TESTS = "wurst.tests";
@@ -44,6 +47,10 @@ public class WurstCommands {
                 return server.worker().handle(new CleanProject()).thenApply(x -> x);
             case WURST_STARTMAP:
                 return startmap(server, params);
+            case WURST_HOTSTARTMAP:
+                return startmap(server, params, "-hotstart");
+            case WURST_HOTRELOAD:
+                return startmap(server, params, "-hotreload");
             case WURST_TESTS:
                 return testMap(server, params);
             case WURST_PERFORM_CODE_ACTION:
@@ -80,7 +87,7 @@ public class WurstCommands {
         return server.worker().handle(new BuildMap(workspaceRoot, map, compileArgs)).thenApply(x -> x);
     }
 
-    private static CompletableFuture<Object> startmap(WurstLanguageServer server, ExecuteCommandParams params) {
+    private static CompletableFuture<Object> startmap(WurstLanguageServer server, ExecuteCommandParams params, String... additionalArgs) {
         WFile workspaceRoot = server.getRootUri();
         if (params.getArguments().isEmpty()) {
             throw new RuntimeException("Missing arguments");
@@ -96,17 +103,20 @@ public class WurstCommands {
         }
 
         File map = new File(mapPath);
-        List<String> compileArgs = getCompileArgs(workspaceRoot);
+        List<String> compileArgs = getCompileArgs(workspaceRoot, additionalArgs);
         return server.worker().handle(new RunMap(workspaceRoot, wc3Path, map, compileArgs)).thenApply(x -> x);
     }
 
     private static final List<String> defaultArgs = ImmutableList.of("-runcompiletimefunctions", "-injectobjects", "-stacktraces");
 
-    private static List<String> getCompileArgs(WFile rootPath) {
+    private static List<String> getCompileArgs(WFile rootPath, String... additionalArgs) {
         try {
             Path configFile = Paths.get(rootPath.toString(), "wurst_run.args");
             if (Files.exists(configFile)) {
-                return Files.lines(configFile).filter(s -> s.startsWith("-")).collect(Collectors.toList());
+                return Stream.concat(
+                        Files.lines(configFile).filter(s -> s.startsWith("-")),
+                        Stream.of(additionalArgs)
+                ).collect(Collectors.toList());
             } else {
 
                 String cfg = String.join("\n", defaultArgs) + "\n";

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/WurstCommands.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/WurstCommands.java
@@ -84,7 +84,7 @@ public class WurstCommands {
 
         File map = new File(mapPath);
         List<String> compileArgs = getCompileArgs(workspaceRoot);
-        return server.worker().handle(new BuildMap(workspaceRoot, map, compileArgs)).thenApply(x -> x);
+        return server.worker().handle(new BuildMap(server.getConfigProvider(), workspaceRoot, map, compileArgs)).thenApply(x -> x);
     }
 
     private static CompletableFuture<Object> startmap(WurstLanguageServer server, ExecuteCommandParams params, String... additionalArgs) {
@@ -104,7 +104,7 @@ public class WurstCommands {
 
         File map = new File(mapPath);
         List<String> compileArgs = getCompileArgs(workspaceRoot, additionalArgs);
-        return server.worker().handle(new RunMap(workspaceRoot, wc3Path, map, compileArgs)).thenApply(x -> x);
+        return server.worker().handle(new RunMap(server.getConfigProvider(), workspaceRoot, wc3Path, map, compileArgs)).thenApply(x -> x);
     }
 
     private static final List<String> defaultArgs = ImmutableList.of("-runcompiletimefunctions", "-injectobjects", "-stacktraces");

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/WurstLanguageServer.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/WurstLanguageServer.java
@@ -113,4 +113,8 @@ public class WurstLanguageServer implements org.eclipse.lsp4j.services.LanguageS
     public LanguageClient getLanguageClient() {
         return languageClient;
     }
+
+    public ConfigProvider getConfigProvider() {
+        return new ConfigProvider(languageClient);
+    }
 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/BuildMap.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/BuildMap.java
@@ -4,6 +4,7 @@ import com.google.common.io.Files;
 import config.*;
 import de.peeeq.wurstio.Pjass;
 import de.peeeq.wurstio.gui.WurstGuiImpl;
+import de.peeeq.wurstio.languageserver.ConfigProvider;
 import de.peeeq.wurstio.languageserver.ModelManager;
 import de.peeeq.wurstio.languageserver.WFile;
 import de.peeeq.wurstio.mpq.MpqEditor;
@@ -43,8 +44,8 @@ public class BuildMap extends MapRequest {
         QuickAndDirty, KindOfSafe
     }
 
-    public BuildMap(WFile workspaceRoot, File map, List<String> compileArgs) {
-        super(map, compileArgs, workspaceRoot);
+    public BuildMap(ConfigProvider configProvider, WFile workspaceRoot, File map, List<String> compileArgs) {
+        super(configProvider, map, compileArgs, workspaceRoot);
     }
 
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/MapRequest.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/MapRequest.java
@@ -5,6 +5,7 @@ import com.google.common.io.Files;
 import de.peeeq.wurstio.Pjass;
 import de.peeeq.wurstio.UtilsIO;
 import de.peeeq.wurstio.WurstCompilerJassImpl;
+import de.peeeq.wurstio.languageserver.ConfigProvider;
 import de.peeeq.wurstio.languageserver.ModelManager;
 import de.peeeq.wurstio.languageserver.WFile;
 import de.peeeq.wurstio.mpq.MpqEditor;
@@ -41,12 +42,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public abstract class MapRequest extends UserRequest<Object> {
+    protected final ConfigProvider configProvider;
     protected final File map;
     protected final List<String> compileArgs;
     protected final WFile workspaceRoot;
     protected final RunArgs runArgs;
 
-    public MapRequest(File map, List<String> compileArgs, WFile workspaceRoot) {
+    public MapRequest(ConfigProvider configProvider, File map, List<String> compileArgs, WFile workspaceRoot) {
+        this.configProvider = configProvider;
         this.map = map;
         this.compileArgs = compileArgs;
         this.workspaceRoot = workspaceRoot;
@@ -186,7 +189,7 @@ public abstract class MapRequest extends UserRequest<Object> {
             throw new IOException("Could not find file " + blizzardJ.getAbsolutePath());
         }
 
-        ProcessBuilder pb = new ProcessBuilder("jhcr.exe", "init", commonJ.getName(), blizzardJ.getName(), mapScript.getName());
+        ProcessBuilder pb = new ProcessBuilder(configProvider.getJhcrExe(), "init", commonJ.getName(), blizzardJ.getName(), mapScript.getName());
         pb.directory(mapScriptFolder);
         Utils.ExecResult result = Utils.exec(pb, Duration.ofSeconds(30), System.err::println);
         return new File(mapScriptFolder, "jhcr_war3map.j");

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/MapRequest.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/MapRequest.java
@@ -259,4 +259,5 @@ public abstract class MapRequest extends UserRequest<Object> {
     protected void println(String s) {
         WLogger.info(s);
     }
+
 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
@@ -191,7 +191,7 @@ public class RunMap extends MapRequest {
 
         Path documents;
         try {
-            documents = Paths.get(WinRegistry.readString(WinRegistry.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders", "Personal"));
+            documents = FileSystemView.getFileSystemView().getDefaultDirectory().toPath();
         } catch (Throwable t) {
             WLogger.info(t);
             Path homeFolder = Paths.get(System.getProperty("user.home"));

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
@@ -172,7 +172,7 @@ public class RunMap extends MapRequest {
 
         Path customMapDataPath = getCustomMapDataPath();
 
-        ProcessBuilder pb = new ProcessBuilder("jhcr.exe", "update", mapScript.getName(), "--asm",
+        ProcessBuilder pb = new ProcessBuilder(configProvider.getJhcrExe(), "update", mapScript.getName(), "--asm",
                 "--preload-path", customMapDataPath.toAbsolutePath().toString());
         pb.directory(mapScriptFolder);
         Utils.ExecResult result = Utils.exec(pb, Duration.ofSeconds(30), System.err::println);
@@ -184,6 +184,11 @@ public class RunMap extends MapRequest {
      * C:\\Users\\Peter\\Documents\\Warcraft III\\CustomMapData
      */
     private Path getCustomMapDataPath() {
+        String customMapDataPath = configProvider.getConfig("wurst.customMapDataPath", "");
+        if (!customMapDataPath.isEmpty()) {
+            return Paths.get(customMapDataPath);
+        }
+
         Path documents;
         try {
             documents = Paths.get(WinRegistry.readString(WinRegistry.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders", "Personal"));

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
@@ -93,6 +93,17 @@ public class RunMap extends MapRequest {
                 println("We will try to start the map now, but it will probably fail. ");
             }
 
+            if (runArgs.isHotReload() || runArgs.isHotStartmap()) {
+                // call jhcr update
+                callJhcrUpdate(compiledScript);
+            }
+
+
+            if (runArgs.isHotReload()) {
+                // if we are just reloading the mapscript with JHCR, we are done here
+                return "ok";
+            }
+
             gui.sendProgress("preparing testmap ... ");
 
             // then inject the script into the map
@@ -137,6 +148,27 @@ public class RunMap extends MapRequest {
             }
         }
         return "ok"; // TODO
+    }
+
+    private void callJhcrUpdate(File mapScript) throws IOException, InterruptedException {
+        File mapScriptFolder = mapScript.getParentFile();
+        File commonJ = new File(mapScriptFolder, "common.j");
+        File blizzardJ = new File(mapScriptFolder, "blizzard.j");
+        if (!commonJ.exists()) {
+            throw new IOException("Could not find file " + commonJ.getAbsolutePath());
+        }
+
+        if (!blizzardJ.exists()) {
+            throw new IOException("Could not find file " + blizzardJ.getAbsolutePath());
+        }
+        ProcessBuilder pb = new ProcessBuilder("jhcr.exe", "update", mapScript.getName(),
+                "--preload-path", "C:\\Users\\Peter\\Documents\\Warcraft III\\CustomMapData");
+        pb.directory(mapScriptFolder);
+        Process process = pb.start();
+        int r = process.waitFor();
+        if (r != 0) {
+            throw new IOException("Failed to run jhcr");
+        }
     }
 
     @NotNull

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
@@ -14,6 +14,7 @@ import de.peeeq.wurstscript.ast.CompilationUnit;
 import de.peeeq.wurstscript.ast.WurstModel;
 import de.peeeq.wurstscript.attributes.CompileError;
 import de.peeeq.wurstscript.gui.WurstGui;
+import de.peeeq.wurstscript.utils.Utils;
 import net.moonlightflower.wc3libs.bin.GameExe;
 import org.eclipse.lsp4j.MessageType;
 import org.jetbrains.annotations.NotNull;
@@ -22,6 +23,7 @@ import javax.swing.filechooser.FileSystemView;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -93,14 +95,16 @@ public class RunMap extends MapRequest {
                 println("We will try to start the map now, but it will probably fail. ");
             }
 
-            if (runArgs.isHotReload() || runArgs.isHotStartmap()) {
+            if (runArgs.isHotReload()) {
                 // call jhcr update
+                gui.sendProgress("Calling JHCR update");
                 callJhcrUpdate(compiledScript);
             }
 
 
             if (runArgs.isHotReload()) {
                 // if we are just reloading the mapscript with JHCR, we are done here
+                gui.sendProgress("update complete");
                 return "ok";
             }
 
@@ -164,11 +168,7 @@ public class RunMap extends MapRequest {
         ProcessBuilder pb = new ProcessBuilder("jhcr.exe", "update", mapScript.getName(),
                 "--preload-path", "C:\\Users\\Peter\\Documents\\Warcraft III\\CustomMapData");
         pb.directory(mapScriptFolder);
-        Process process = pb.start();
-        int r = process.waitFor();
-        if (r != 0) {
-            throw new IOException("Failed to run jhcr");
-        }
+        Utils.ExecResult result = Utils.exec(pb, Duration.ofSeconds(30), System.err::println);
     }
 
     @NotNull

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/RunArgs.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/RunArgs.java
@@ -43,6 +43,8 @@ public class RunArgs {
     private RunOption optionDisablePjass;
     private RunOption optionShowVersion;
     private RunOption optionMeasureTimes;
+    private RunOption optionHotStartmap;
+    private RunOption optionHotReload;
 
     public RunArgs with(String... additionalArgs) {
         return new RunArgs(Stream.concat(Stream.of(args), Stream.of(additionalArgs))
@@ -112,6 +114,8 @@ public class RunArgs {
 
         optionHelp = addOption("help", "Prints this help message.");
         optionDisablePjass = addOption("noPJass", "Disables PJass checks for the generated code.");
+        optionHotStartmap = addOption("hotstart", "Uses Jass Hot Code Reload (JHCR) to start the map.");
+        optionHotReload = addOption("hotreload", "Reloads the mapscript after running the map with Jass Hot Code Reload (JHCR).");
 
         nextArg:
         for (int i = 0; i < args.length; i++) {
@@ -306,6 +310,14 @@ public class RunArgs {
 
     public boolean isMeasureTimes() {
         return optionMeasureTimes.isSet;
+    }
+
+    public boolean isHotStartmap() {
+        return optionHotStartmap.isSet;
+    }
+
+    public boolean isHotReload() {
+        return optionHotReload.isSet;
     }
 
 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ClosureTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ClosureTranslator.java
@@ -16,7 +16,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 
@@ -174,26 +173,27 @@ public class ClosureTranslator {
     }
 
     private String makeClassName(ImClassType superClass) {
-        String res =
-                superClass.getClassDef().getName()
-                        + "_line" + e.attrSource().getLine();
-        return addScopeNames(res);
+        return superClass.getClassDef().getName() + makeNameSuffix();
     }
 
-    private String makeFuncName(FuncDef superClass) {
-        String res = superClass.getName() + "_line" + e.attrSource().getLine();
-        return addScopeNames(res);
-    }
-
-    private String addScopeNames(String res) {
-        Element elem = e;
+    private String makeNameSuffix() {
+        StringBuilder sb = new StringBuilder();
+        Element elem = this.e;
         while (elem != null) {
             if (elem instanceof NamedScope) {
-                res = ((NamedScope) elem).getName() + "_" + res;
+                sb.append("_");
+                sb.append(((NamedScope) elem).getName());
+            } else if (elem instanceof AstElementWithFuncName) {
+                sb.append("_");
+                sb.append(((AstElementWithFuncName) elem).getFuncNameId().getName());
             }
             elem = elem.getParent();
         }
-        return res;
+        return sb.toString();
+    }
+
+    private String makeFuncName(FuncDef superClass) {
+        return superClass.getName() + makeNameSuffix();
     }
 
     /**

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypesHelper.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypesHelper.java
@@ -55,6 +55,10 @@ public class TypesHelper {
         return false;
     }
 
+    public static ImSimpleType imTrigger() {
+        return JassIm.ImSimpleType("trigger");
+    }
+
 
 //	public static boolean checkTypeArgs(InstanceDef iDef, List<PscriptType> classParams, List<PscriptType> interfaceParams) {
 //		if (classParams.size() == 0 && interfaceParams.size() == 0) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/utils/Utils.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/utils/Utils.java
@@ -1090,7 +1090,9 @@ public class Utils {
         }
 
         Collector cIn = new Collector(process.getInputStream());
+        cIn.start();
         Collector cErr = new Collector(process.getErrorStream());
+        cErr.start();
 
         boolean r = process.waitFor(duration.toMillis(), TimeUnit.MILLISECONDS);
         process.destroyForcibly();


### PR DESCRIPTION
Corresponding plugin update on branch https://github.com/wurstscript/wurst4vscode/tree/jhcr-commands

This adds 2 commands to vscode:

- Start a map with JHCR (will insert code for activating JHCR into the mapscript and runs `jhcr init` on the mapscript before injecting it into the map)
- Reload JHCR code (will rebuild the mapscript and run `jhcr update`)

TODO:

- [x] Make reload work
- [x] Make preload-path configurable (currently hardcoded for my machine)
- [x] Make jhcr executable path configurable (currently assumes it is on the path)
- [ ] Documentation
- [x] Remove line numbers from method names when translating closures (more stable identifiers)
- [ ] Maybe run inlining for global constants when updating mapscript

