### PR TITLE
Remove type dependency from cast translation

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
@@ -326,7 +326,7 @@ public class ExprTranslation {
 
     public static LuaExpr translate(ImCast imCast, LuaTranslator tr) {
         LuaExpr translated = imCast.getExpr().translateToLua(tr);
-        if (TypesHelper.isIntType(imCast.getToType()) && !TypesHelper.isIntType(imCast.getExpr().attrTyp())) {
+        if (TypesHelper.isIntType(imCast.getToType())) {
             return LuaAst.LuaExprFunctionCall(tr.toIndexFunction, LuaAst.LuaExprlist(translated));
         } else if (imCast.getToType() instanceof ImClassType
             || imCast.getToType() instanceof ImAnyType) {


### PR DESCRIPTION
What I said [here](https://github.com/wurstscript/WurstScript/pull/1063#issuecomment-1179729151) with the enums working differently is wrong. I assumed so, because I saw objectToIndex being used for the cast.
What happened is that due to the local type elimination, the translator did not know it was a cast from int (Enum) to int and only saw a cast from something to int, so it inserted the objectToIndex.

Now these unnecessary casts from int to int are removed in advance, so that the translator does not need to know the type of the expression that's being cast and works with eliminated local types.