### PR TITLE
Omit unused warning from private static functions with compiletime annotation

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/ValidateClassMemberUsage.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/ValidateClassMemberUsage.java
@@ -146,7 +146,7 @@ public class ValidateClassMemberUsage {
         });
 
         definedFuncs.forEach(funcDef -> {
-            if (funcDef.attrIsPrivate()) {
+            if (funcDef.attrIsPrivate() && !(funcDef.attrIsStatic() && funcDef.hasAnnotation("@compiletime"))) {
                 funcDef.addWarning("Private function <" + funcDef.getName() + "> is never used.");
             }
         });


### PR DESCRIPTION
fixes https://github.com/wurstscript/WurstScript/issues/953