### PR TITLE
Add mocks for Quest and QuestItem natives.

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/ReflectionNativeProvider.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/ReflectionNativeProvider.java
@@ -43,6 +43,8 @@ public class ReflectionNativeProvider implements NativesProvider {
         addProvider(new IntegerProvider(interpreter));
         addProvider(new FrameProvider(interpreter));
         addProvider(new LuaEnsureTypeProvider(interpreter));
+        addProvider(new QuestProvider(interpreter));
+        addProvider(new QuestItemProvider(interpreter));
     }
 
     public NativeJassFunction getFunctionPair(String funcName) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/mocks/QuestItemMock.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/mocks/QuestItemMock.java
@@ -1,0 +1,11 @@
+package de.peeeq.wurstio.jassinterpreter.mocks;
+
+import de.peeeq.wurstscript.intermediatelang.ILconstBool;
+
+public class QuestItemMock {
+    public ILconstBool completed;
+
+    public QuestItemMock() {
+        this.completed = ILconstBool.FALSE;
+    }
+}

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/mocks/QuestMock.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/mocks/QuestMock.java
@@ -1,0 +1,19 @@
+package de.peeeq.wurstio.jassinterpreter.mocks;
+
+import de.peeeq.wurstscript.intermediatelang.ILconstBool;
+
+public class QuestMock {
+    public ILconstBool completed;
+    public ILconstBool discovered;
+    public ILconstBool enabled;
+    public ILconstBool failed;
+    public ILconstBool required;
+
+    public QuestMock() {
+        this.completed = ILconstBool.FALSE;
+        this.discovered = ILconstBool.FALSE;
+        this.enabled = ILconstBool.FALSE;
+        this.failed = ILconstBool.FALSE;
+        this.required = ILconstBool.FALSE;
+    }
+}

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/providers/QuestItemProvider.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/providers/QuestItemProvider.java
@@ -1,0 +1,28 @@
+package de.peeeq.wurstio.jassinterpreter.providers;
+
+import de.peeeq.wurstio.jassinterpreter.mocks.QuestItemMock;
+import de.peeeq.wurstscript.intermediatelang.ILconstBool;
+import de.peeeq.wurstscript.intermediatelang.ILconstString;
+import de.peeeq.wurstscript.intermediatelang.IlConstHandle;
+import de.peeeq.wurstscript.intermediatelang.interpreter.AbstractInterpreter;
+
+public class QuestItemProvider extends Provider {
+    public QuestItemProvider(AbstractInterpreter interpreter) {
+        super(interpreter);
+    }
+
+    public IlConstHandle QuestCreateItem(IlConstHandle quest) {
+        return new IlConstHandle(NameProvider.getRandomName("questitem"), new QuestItemMock());
+    }
+
+    public void QuestItemSetDescription(IlConstHandle questItem, ILconstString description) {
+    }
+
+    public ILconstBool IsQuestItemCompleted(IlConstHandle questItem) {
+        return ((QuestItemMock) questItem.getObj()).completed;
+    }
+
+    public void QuestItemSetCompleted(IlConstHandle questItem, ILconstBool completed) {
+        ((QuestItemMock) questItem.getObj()).completed = completed;
+    }
+}

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/providers/QuestProvider.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/providers/QuestProvider.java
@@ -1,0 +1,69 @@
+package de.peeeq.wurstio.jassinterpreter.providers;
+
+import de.peeeq.wurstio.jassinterpreter.mocks.QuestMock;
+import de.peeeq.wurstscript.intermediatelang.ILconstBool;
+import de.peeeq.wurstscript.intermediatelang.ILconstString;
+import de.peeeq.wurstscript.intermediatelang.IlConstHandle;
+import de.peeeq.wurstscript.intermediatelang.interpreter.AbstractInterpreter;
+
+public class QuestProvider extends Provider {
+    public QuestProvider(AbstractInterpreter interpreter) {
+        super(interpreter);
+    }
+
+    public IlConstHandle CreateQuest() {
+        return new IlConstHandle(NameProvider.getRandomName("quest"), new QuestMock());
+    }
+
+    public void DestroyQuest(IlConstHandle quest) {
+    }
+
+    public void QuestSetTitle(IlConstHandle quest, ILconstString title) {
+    }
+
+    public void QuestSetIconPath(IlConstHandle quest, ILconstString title) {
+    }
+
+    public void QuestSetDescription(IlConstHandle quest, ILconstString description) {
+    }
+
+    public ILconstBool IsQuestCompleted(IlConstHandle quest) {
+        return ((QuestMock) quest.getObj()).completed;
+    }
+
+    public ILconstBool IsQuestDiscovered(IlConstHandle quest) {
+        return ((QuestMock) quest.getObj()).discovered;
+    }
+
+    public ILconstBool IsQuestEnabled(IlConstHandle quest) {
+        return ((QuestMock) quest.getObj()).enabled;
+    }
+
+    public ILconstBool IsQuestFailed(IlConstHandle quest) {
+        return ((QuestMock) quest.getObj()).failed;
+    }
+
+    public ILconstBool IsQuestRequired(IlConstHandle quest) {
+        return ((QuestMock) quest.getObj()).required;
+    }
+
+    public void QuestSetCompleted(IlConstHandle quest, ILconstBool completed) {
+        ((QuestMock) quest.getObj()).completed = completed;
+    }
+
+    public void QuestSetDiscovered(IlConstHandle quest, ILconstBool discovered) {
+        ((QuestMock) quest.getObj()).discovered = discovered;
+    }
+
+    public void QuestSetEnabled(IlConstHandle quest, ILconstBool enabled) {
+        ((QuestMock) quest.getObj()).enabled = enabled;
+    }
+
+    public void QuestSetFailed(IlConstHandle quest, ILconstBool failed) {
+        ((QuestMock) quest.getObj()).failed = failed;
+    }
+
+    public void QuestSetRequired(IlConstHandle quest, ILconstBool required) {
+        ((QuestMock) quest.getObj()).required = required;
+    }
+}


### PR DESCRIPTION
Natives which have some visible effect are mocked out (QuestSetCompleted, IsQuestCompleted, etc...). Others are just no-ops.

I couldn't find prior examples of how to test mocks for their correctness, so no unit tests are added to the repository. These changes were manually test with a local rebuild of the repository and running Wurstscript unit tests that rely on the mocks being available. The tests fail at HEAD and succeed with these changes.

Also didn't see a style guide, and Java is not my primary language. Suggestions are welcome!