### PR TITLE
Custom wc3 run arguments

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ConfigProvider.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ConfigProvider.java
@@ -48,6 +48,10 @@ public class ConfigProvider {
     public String getJhcrExe() {
         return getConfig("jhcrExe", "jhcr.exe");
     }
+    
+    public String getWc3RunArgs() {
+        return getConfig("wc3RunArgs", null);
+    }
 
     /**
      * The path where to put maps before running them

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.List;
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 import static de.peeeq.wurstio.languageserver.ProjectConfigBuilder.FILE_NAME;
@@ -137,12 +138,20 @@ public class RunMap extends MapRequest {
                     if (W3Utils.getWc3PatchVersion() == null) {
                         throw new RequestFailedException(MessageType.Error, wc3Path + " does not exist.");
                     }
-                    List<String> cmd;
-                    if (W3Utils.getWc3PatchVersion().compareTo(VERSION_1_31) < 0) {
-                        cmd = Lists.newArrayList(gameExe.getAbsolutePath(), "-window", "-loadfile", path);
+                    List<String> cmd = Lists.newArrayList(gameExe.getAbsolutePath());
+                    String wc3RunArgs = configProvider.getWc3RunArgs();
+                    if (wc3RunArgs == null) {
+	                    if (W3Utils.getWc3PatchVersion().compareTo(VERSION_1_31) < 0) {
+	                        cmd.add("-window");
+	                    } else {
+	                        cmd.add("-windowmode");
+	                        cmd.add("windowed");
+	                    }
                     } else {
-                        cmd = Lists.newArrayList(gameExe.getAbsolutePath(), "-windowmode", "windowed", "-loadfile", path);
+                    	cmd.addAll(Arrays.asList(wc3RunArgs.split("\\s+")));
                     }
+                    cmd.add("-loadfile");
+                    cmd.add(path);
 
                     if (!System.getProperty("os.name").startsWith("Windows")) {
                         // run with wine


### PR DESCRIPTION
Added a way to set custom wc3 run arguments for the run map command via vscode settings.
If this merged, should also update the vscode plugin.