### PR TITLE
lua: use BJDebugMsg for error messages if not using ErrorHandling package

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
@@ -3,6 +3,7 @@ package de.peeeq.wurstscript.translation.lua.translation;
 import de.peeeq.wurstscript.WurstOperator;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.luaAst.*;
+import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
 import de.peeeq.wurstscript.types.TypesHelper;
 
 import java.util.Optional;
@@ -71,7 +72,11 @@ public class ExprTranslation {
     }
 
     public static LuaExpr translate(ImFunctionCall e, LuaTranslator tr) {
-        return LuaAst.LuaExprFunctionCall(tr.luaFunc.getFor(e.getFunc()), tr.translateExprList(e.getArguments()));
+        LuaFunction f = tr.luaFunc.getFor(e.getFunc());
+        if (f.getName().equals(ImTranslator.$DEBUG_PRINT)) {
+            f.setName("BJDebugMsg");
+        }
+        return LuaAst.LuaExprFunctionCall(f, tr.translateExprList(e.getArguments()));
     }
 
     public static LuaExpr translate(ImInstanceof e, LuaTranslator tr) {


### PR DESCRIPTION
In lua, init blocks result in incorrect map scripts, if the package ErrorHandling is not used.
In particular, the print function inside the error function will be "$debugPrint". The $ character causes the map to not load.

This change is based on the jass expression translation here: [ExprTranslation.java](https://github.com/wurstscript/WurstScript/blob/e25c260b65dcb3186cb9c6ec1e9cb44c78bb7b0d/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ExprTranslation.java#L28)

This change only has an effect if ErrorHandling is not used. Then the call to "$debugPrint" is replaced with "BJDebugMsg" like in the jass expression translator.