### PR TITLE
Fix updating module instantiations in model manager

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManagerImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManagerImpl.java
@@ -238,18 +238,38 @@ public class ModelManagerImpl implements ModelManager {
         model2.clearAttributesLocal();
         Set<String> packageNames = Sets.newHashSet();
         for (CompilationUnit cu : toCheck) {
-            cu.clearAttributes();
+            clearCompilationUnit(cu);
             for (WPackage p : cu.getPackages()) {
                 packageNames.add(p.getName());
             }
         }
         for (CompilationUnit cu : model2) {
             if (imports(cu, packageNames)) {
-                cu.clearAttributes();
+                clearCompilationUnit(cu);
                 cleared.add(cu);
             }
         }
         return cleared;
+    }
+
+    private void clearCompilationUnit(CompilationUnit cu) {
+        cu.clearAttributes();
+        // clear module instantiations
+        for (WPackage p : cu.getPackages()) {
+            for (WEntity elem : p.getElements()) {
+                if (elem instanceof ClassOrModuleInstanciation) {
+                    clearModuleInstantiation(((ClassOrModuleInstanciation) elem));
+                }
+            }
+        }
+    }
+
+    private void clearModuleInstantiation(ClassOrModuleInstanciation elem) {
+        elem.getP_moduleInstanciations().clear();
+        elem.getModuleInstanciations().clear();
+        for (ClassDef innerClass : elem.getInnerClasses()) {
+            clearModuleInstantiation(innerClass);
+        }
     }
 
     /**


### PR DESCRIPTION
When changing a module in vscode, changes were not directly reflected in other files using the module. With this change, we now clear the module intantiations in depending packages so that they are recomputed on demand.