### PR TITLE
Improve Lua optimizers

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
@@ -857,6 +857,11 @@ public class WurstCompilerJassImpl implements WurstCompiler {
             printDebugImProg("./test-output/lua/im " + stage++ + "_afterinline.im");
         }
 
+        // eliminate local types
+        beginPhase(6, "eliminate local type");
+        getImProg().flatten(imTranslator2);
+        EliminateLocalTypes.eliminateLocalTypesProg(getImProg(), imTranslator2);
+
         optimizer.removeGarbage();
         imProg.flatten(imTranslator);
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/providers/LuaEnsureTypeProvider.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/providers/LuaEnsureTypeProvider.java
@@ -23,4 +23,6 @@ public class LuaEnsureTypeProvider extends Provider {
     public ILconstReal realEnsure(ILconstReal x) {
         return x;
     }
+
+    public ILconstString stringConcat(ILconstString x, ILconstString y) { return new ILconstString(x.getVal() + y.getVal()); }
 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/TempMerger.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/TempMerger.java
@@ -7,6 +7,7 @@ import de.peeeq.wurstscript.translation.imoptimizer.OptimizerPass;
 import de.peeeq.wurstscript.translation.imtranslation.AssertProperty;
 import de.peeeq.wurstscript.translation.imtranslation.ImHelper;
 import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
+import de.peeeq.wurstscript.types.TypesHelper;
 import de.peeeq.wurstscript.utils.MapWithIndexes;
 import de.peeeq.wurstscript.utils.MapWithIndexes.Index;
 import de.peeeq.wurstscript.utils.MapWithIndexes.PredIndex;
@@ -116,6 +117,11 @@ public class TempMerger implements OptimizerPass {
             } else if (imSet.getLeft() instanceof ImVarArrayAccess) {
                 ImVarArrayAccess va = (ImVarArrayAccess) imSet.getLeft();
                 kn.invalidateVar(va.getVar());
+            } else if (imSet.getLeft() instanceof ImMemberAccess) {
+                ImMemberAccess ma = (ImMemberAccess) imSet.getLeft();
+                kn.invalidateVar(ma.getVar());
+            } else if (imSet.getLeft() instanceof ImTupleSelection) {
+                kn.invalidateVar(TypesHelper.getTupleVar(((ImTupleSelection) imSet.getLeft())));
             }
         } else if (s instanceof ImExitwhen || s instanceof ImIf || s instanceof ImLoop || s instanceof ImVarargLoop) {
             kn.clear();
@@ -319,6 +325,9 @@ public class TempMerger implements OptimizerPass {
             private void collectReadVariables(Collection<ImVar> result, Element e) {
                 if (e instanceof ImVarRead) {
                     result.add(((ImVarRead) e).getVar());
+                }
+                if (e instanceof ImMemberAccess) {
+                    result.add(((ImMemberAccess) e).getVar());
                 }
                 for (int i = 0; i < e.size(); i++) {
                     collectReadVariables(result, e.get(i));

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImAttrType.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImAttrType.java
@@ -113,7 +113,11 @@ public class ImAttrType {
     }
 
     public static ImType getType(ImTupleSelection e) {
-        ImTupleType tt = (ImTupleType) e.getTupleExpr().attrTyp();
+        ImType t = e.getTupleExpr().attrTyp();
+        if(t instanceof ImArrayTypeMulti) {
+            t = ((ImArrayTypeMulti) t).getEntryType();
+        }
+        ImTupleType tt = (ImTupleType) t;
         return tt.getTypes().get(e.getTupleIndex());
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateLocalTypes.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateLocalTypes.java
@@ -1,11 +1,17 @@
 package de.peeeq.wurstscript.translation.imtranslation;
 
+import de.peeeq.wurstscript.WurstOperator;
 import de.peeeq.wurstscript.jassIm.*;
+import de.peeeq.wurstscript.types.TypesHelper;
 
 public class EliminateLocalTypes {
     private static ImType localVarType = JassIm.ImSimpleType("localVarType");
 
     public static void eliminateLocalTypesProg(ImProg imProg, ImTranslator translator) {
+        // While local types are still there, perform transformation specifically for strings:
+        // null string -> ""
+        // string1 + string2 -> stringConcat(string1, string2)
+        transformStrings(imProg, translator);
         // Eliminates local types to be able to merge more locals in Lua.
         for (ImFunction f : ImHelper.calculateFunctionsOfProg(imProg)) {
             eliminateLocalTypesFunc(f, translator);
@@ -26,5 +32,28 @@ public class EliminateLocalTypes {
             // Types of single values can be erased, because they have to be initialized with a specific value before they can be used.
             local.setType(localVarType);
         }
+    }
+    
+    private static void transformStrings(ImProg imProg, ImTranslator translator) {
+        imProg.accept(new Element.DefaultVisitor() {
+            @Override
+            public void visit(ImOperatorCall imOperatorCall) {
+                super.visit(imOperatorCall);
+                ImExprs args = imOperatorCall.getArguments();
+                if (imOperatorCall.getOp() == WurstOperator.PLUS) {
+                    if(args.size() == 2 && TypesHelper.isStringType(args.get(0).attrTyp()) && TypesHelper.isStringType(args.get(1).attrTyp()) ) {
+                        imOperatorCall.replaceBy(JassIm.ImFunctionCall(imOperatorCall.attrTrace(), translator.stringConcatFunc, JassIm.ImTypeArguments(), imOperatorCall.getArguments().copy(), false, CallType.NORMAL));
+                    }
+                }
+            }
+
+            @Override
+            public void visit(ImNull imNull) {
+                super.visit(imNull);
+                if(TypesHelper.isStringType(imNull.getType())) {
+                    imNull.replaceBy(JassIm.ImStringVal(""));
+                }
+            }
+        });
     }
 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateLocalTypes.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateLocalTypes.java
@@ -1,0 +1,30 @@
+package de.peeeq.wurstscript.translation.imtranslation;
+
+import de.peeeq.wurstscript.jassIm.*;
+
+public class EliminateLocalTypes {
+    private static ImType localVarType = JassIm.ImSimpleType("localVarType");
+
+    public static void eliminateLocalTypesProg(ImProg imProg, ImTranslator translator) {
+        // Eliminates local types to be able to merge more locals in Lua.
+        for (ImFunction f : ImHelper.calculateFunctionsOfProg(imProg)) {
+            eliminateLocalTypesFunc(f, translator);
+        }
+    }
+
+    private static void eliminateLocalTypesFunc(ImFunction f, final ImTranslator translator) {
+        for(ImVar local : f.getLocals()) {
+            ImType t = local.getType();
+            if(t instanceof ImArrayLikeType) {
+                // Arrays are initialized with the default value of the type, so type information needs to be preserved.
+                continue;
+            }
+            if(t instanceof ImTupleType) {
+                // Tuples use special access functions, so type information needs to be preserved.
+                continue;
+            }
+            // Types of single values can be erased, because they have to be initialized with a specific value before they can be used.
+            local.setType(localVarType);
+        }
+    }
+}

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateLocalTypes.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateLocalTypes.java
@@ -5,7 +5,7 @@ import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.types.TypesHelper;
 
 public class EliminateLocalTypes {
-    private static ImType localVarType = JassIm.ImSimpleType("localVarType");
+    private static ImType localSimpleType = JassIm.ImSimpleType("localSimpleType");
 
     public static void eliminateLocalTypesProg(ImProg imProg, ImTranslator translator) {
         // While local types are still there, perform transformation specifically for strings:
@@ -21,16 +21,10 @@ public class EliminateLocalTypes {
     private static void eliminateLocalTypesFunc(ImFunction f, final ImTranslator translator) {
         for(ImVar local : f.getLocals()) {
             ImType t = local.getType();
-            if(t instanceof ImArrayLikeType) {
-                // Arrays are initialized with the default value of the type, so type information needs to be preserved.
-                continue;
+            if(t instanceof ImSimpleType) {
+                // Simple types can always be merged.
+                local.setType(localSimpleType);
             }
-            if(t instanceof ImTupleType) {
-                // Tuples use special access functions, so type information needs to be preserved.
-                continue;
-            }
-            // Types of single values can be erased, because they have to be initialized with a specific value before they can be used.
-            local.setType(localVarType);
         }
     }
     

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
@@ -176,13 +176,6 @@ public class ExprTranslation {
             ImFunction calledFunc = t.getFuncFor(e.attrFuncDef());
             return ImFunctionCall(e, calledFunc, ImTypeArguments(), ImExprs(left, right), false, CallType.NORMAL);
         }
-        if(op == WurstOperator.PLUS) {
-            if(t.isLuaTarget()) {
-                if(TypesHelper.isStringType(left.attrTyp()) && TypesHelper.isStringType(right.attrTyp())) {
-                    return ImFunctionCall(e, t.stringConcatFunc, ImTypeArguments(), ImExprs(left, right), false, CallType.NORMAL);
-                }
-            }
-        }
         if (op == WurstOperator.DIV_REAL) {
             if (Utils.isJassCode(e)) {
                 if (e.getLeft().attrTyp().isSubtypeOf(WurstTypeInt.instance(), e)
@@ -231,9 +224,6 @@ public class ExprTranslation {
         WurstType expectedTypeRaw = e.attrExpectedTypRaw();
         if (expectedTypeRaw instanceof WurstTypeUnknown) {
             e.addError("Cannot use 'null' in this context.");
-        }
-        if(t.isLuaTarget() && expectedTypeRaw instanceof WurstTypeString) {
-            return ImStringVal("");
         }
         return ImNull(expectedTypeRaw.imTranslateType(t));
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
@@ -176,6 +176,13 @@ public class ExprTranslation {
             ImFunction calledFunc = t.getFuncFor(e.attrFuncDef());
             return ImFunctionCall(e, calledFunc, ImTypeArguments(), ImExprs(left, right), false, CallType.NORMAL);
         }
+        if(op == WurstOperator.PLUS) {
+            if(t.isLuaTarget()) {
+                if(TypesHelper.isStringType(left.attrTyp()) && TypesHelper.isStringType(right.attrTyp())) {
+                    return ImFunctionCall(e, t.stringConcatFunc, ImTypeArguments(), ImExprs(left, right), false, CallType.NORMAL);
+                }
+            }
+        }
         if (op == WurstOperator.DIV_REAL) {
             if (Utils.isJassCode(e)) {
                 if (e.getLeft().attrTyp().isSubtypeOf(WurstTypeInt.instance(), e)
@@ -224,6 +231,9 @@ public class ExprTranslation {
         WurstType expectedTypeRaw = e.attrExpectedTypRaw();
         if (expectedTypeRaw instanceof WurstTypeUnknown) {
             e.addError("Cannot use 'null' in this context.");
+        }
+        if(t.isLuaTarget() && expectedTypeRaw instanceof WurstTypeString) {
+            return ImStringVal("");
         }
         return ImNull(expectedTypeRaw.imTranslateType(t));
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
@@ -95,6 +95,7 @@ public class ImTranslator {
     @Nullable public ImFunction ensureBoolFunc = null;
     @Nullable public ImFunction ensureRealFunc = null;
     @Nullable public ImFunction ensureStrFunc = null;
+    @Nullable public ImFunction stringConcatFunc = null;
 
     private final Map<ImVar, VarsForTupleResult> varsForTupleVar = new LinkedHashMap<>();
 
@@ -134,10 +135,12 @@ public class ImTranslator {
                 ensureBoolFunc = JassIm.ImFunction(emptyTrace, "boolEnsure", ImTypeVars(), ImVars(JassIm.ImVar(wurstProg, WurstTypeBool.instance().imTranslateType(this), "x", false)), WurstTypeBool.instance().imTranslateType(this), ImVars(), ImStmts(), flags(IS_NATIVE, IS_BJ));
                 ensureRealFunc = JassIm.ImFunction(emptyTrace, "realEnsure", ImTypeVars(), ImVars(JassIm.ImVar(wurstProg, WurstTypeReal.instance().imTranslateType(this), "x", false)), WurstTypeReal.instance().imTranslateType(this), ImVars(), ImStmts(), flags(IS_NATIVE, IS_BJ));
                 ensureStrFunc = JassIm.ImFunction(emptyTrace, "stringEnsure", ImTypeVars(), ImVars(JassIm.ImVar(wurstProg, WurstTypeString.instance().imTranslateType(this), "x", false)), WurstTypeString.instance().imTranslateType(this), ImVars(), ImStmts(), flags(IS_NATIVE, IS_BJ));
+                stringConcatFunc =JassIm.ImFunction(emptyTrace, "stringConcat", ImTypeVars(), ImVars(JassIm.ImVar(wurstProg, WurstTypeString.instance().imTranslateType(this), "x", false),JassIm.ImVar(wurstProg, WurstTypeString.instance().imTranslateType(this), "y", false)), WurstTypeString.instance().imTranslateType(this), ImVars(), ImStmts(), flags(IS_NATIVE, IS_BJ));
                 addFunction(ensureIntFunc);
                 addFunction(ensureBoolFunc);
                 addFunction(ensureRealFunc);
                 addFunction(ensureStrFunc);
+                addFunction(stringConcatFunc);
             }
 
             calculateCompiletimeOrder();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
@@ -107,11 +107,7 @@ public class ExprTranslation {
     }
 
     public static LuaExpr translate(ImNull e, LuaTranslator tr) {
-        if(isStringType(e.getType())) {
-            return LuaAst.LuaExprStringVal("");
-        } else {
-            return LuaAst.LuaExprNull();
-        }
+        return LuaAst.LuaExprNull();
     }
 
     public static LuaExpr translate(ImOperatorCall e, LuaTranslator tr) {
@@ -126,13 +122,7 @@ public class ExprTranslation {
             LuaExpr leftExpr = left.translateToLua(tr);
             LuaExpr rightExpr = right.translateToLua(tr);
             LuaOpBinary op;
-            if (e.getOp() == WurstOperator.PLUS
-                && isStringType(left.attrTyp())
-                && isStringType(right.attrTyp())) {
-                // special case for string concatenation
-                return LuaAst.LuaExprFunctionCall(tr.stringConcatFunction,
-                    LuaAst.LuaExprlist(leftExpr, rightExpr));
-            } else if (e.getOp() == WurstOperator.MOD_INT) {
+            if (e.getOp() == WurstOperator.MOD_INT) {
                 op = LuaAst.LuaOpMod();
 
                 return LuaAst.LuaExprFunctionCallE(LuaAst.LuaLiteral("math.floor"),
@@ -270,15 +260,6 @@ public class ExprTranslation {
             return LuaAst.LuaExprFunctionCall(ef, LuaAst.LuaExprlist(leftExpr, rightExpr));
         }
         return LuaAst.LuaExprBinary(leftExpr, LuaAst.LuaOpEquals(), rightExpr);
-    }
-
-
-    private static boolean isStringType(ImType t) {
-        if (t instanceof ImSimpleType) {
-            ImSimpleType st = (ImSimpleType) t;
-            return st.getTypename().equals("string");
-        }
-        return false;
     }
 
     public static LuaExpr translate(ImRealVal e, LuaTranslator tr) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/StmtTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/StmtTranslation.java
@@ -39,8 +39,10 @@ public class StmtTranslation {
         LuaExpr right = s.getRight().translateToLua(tr);
         if (s.getRight().attrTyp() instanceof ImTupleType) {
             ImTupleType tt = (ImTupleType) s.getRight().attrTyp();
-            // tuples must be copied
-            right = LuaAst.LuaExprFunctionCall(ExprTranslation.getTupleCopyFunc(tt, tr), LuaAst.LuaExprlist(right));
+            // tuples must be copied, unless they are literals
+            if(!(right instanceof LuaTableConstructor)) {
+                right = LuaAst.LuaExprFunctionCall(ExprTranslation.getTupleCopyFunc(tt, tr), LuaAst.LuaExprlist(right));
+            }
         }
         res.add(LuaAst.LuaAssignment(left, right));
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypesHelper.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypesHelper.java
@@ -48,6 +48,21 @@ public class TypesHelper {
                 || vt instanceof ImArrayTypeMulti && typeContainsTuples(((ImArrayTypeMulti) vt).getEntryType());
     }
     
+    public static ImVar getSimpleAndPureTupleVar(ImTupleSelection ts) {
+        ImExpr te = ts;
+        while(te instanceof ImTupleSelection) {
+            te = ((ImTupleSelection) te).getTupleExpr();
+        }
+        if(te instanceof ImVarAccess) {
+            ImVar var = ((ImVarAccess) te).getVar();
+            if(var.isGlobal()) {
+                return null;
+            }
+            return var;
+        }
+        return null;
+    }
+    
     public static ImVar getTupleVar(ImTupleSelection ts) {
         ImExpr te = ts;
         while(te instanceof ImTupleSelection) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypesHelper.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypesHelper.java
@@ -47,6 +47,23 @@ public class TypesHelper {
                 || vt instanceof ImArrayType && typeContainsTuples(((ImArrayType) vt).getEntryType())
                 || vt instanceof ImArrayTypeMulti && typeContainsTuples(((ImArrayTypeMulti) vt).getEntryType());
     }
+    
+    public static ImVar getTupleVar(ImTupleSelection ts) {
+        ImExpr te = ts;
+        while(te instanceof ImTupleSelection) {
+            te = ((ImTupleSelection) te).getTupleExpr();
+        }
+        if(te instanceof ImVarAccess) {
+            return ((ImVarAccess) te).getVar();
+        }
+        if(te instanceof ImVarArrayAccess) {
+            return ((ImVarArrayAccess) te).getVar();
+        }
+        if(te instanceof ImMemberAccess) {
+            return ((ImMemberAccess) te).getVar();
+        }
+        throw new Error("not implemented");
+    }
 
     public static boolean isIntType(ImType t) {
         if (t instanceof ImSimpleType) {
@@ -65,6 +82,13 @@ public class TypesHelper {
     public static boolean isBoolType(ImType t) {
         if (t instanceof ImSimpleType) {
             return ((ImSimpleType) t).getTypename().equals("boolean");
+        }
+        return false;
+    }
+
+    public static boolean isStringType(ImType t) {
+        if (t instanceof ImSimpleType) {
+            return ((ImSimpleType) t).getTypename().equals("string");
         }
         return false;
     }


### PR DESCRIPTION
Bugfixes and improvements for Lua optimizers.
Implements some handling of tuples and members that was missing and could cause:

<details> 
  <summary>Compiler error due to unattached variables, when doing some optimizations with tuples</summary>
-inline
-localOptimizations
-lua

```
package MyTest

function locals() returns bool
    var d = vec2(1,0)
    d.y = 2
    return d.x == 1
    
init
    if locals()
        print("Success")
```
</details>

<details> 
  <summary>Wrong output script due to incorrect assumptions by the optimizer </summary>
-inline
-localOptimizations
-lua
   
```
package ListSort

import LinkedList

init
    let list = new LinkedList<int>()
    list.add(1,2)
    list.sort()
    print(list.get(0))
    print(list.get(1))
```

This prints 1 and 0. It is caused by the split function in LinkedList:
```
...
let tmp = halfRef.next
halfRef.next = dummy
return tmp
```
Without stacktraces, only the member set halfRef.next is between the tmp accesses and the optimizer would think tmp equals halfRef.next, so it can just return halfRef.next.
</details>

The optimizer now also deals better with tuple literals and avoids copying them after constructing them. There are still possible improvements for tuples, but I first wanted to fix the bugs.

Unused members are now removed like in Jass.

Some Lua translation steps that relied on type information were moved before local optimizations:
- null string to ""
- string concatenation

This makes it possible to unify some types before the optimizers, allowing more local merging.
Arrays and tuple types are kept, because they are required for the initialization.


I actually only found the first issue by running all unit tests with Lua and getting the error. With these changes all unit tests also passed in Lua with the same optimizer options as in Jass, as long as execution is disabled for Lua. Maybe it would be good to have unit tests by default also compile with Lua just so compiler errors would be detected.

