### PR TITLE
Add option for disabling map configuration when building or running maps

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/BuildMap.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/BuildMap.java
@@ -61,8 +61,10 @@ public class BuildMap extends MapRequest {
             File targetMap = new File(buildDir, fileName.isEmpty() ? projectConfig.getProjectName() + ".w3x" : fileName + ".w3x");
             File compiledScript = compileScript(modelManager, gui, targetMap);
 
-            gui.sendProgress("Applying Map Config...");
-            ProjectConfigBuilder.apply(projectConfig, targetMap, compiledScript, buildDir, runArgs);
+            if (!runArgs.isDisableMapConfig()) {
+                gui.sendProgress("Applying Map Config...");
+                ProjectConfigBuilder.apply(projectConfig, targetMap, compiledScript, buildDir, runArgs);
+            }
 
             JMpqEditor finalizer = new JMpqEditor(targetMap, MPQOpenOption.FORCE_V0);
             finalizer.close();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunMap.java
@@ -119,8 +119,10 @@ public class RunMap extends MapRequest {
                     mpqEditor.insertFile(mapScriptName, compiledScript);
                 }
 
-                gui.sendProgress("Applying Map Config...");
-                ProjectConfigBuilder.apply(projectConfig, testMap, compiledScript, buildDir, runArgs);
+                if (!runArgs.isDisableMapConfig()) {
+                    gui.sendProgress("Applying Map Config...");
+                    ProjectConfigBuilder.apply(projectConfig, testMap, compiledScript, buildDir, runArgs);
+                }
 
                 File mapCopy = copyToWarcraftMapDir(testMap);
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/RunArgs.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/RunArgs.java
@@ -47,6 +47,7 @@ public class RunArgs {
     private RunOption optionMeasureTimes;
     private RunOption optionHotStartmap;
     private RunOption optionHotReload;
+    private RunOption optionDisableMapConfig;
 
     private RunOption optionBuild;
 
@@ -124,7 +125,7 @@ public class RunArgs {
         addOptionWithArg("workspaceroot", "The next argument should be the root folder of the project to build.", arg -> workspaceroot = arg);
         addOptionWithArg("inputmap", "The next argument should be the input map.", arg -> inputmap = arg);
         optionLua = addOption("lua", "Choose Lua as the compilation target.");
-
+        optionDisableMapConfig = addOption("disableMapConfig", "Disable map configuration when building or running maps");
 
         nextArg:
         for (int i = 0; i < args.length; i++) {
@@ -344,4 +345,7 @@ public class RunArgs {
         return optionLua.isSet;
     }
 
+    public boolean isDisableMapConfig() {
+        return optionDisableMapConfig.isSet;
+    }
 }


### PR DESCRIPTION
Option for disabling map configuration.

Useful workaround when running and building reforged maps, since their W3I format is not yet supported.