### PR TITLE
detect cyclic dependencies caused by config packages 

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/InitOrder.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/InitOrder.java
@@ -7,13 +7,12 @@ import com.google.common.collect.Sets;
 import de.peeeq.wurstscript.ast.WImport;
 import de.peeeq.wurstscript.ast.WImports;
 import de.peeeq.wurstscript.ast.WPackage;
-import de.peeeq.wurstscript.utils.Utils;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.HashMap;
 
 public class InitOrder {
 
@@ -30,12 +29,6 @@ public class InitOrder {
         }
 
         return ImmutableList.copyOf(packages);
-    }
-
-    private static List<String> toStringArray(List<WPackage> importChain) {
-        return importChain.stream()
-                .map(WPackage::getName)
-                .collect(Collectors.toList());
     }
 
     public static ImmutableList<WPackage> initDependenciesTransitive(WPackage p) {
@@ -58,12 +51,88 @@ public class InitOrder {
 
     public static ImmutableCollection<WPackage> importedPackagesTrans(WPackage p) {
         Collection<WPackage> result = Sets.newLinkedHashSet();
+        Set<String> reportedErrors = Sets.newHashSet();
         List<WPackage> callStack = Lists.newArrayList();
-        collectImportedPackages(callStack, p, result);
+        // the old cyclic check reports cyclic dependencies as errors
+        // it ignores cyclic dependencies caused by config packages
+        // it stores reported errors in reportedErrors
+        collectImportedPackages(callStack, p, result, reportedErrors, false, false);
+        // the new cyclic check reports cyclic dependencies caused by config packages as warnings
+        // it does not report warnings for cyclic dependencies stored in reportedErrors
+        collectImportedPackages(callStack, p, Sets.newLinkedHashSet(), reportedErrors, true, true);
+        // only the result of the old cyclic check is used
         return ImmutableList.copyOf(result);
     }
 
-    private static void addCollectImportedPackage(List<WPackage> callStack, WPackage p, Collection<WPackage> result, WImports imports) {
+    private static String getCyclicDependencyString(List<WPackage> callStack, WPackage imported) {
+        return getCyclicDependencyString(callStack, imported, false);
+    }
+
+    private static String getCyclicDependencyString(List<WPackage> callStack, WPackage imported, boolean considerConfig) {
+        // string representation of a cyclic dependency
+        // used for the error message and for storing already reported cyclic dependencies
+        StringBuilder msg = new StringBuilder();
+        Map<WPackage, WPackage> configuredPackage = new HashMap<>();
+        if (considerConfig) {
+            for (WPackage configured : imported.getModel().attrConfigOverridePackages().keySet()) {
+                configuredPackage.put(imported.getModel().attrConfigOverridePackages().get(configured), configured);
+            }
+        }
+        for (WPackage p : callStack) {
+            String packageString = p.getName();
+            if (considerConfig && configuredPackage.containsKey(p)) {
+                packageString = configuredPackage.get(p).getName() + "/" + packageString;
+            }
+            msg.append(packageString).append(" -> ");
+        }
+        String importedString = imported.getName();
+        if (considerConfig && configuredPackage.containsKey(imported)) {
+            importedString = configuredPackage.get(imported).getName() + "/" + importedString;
+        }
+        return msg + importedString;
+    }
+
+    private static String getErrorMsg(List<WPackage> callStack, WPackage imported) {
+        String cyclicDependency = getCyclicDependencyString(callStack, imported, false);
+        return "Cyclic init dependency between packages: " + cyclicDependency +
+            "\nChange some imports to 'initlater' imports to avoid this problem.";
+    }
+
+    private static String getWarningMsg(List<WPackage> callStack, WPackage imported) {
+        String cyclicDependency = getCyclicDependencyString(callStack, imported, true);
+        return "Cyclic init dependency between packages: " + cyclicDependency +
+            "\nChange some imports to 'initlater' imports to avoid this problem." +
+            "\nThis will be an error in future Wurst versions.";
+    }
+
+    private static void reportCyclicDependency(List<WPackage> callStack, WPackage wPackage, Set<String> reportedErrors, boolean useWarnings) {
+        String cyclicString = getCyclicDependencyString(callStack, wPackage);
+        String errorMsg = getErrorMsg(callStack, wPackage);
+        String warningMsg = getWarningMsg(callStack, wPackage);
+        for (WImport imp : wPackage.getImports()) {
+            if (callStack.size() > 1 && imp.attrImportedPackage() == callStack.get(1)) {
+                if (!reportedErrors.contains(cyclicString)) {
+                    reportedErrors.add(cyclicString);
+                    if (useWarnings) {
+                        wPackage.addWarning(warningMsg);
+                    } else {
+                        wPackage.addError(errorMsg);
+                    }
+                }
+                return;
+            }
+        }
+        if (!reportedErrors.contains(cyclicString)) {
+            reportedErrors.add(cyclicString);
+            if (useWarnings) {
+                wPackage.addWarning(warningMsg);
+            } else {
+                wPackage.addError(errorMsg);
+            }
+        }
+    }
+
+    private static void addCollectImportedPackage(List<WPackage> callStack, WPackage p, Collection<WPackage> result, WImports imports, Set<String> reportedErrors, boolean considerConfig, boolean useWarnings) {
         for (WImport i : imports) {
             WPackage imported = i.attrImportedPackage();
 
@@ -76,52 +145,35 @@ public class InitOrder {
             }
 
             if (imported == callStack.get(0)) {
-                String packagesMsg = Utils.join(toStringArray(callStack), " -> ");
-
-                String msg = "Cyclic init dependency between packages: " + packagesMsg + " -> " + imported.getName() +
-                        "\nChange some imports to 'initlater' imports to avoid this problem.";
-                for (WImport imp : imported.getImports()) {
-                    if (callStack.size() > 1 && imp.attrImportedPackage() == callStack.get(1)) {
-                        imp.addError(msg);
-                        return;
-                    }
-                }
-                imported.addError(msg);
+                reportCyclicDependency(callStack, imported, reportedErrors, useWarnings);
                 return;
             }
 
             if (!result.contains(imported)) {
                 result.add(imported);
-                collectImportedPackages(callStack, imported, result);
+                collectImportedPackages(callStack, imported, result, reportedErrors, considerConfig, useWarnings);
             }
             // add imports of configured package to config package
-            WPackage configPackage = p.getModel().attrConfigOverridePackages().get(imported);
-            if (configPackage != null && configPackage != p) {
-                if (configPackage == callStack.get(0)) {
-                    String packagesMsg = Utils.join(toStringArray(callStack), " -> ");
-
-                    String msg = "Cyclic init dependency between packages: " + packagesMsg + " -> " + configPackage.getName() +
-                            "\nChange some imports to 'initlater' imports to avoid this problem.";
-                    for (WImport imp : configPackage.getImports()) {
-                        if (callStack.size() > 1 && imp.attrImportedPackage() == callStack.get(1)) {
-                            imp.addError(msg);
-                            return;
-                        }
+            // that way cyclic dependencies are checked for the config package and errors will be reported for the config package
+            if (considerConfig) {
+                WPackage configPackage = p.getModel().attrConfigOverridePackages().get(imported);
+                if (configPackage != null && configPackage != p) {
+                    if (configPackage == callStack.get(0)) {
+                        reportCyclicDependency(callStack, configPackage, reportedErrors, useWarnings);
+                        return;
                     }
-                    configPackage.addError(msg);
-                    return;
-                }
-                if(!result.contains(configPackage)) {
-                    result.add(configPackage);
-                    collectImportedPackages(callStack, configPackage, result);
+                    if (!result.contains(configPackage)) {
+                        result.add(configPackage);
+                        collectImportedPackages(callStack, configPackage, result, reportedErrors, considerConfig, useWarnings);
+                    }
                 }
             }
         }
     }
 
-    private static void collectImportedPackages(List<WPackage> callStack, WPackage p, Collection<WPackage> result) {
+    private static void collectImportedPackages(List<WPackage> callStack, WPackage p, Collection<WPackage> result, Set<String> reportedErrors, boolean considerConfig, boolean useWarnings) {
         callStack.add(p);
-        addCollectImportedPackage(callStack, p, result, p.getImports());
+        addCollectImportedPackage(callStack, p, result, p.getImports(), reportedErrors, considerConfig, useWarnings);
         /*
         Imports of config packages are added to the imports of the configured package.
         Since config packages are initialized directly before the configured package,
@@ -129,9 +181,11 @@ public class InitOrder {
         This enables importing the configured package in the config package,
         even though the configured package will be initialized after the config package.
          */
-        for(Map.Entry<WPackage, WPackage> e: p.getModel().attrConfigOverridePackages().entrySet()) {
-            if(e.getValue().equals(p)) {
-                addCollectImportedPackage(callStack, e.getKey(), result, e.getKey().getImports());
+        if (considerConfig) {
+            for (Map.Entry<WPackage, WPackage> e : p.getModel().attrConfigOverridePackages().entrySet()) {
+                if (e.getValue().equals(p)) {
+                    addCollectImportedPackage(callStack, e.getKey(), result, e.getKey().getImports(), reportedErrors, considerConfig, useWarnings);
+                }
             }
         }
         callStack.remove(callStack.size() - 1);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/InitOrder.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/InitOrder.java
@@ -5,11 +5,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import de.peeeq.wurstscript.ast.WImport;
+import de.peeeq.wurstscript.ast.WImports;
 import de.peeeq.wurstscript.ast.WPackage;
 import de.peeeq.wurstscript.utils.Utils;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -61,9 +63,8 @@ public class InitOrder {
         return ImmutableList.copyOf(result);
     }
 
-    private static void collectImportedPackages(List<WPackage> callStack, WPackage p, Collection<WPackage> result) {
-        callStack.add(p);
-        for (WImport i : p.getImports()) {
+    private static void addCollectImportedPackage(List<WPackage> callStack, WPackage p, Collection<WPackage> result, WImports imports) {
+        for (WImport i : imports) {
             WPackage imported = i.attrImportedPackage();
 
             if (imported == null || i.getIsInitLater()) {
@@ -89,11 +90,49 @@ public class InitOrder {
                 return;
             }
 
-            if (result.contains(imported)) {
-                continue;
+            if (!result.contains(imported)) {
+                result.add(imported);
+                collectImportedPackages(callStack, imported, result);
             }
-            result.add(imported);
-            collectImportedPackages(callStack, imported, result);
+            // add imports of configured package to config package
+            WPackage configPackage = p.getModel().attrConfigOverridePackages().get(imported);
+            if (configPackage != null && configPackage != p) {
+                if (configPackage == callStack.get(0)) {
+                    String packagesMsg = Utils.join(toStringArray(callStack), " -> ");
+
+                    String msg = "Cyclic init dependency between packages: " + packagesMsg + " -> " + configPackage.getName() +
+                            "\nChange some imports to 'initlater' imports to avoid this problem.";
+                    for (WImport imp : configPackage.getImports()) {
+                        if (callStack.size() > 1 && imp.attrImportedPackage() == callStack.get(1)) {
+                            imp.addError(msg);
+                            return;
+                        }
+                    }
+                    configPackage.addError(msg);
+                    return;
+                }
+                if(!result.contains(configPackage)) {
+                    result.add(configPackage);
+                    collectImportedPackages(callStack, configPackage, result);
+                }
+            }
+        }
+    }
+
+    private static void collectImportedPackages(List<WPackage> callStack, WPackage p, Collection<WPackage> result) {
+        callStack.add(p);
+        addCollectImportedPackage(callStack, p, result, p.getImports());
+        /*
+        Imports of config packages are added to the imports of the configured package.
+        Since config packages are initialized directly before the configured package,
+        all imports are merged on the configured package to ensure it is initialized at the correct time.
+        This enables importing the configured package in the config package,
+        even though the configured package will be initialized after the config package.
+         */
+        for(Map.Entry<WPackage, WPackage> e: p.getModel().attrConfigOverridePackages().entrySet()) {
+            if(e.getValue().equals(p)) {
+                addCollectImportedPackage(callStack, e.getKey(), result, e.getKey().getImports());
+            }
         }
         callStack.remove(callStack.size() - 1);
     }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ConfigPackageTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ConfigPackageTests.java
@@ -88,6 +88,19 @@ public class ConfigPackageTests extends WurstScriptTest {
         );
     }
 
-
+    @Test
+    public void configCyclicImport() {
+        testAssertErrorsLines(false,
+            "Cyclic init dependency between packages",
+            "package Test",
+            "endpackage",
+            "package Test_config",
+            "import Requirement",
+            "endpackage",
+            "package Requirement",
+            "import Test",
+            "endpackage"
+        );
+    }
 
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ConfigPackageTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ConfigPackageTests.java
@@ -89,7 +89,7 @@ public class ConfigPackageTests extends WurstScriptTest {
     }
 
     @Test
-    public void configCyclicImport() {
+    public void configCyclicImportWarning() {
         testAssertErrorsLines(false,
             "Cyclic init dependency between packages",
             "package Test",


### PR DESCRIPTION
Fix for #990 .

There is an implicit initialization order dependency between the config and configured package:
The config package is always initialized directly before the configured package. However, this dependency is not known to the wurst validator, so it is possible to create cyclic dependencies and packages will be initialized before their imports.

This PR implicitly merges the dependencies on the config package.

- cyclic dependency error message is displayed for the config package
- the config package can still import the configured package. This is necessary in order to use definitions from the configured package

This can break existing and working maps. So implementing the stricter cyclic dependency check as a warning may be preferred. At least for some time, similar to globals being used above their declaration.
