### PR TITLE
Temporary index variable for shorthand assignments

### DIFF
--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ArrayTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ArrayTests.java
@@ -222,5 +222,41 @@ public class ArrayTests extends WurstScriptTest {
             "        testSuccess()");
     }
 
+    @Test
+    public void shorthandAssignmentNoWarning() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "int array testArray",
+            "int numExecutions = 0",
+            "function getIndex() returns int",
+            "    numExecutions++",
+            "    return 2",
+            "init",
+            "    let tmp = 17",
+            "    testArray[getIndex() + tmp] += 1",
+            "    if numExecutions == 1",
+            "        testSuccess()"
+        );
+    }
 
+    @Test
+    public void shorthandAssignmentClassNoWarning() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "int numExecutions = 0",
+            "class C",
+            "    int array[3] v = [7, 8, 9]",
+            "function getIndex() returns int",
+            "    numExecutions++",
+            "    return 1",
+            "init",
+            "    let tmp = 1",
+            "    let c = new C()",
+            "    c.v[getIndex() + tmp] += 1",
+            "    if numExecutions == 1",
+            "        testSuccess()"
+        );
+    }
 }


### PR DESCRIPTION
Addresses #998 .

rewrites
`test[getIndex()]++`
to
```
let tmp = getIndex()
test[tmp] = test[tmp] + 1
``` 

Few remarks:
- I rewrote transformStatement so it returns a list of statements rather than a single one in order to add the temporary variables before the set statement. Maybe there is a way to combine multiple statements in a single one?
- It assumes, indexes are integers. Since this transformation happens so early in the compiler, there doesn't seem to be a way to get the type of the index expressions. Should be fine though, because all array indexes are always integer.
- From a quick look, jurst seems to have the same code. I haven't updated it, but if this implementation is ok, I can apply it to jurst as well.
- I used tmpArrayIndex_ combined with the line number as name for the temporary variable which should avoid conflicts, but if there is a function to get a unique identifier that would be better.


Integer literals and variables don't use temporary variables:
`test[4]++` -> `test[4] = test[4] + 1`
`test[myInt]++` -> `test[myInt] = test[myInt] + 1`
When using expression that can be evaluated to constants, the optimizer will take care of that and you end up with a case like above.
Right now integer arrays are also stored in temporary variables:
`test[myIntArray[0]]++` ->
```
let tmp = myIntArray[0]
test[tmp] = test[tmp] + 1
```
In theory one could leave integer arrays, as long as the index itself is again constant, but if enough integer arrays are used, using a temporary variable will be faster. Could probably add a cutoff and say if it's less than x nested integer arrays, keep them, otherwise use temp variable.