### PR TITLE
Eliminate stacktrace when compiling on linux

### DIFF
--- a/de.peeeq.wurstscript/build.gradle
+++ b/de.peeeq.wurstscript/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     implementation group: 'com.github.inwc3', name: 'jmpq3', version: 'b4ef7121a4'
 
     // Water's wc3 libs
-    implementation 'com.github.inwc3:wc3libs:1c667fae6a'
+    implementation 'com.github.inwc3:wc3libs:2d190647ae'
 
     // The setup tool for wurst.build handling
     implementation 'com.github.wurstscript:wurstsetup:4c65824b40'

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ProjectConfigBuilder.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ProjectConfigBuilder.java
@@ -54,7 +54,11 @@ public class ProjectConfigBuilder {
                     if (w3data.getWc3PatchVersion().isPresent()) {
                         w3I.injectConfigsInJassScript(inputStream, sw, w3data.getWc3PatchVersion().get());
                     } else {
-                        w3I.injectConfigsInJassScript(inputStream, sw, GameVersion.VERSION_1_32);
+                        GameVersion version = GameVersion.VERSION_1_32;
+                        System.out.println(
+                            "Failed to determine installed game version. Falling back to " + version.toString()
+                        );
+                        w3I.injectConfigsInJassScript(inputStream, sw, version);
                     }
                 }
                 scriptBytes = sw.toString().getBytes(StandardCharsets.UTF_8);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/utils/W3InstallationData.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/utils/W3InstallationData.java
@@ -7,6 +7,7 @@ import net.moonlightflower.wc3libs.port.NotFoundException;
 import net.moonlightflower.wc3libs.port.Orient;
 import net.moonlightflower.wc3libs.port.StdGameExeFinder;
 import net.moonlightflower.wc3libs.port.StdGameVersionFinder;
+import net.moonlightflower.wc3libs.port.UnsupportedPlatformException;
 import net.moonlightflower.wc3libs.port.win.WinGameExeFinder;
 
 import java.io.File;
@@ -81,6 +82,8 @@ public class W3InstallationData {
             WLogger.info("Parsed game version: " + version);
         } catch (NotFoundException e) {
             WLogger.warning("Wurst compiler failed to determine game version", e);
+        } catch (UnsupportedPlatformException e) {
+            WLogger.warning("Wurst compiler cannot determine game version: " + e.getMessage());
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/utils/W3InstallationData.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/utils/W3InstallationData.java
@@ -73,6 +73,8 @@ public class W3InstallationData {
             WLogger.info("Parsed game path: " + gameExe);
         } catch (NotFoundException e) {
             e.printStackTrace();
+        } catch (UnsupportedPlatformException e) {
+            WLogger.warning("Wurst compiler cannot determine game path: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION

```
$ grill build base_map.w3x
🔥 Grill warming up..
Custom WurstScript installation detected.
🔥 Ready. Version: <1.3.4.1-jenkins-WurstSetup-157>
🔨 Building project..
java.nio.file.NoSuchFileException: /mnt/c/Users/Cokem/workspace/kill-katydma/./wurst/_build/dependencies
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
        at sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:427)
        at java.nio.file.Files.newDirectoryStream(Files.java:457)
        at java.nio.file.Files.list(Files.java:3451)
        at de.peeeq.wurstio.map.importer.ImportFile.getTransientImportDirectories(ImportFile.java:216)
        at de.peeeq.wurstio.map.importer.ImportFile.importFilesFromImports(ImportFile.java:188)
        at de.peeeq.wurstio.WurstCompilerJassImpl.runCompiletime(WurstCompilerJassImpl.java:125)
        at de.peeeq.wurstio.CompilationProcess.lambda$doCompilation$3(CompilationProcess.java:88)
        at de.peeeq.wurstio.TimeTaker.lambda$measure$0(TimeTaker.java:15)
        at de.peeeq.wurstio.TimeTaker$Default.measure(TimeTaker.java:33)
        at de.peeeq.wurstio.TimeTaker.measure(TimeTaker.java:14)
        at de.peeeq.wurstio.CompilationProcess.doCompilation(CompilationProcess.java:88)
        at de.peeeq.wurstio.Main.main(Main.java:146)
Failed to determine installed game version. Falling back to [1, 32]
Build succeeded. Output file: </mnt/c/Users/Cokem/workspace/kill-katydma/./_build/(1)KillKatydma0.2.1-prerelease.w3x>
compilation finished (errors: 0, warnings: 0)
🗺 Map has been built!
```

Note that there is still one stacktrace on linux, but the NotFoundException is now fixed