### PR TITLE
Use original object ID if new object ID is 0

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/objectreader/ObjectTable.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/objectreader/ObjectTable.java
@@ -4,13 +4,11 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 public class ObjectTable {
 
-    private LinkedHashMap<Integer, ObjectDefinition> objectDefinitions = new HashMap<>();
+    private LinkedHashMap<Integer, ObjectDefinition> objectDefinitions = new LinkedHashMap<>();
     private ObjectFileType fileType;
 
     public ObjectTable(ObjectFileType fileType2) {
@@ -40,7 +38,7 @@ public class ObjectTable {
     }
 
 
-    public Map<Integer, ObjectDefinition>  getObjectDefinitions() {
+    public LinkedHashMap<Integer, ObjectDefinition> getObjectDefinitions() {
         return objectDefinitions;
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/objectreader/ObjectTable.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/objectreader/ObjectTable.java
@@ -18,7 +18,11 @@ public class ObjectTable {
     }
 
     public void add(ObjectDefinition objDef) {
-        objectDefinitions.put(objDef.getNewObjectId(), objDef);
+        int objId = objDef.getNewObjectId();
+        if (objId == 0) {
+            objId = objDef.getOrigObjectId();
+        }
+        objectDefinitions.put(objId, objDef);
     }
 
     static ObjectTable readFromStream(BinaryDataInputStream in, ObjectFileType fileType) throws IOException {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/objectreader/ObjectTable.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/objectreader/ObjectTable.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 public class ObjectTable {
 
-    private Map<Integer, ObjectDefinition> objectDefinitions = new HashMap<>();
+    private LinkedHashMap<Integer, ObjectDefinition> objectDefinitions = new HashMap<>();
     private ObjectFileType fileType;
 
     public ObjectTable(ObjectFileType fileType2) {


### PR DESCRIPTION
Simplest fix for #984, based on [these few comments](https://github.com/wurstscript/WurstScript/commit/aadcf2905d4fab61ee6c05a010a3393cb29fc86c#diff-a431aa1b9398e51369f3b3d4418b9f3c1804c503269b3a3f6f6e8f936e57bf67L18). If this is all that's needed, great! If you had other plans for this fix or wanted to include some more changes, please feel free to close this PR.

Also changed `Map` to `LinkedHashMap` per @peq's comment, to keep the order deterministic.