### PR TITLE
fix unused import warning with configured packages

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -159,6 +159,20 @@ public class WurstValidator {
         return result;
     }
 
+    private WPackage getConfiguredPackage(Element e) {
+        PackageOrGlobal p = e.attrNearestPackage();
+        if(p instanceof WPackage) {
+            if (p.getModel().attrConfigOverridePackages().containsValue(p)) {
+                for(WPackage k : p.getModel().attrConfigOverridePackages().keySet()) {
+                    if(p.getModel().attrConfigOverridePackages().get(k).equals(p)) {
+                        return k;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     private void collectUsedPackages(Set<PackageOrGlobal> used, Element e) {
         for (int i = 0; i < e.size(); i++) {
             collectUsedPackages(used, e.get(i));
@@ -169,6 +183,12 @@ public class WurstValidator {
             FuncLink link = fr.attrFuncLink();
             if (link != null) {
                 used.add(link.getDef().attrNearestPackage());
+                if(link.getDef().attrHasAnnotation("@config")) {
+                    WPackage configPackage = getConfiguredPackage(link.getDef());
+                    if(configPackage != null) {
+                        used.add(configPackage);
+                    }
+                }
             }
         }
         if (e instanceof NameRef) {
@@ -176,6 +196,12 @@ public class WurstValidator {
             NameLink def = nr.attrNameLink();
             if (def != null) {
                 used.add(def.getDef().attrNearestPackage());
+                if(def.getDef().attrHasAnnotation("@config")) {
+                    WPackage configPackage = getConfiguredPackage(def.getDef());
+                    if(configPackage != null) {
+                        used.add(configPackage);
+                    }
+                }
             }
         }
         if (e instanceof TypeRef) {


### PR DESCRIPTION
When only configured functions (functions that are overridden by the config package) are used, Wurst will consider the configured package unused. In other cases, the function is not considered to be unused, but will be attributed to the wrong package, resulting in "the import ... can be removed, because it is already included in ...".

This can be fixed by implicitly adding the configured package to the used packages, when the config package is used.

A prime example is the ErrorHandling package. In most cases, only the configurable error function is used, so when this function is configured  most packages that import ErrorHandling will throw a warning.