### PR TITLE
improved performance for liveness calculation in LocalMerger

### DIFF
--- a/de.peeeq.wurstscript/build.gradle
+++ b/de.peeeq.wurstscript/build.gradle
@@ -86,6 +86,9 @@ dependencies {
     // Functional data structures:
     compile group: 'org.functionaljava', name: 'functionaljava', version: '4.8.1'
 
+    // Better functional data structures:
+    compile 'io.vavr:vavr:1.0.0-alpha-3'
+
     // Support for the vscode language server protocol
     compile group: 'org.eclipse.lsp4j', name: 'org.eclipse.lsp4j', version: '0.7.0'
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/datastructures/Worklist.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/datastructures/Worklist.java
@@ -1,0 +1,60 @@
+package de.peeeq.datastructures;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * A queue with efficient lookup using a hashset.
+ * <p>
+ * No element is added to the queue more than once.
+ */
+public class Worklist<T> {
+    private ArrayDeque<T> queue = new ArrayDeque<>();
+    private HashSet<T> set = new HashSet<>();
+
+    public Worklist() {
+    }
+
+    public Worklist(Iterable<? extends T> nodes) {
+        for (T node : nodes) {
+            addLast(node);
+        }
+    }
+
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+
+
+    public void addFirst(T node) {
+        if (set.add(node)) {
+            queue.addFirst(node);
+        }
+    }
+
+    public void addLast(T node) {
+        if (set.add(node)) {
+            queue.addLast(node);
+        }
+    }
+
+    public T poll() {
+        T result = queue.poll();
+        if (result != null) {
+            set.remove(result);
+        }
+        return result;
+    }
+
+    public int size() {
+        return queue.size();
+    }
+
+    public void addAll(Collection<? extends T> elems) {
+        for (T elem : elems) {
+            addLast(elem);
+        }
+    }
+}


### PR DESCRIPTION
- using immutable collections to share data between nodes in the graph
- better strategy for calculating fixed point