### PR TITLE
warn log instead of printing stacktrace on linux platform

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/utils/W3InstallationData.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/utils/W3InstallationData.java
@@ -80,7 +80,7 @@ public class W3InstallationData {
             version = Optional.ofNullable(new StdGameVersionFinder().get());
             WLogger.info("Parsed game version: " + version);
         } catch (NotFoundException e) {
-            e.printStackTrace();
+            WLogger.warning("Wurst compiler failed to determine game version", e);
         }
     }
 


### PR DESCRIPTION
It may be better to update w3utils to throw a different exception to match against for linux versus a not-found mac/windows one, but this seems like a sensible improvement anyway since wurstc just uses latest patch when the version cannot be determined.

To be clear, when this stacktrace appears, wurstc has no problem building a map successfully.

```
$ grill build base_map.w3x
🔥 Grill warming up..
🔥 Ready. Version: <1.3.4.1-jenkins-WurstSetup-157>
🔨 Building project..
java.nio.file.NoSuchFileException: /mnt/c/Users/Cokem/workspace/..././wurst/_build/dependencies
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
        at sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:427)
        at java.nio.file.Files.newDirectoryStream(Files.java:457)
        at java.nio.file.Files.list(Files.java:3451)
        at de.peeeq.wurstio.map.importer.ImportFile.getTransientImportDirectories(ImportFile.java:216)
        at de.peeeq.wurstio.map.importer.ImportFile.importFilesFromImports(ImportFile.java:188)
        at de.peeeq.wurstio.WurstCompilerJassImpl.runCompiletime(WurstCompilerJassImpl.java:125)
        at de.peeeq.wurstio.CompilationProcess.lambda$doCompilation$3(CompilationProcess.java:88)
        at de.peeeq.wurstio.TimeTaker.lambda$measure$0(TimeTaker.java:15)
        at de.peeeq.wurstio.TimeTaker$Default.measure(TimeTaker.java:33)
        at de.peeeq.wurstio.TimeTaker.measure(TimeTaker.java:14)
        at de.peeeq.wurstio.CompilationProcess.doCompilation(CompilationProcess.java:88)
        at de.peeeq.wurstio.Main.main(Main.java:146)
net.moonlightflower.wc3libs.port.NotFoundException: java.lang.Exception: system not supported: Linux
        at net.moonlightflower.wc3libs.port.StdGameExeFinder.find(StdGameExeFinder.java:41)
        at net.moonlightflower.wc3libs.port.StdGameExeFinder.find(StdGameExeFinder.java:9)
        at net.moonlightflower.wc3libs.port.Finder.get(Finder.java:25)
        at de.peeeq.wurstio.utils.W3InstallationData.discoverExePath(W3InstallationData.java:71)
        at de.peeeq.wurstio.utils.W3InstallationData.<init>(W3InstallationData.java:28)
        at de.peeeq.wurstio.Main.main(Main.java:164)
Caused by: java.lang.Exception: system not supported: Linux
        ... 6 more
net.moonlightflower.wc3libs.port.NotFoundException: java.lang.Exception: system not supported: Linux
        at net.moonlightflower.wc3libs.port.StdGameVersionFinder.find(StdGameVersionFinder.java:43)
        at net.moonlightflower.wc3libs.port.StdGameVersionFinder.find(StdGameVersionFinder.java:12)
        at net.moonlightflower.wc3libs.port.Finder.get(Finder.java:25)
        at de.peeeq.wurstio.utils.W3InstallationData.discoverVersion(W3InstallationData.java:80)
        at de.peeeq.wurstio.utils.W3InstallationData.<init>(W3InstallationData.java:29)
        at de.peeeq.wurstio.Main.main(Main.java:164)
Caused by: java.lang.Exception: system not supported: Linux
        ... 6 more
Build succeeded. Output file: </mnt/c/Users/Cokem/workspace/....w3x>
compilation finished (errors: 0, warnings: 0)
🗺️ Map has been built!
```