### PR TITLE
Fixed a bug with ExecuteFunc and stacktraces

### DIFF
--- a/de.peeeq.wurstscript/parserspec/jass_im.parseq
+++ b/de.peeeq.wurstscript/parserspec/jass_im.parseq
@@ -155,6 +155,8 @@ ImTypeArgument(ref ImType type, java.util.Map<ImTypeClassFunc, io.vavr.control.E
 
 JassImElementWithName = ImVar | ImFunction | ImClass | ImMethod
 
+ImFuncRefOrCall = ImFuncRef | ImFunctionCall
+
 ElementWithTrace = ImVar | ImFunction | ImClass | ImMethod | ImIf | ImLoop | ImExitwhen | ImReturn
  | ImSet | ImSetTuple | ImSetArray | ImSetArrayMulti | ImSetArrayTuple 
  | ImMethodCall | ImFunctionCall | ImCompiletimeExpr | ImVarArrayAccess | ImMemberAccess

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImInliner.java
@@ -207,7 +207,7 @@ public class ImInliner {
     }
 
     private boolean shouldInline(ImFunctionCall call, ImFunction f) {
-        if (f.isNative()) {
+        if (f.isNative() || call.getCallType() == CallType.EXECUTE) {
             return false;
         }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImPrinter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImPrinter.java
@@ -186,7 +186,7 @@ public class ImPrinter {
     public static void print(ImIf p, Appendable sb, int indent) {
         append(sb, "if ");
         p.getCondition().print(sb, indent);
-        append(sb, "{\n");
+        append(sb, " {\n");
         p.getThenBlock().print(sb, indent + 1);
         indent(sb, indent);
         append(sb, "} else {\n");
@@ -241,6 +241,9 @@ public class ImPrinter {
 
 
     public static void print(ImFunctionCall p, Appendable sb, int indent) {
+        if (p.getCallType() == CallType.EXECUTE) {
+            append(sb, "EXECUTE ");
+        }
         append(sb, p.getFunc().getName());
         append(sb, smallHash(p.getFunc()));
         printTypeArguments(p.getTypeArguments(), indent, sb);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
@@ -1652,7 +1652,14 @@ public class ImTranslator {
         ImStmts body = JassIm.ImStmts();
 
         // print message:
-        body.add(ImFunctionCall(emptyTrace, getDebugPrintFunction(), ImTypeArguments(), JassIm.ImExprs(JassIm.ImVarAccess(msgVar)), false, CallType.NORMAL));
+        // msg = msg + stacktrace
+        ImExpr msg = JassIm.ImOperatorCall(WurstOperator.PLUS, ImExprs(JassIm.ImVarAccess(msgVar),
+            JassIm.ImOperatorCall(WurstOperator.PLUS,
+                ImExprs(
+                    JassIm.ImStringVal("\n"),
+                    JassIm.ImGetStackTrace()))));
+
+        body.add(ImFunctionCall(emptyTrace, getDebugPrintFunction(), ImTypeArguments(), JassIm.ImExprs(msg), false, CallType.NORMAL));
         // TODO divide by zero to crash thread:
 
 
@@ -1667,7 +1674,9 @@ public class ImTranslator {
 
         List<FunctionFlag> flags = Lists.newArrayList();
 
-        return ImFunction(emptyTrace, "error", ImTypeVars(), parameters, returnType, locals, body, flags);
+        ImFunction errorFunc = ImFunction(emptyTrace, "error", ImTypeVars(), parameters, returnType, locals, body, flags);
+        imProg.getFunctions().add(errorFunc);
+        return errorFunc;
     }
 
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/BugTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/BugTests.java
@@ -1365,4 +1365,23 @@ public class BugTests extends WurstScriptTest {
         );
     }
 
+    @Test
+    public void executeFuncWithStackTrace() {
+        testAssertOkLines(true,
+            "package Test",
+            "native testSuccess()",
+            "@extern native ExecuteFunc(string f)",
+            "function getStackTraceString() returns string",
+            "    return \"foo\"",
+            "class A",
+            "    function bar()",
+            "        testSuccess()",
+            "A a = new A",
+            "function foo()",
+            "    a.bar()", // calling a function to ensure stacktraces are needed
+            "init",
+            "    ExecuteFunc(\"foo\")"
+        );
+    }
+
 }


### PR DESCRIPTION
The stack trace injector would add parameters to functions that were
called with ExecuteFunc, which is not allowed. With this changed it is
now handled similar to function references by adding a bridge function.

See #920