### PR TITLE
Remove empty lines between globals in lua

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/printing/LuaPrinter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/printing/LuaPrinter.java
@@ -20,10 +20,16 @@ public class LuaPrinter {
             if (d instanceof LuaVariable) {
                 // don't translate global variables as locals:
                 printVariable((LuaVariable) d, sb, indent);
-            } else {
+                sb.append("\n");
+            } else if(d instanceof LuaAssignment) {
+                // these are top level assignments that are not inside functions
                 d.print(sb, indent);
+                sb.append("\n");
+            } else {
+                // every other statement is considered a block and has an empty line after it
+                d.print(sb, indent);
+                sb.append("\n\n");
             }
-            sb.append("\n\n");
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/printing/LuaPrinter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/printing/LuaPrinter.java
@@ -16,19 +16,26 @@ public class LuaPrinter {
     }
 
     public static void print(LuaCompilationUnit cu, StringBuilder sb, int indent) {
+        boolean statementBlock = false;
         for (LuaStatement d : cu) {
             if (d instanceof LuaVariable) {
                 // don't translate global variables as locals:
                 printVariable((LuaVariable) d, sb, indent);
                 sb.append("\n");
+                statementBlock = true;
             } else if(d instanceof LuaAssignment) {
                 // these are top level assignments that are not inside functions
                 d.print(sb, indent);
                 sb.append("\n");
+                statementBlock = true;
             } else {
                 // every other statement is considered a block and has an empty line after it
+                if(statementBlock) {
+                    sb.append("\n");
+                }
                 d.print(sb, indent);
                 sb.append("\n\n");
+                statementBlock = false;
             }
         }
     }


### PR DESCRIPTION
The lua printer adds two line breaks after every part of the program. This makes sense for functions, but causes every second line to be empty for globals.

Before:
```
function f()
    ...
end

x = nil

y = nil

z = nil

function g()
    ...
end

A.a = nil

B.b = nil
```
After:
```
function f()
    ...
end

x = nil
y = nil
z = nil

function g()
    ...
end

A.a = nil
B.b = nil
```