### PR TITLE
Fix lua map config and number issues

### DIFF
--- a/de.peeeq.wurstscript/parserspec/lua.parseq
+++ b/de.peeeq.wurstscript/parserspec/lua.parseq
@@ -81,6 +81,7 @@ LuaOpBinary =
     | LuaOpMult()
     | LuaOpDiv()
     | LuaOpMod()
+    | LuaOpFloorDiv()
 
 LuaOpUnary = 
       LuaOpNot()

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/MapRequest.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/MapRequest.java
@@ -28,6 +28,7 @@ import de.peeeq.wurstscript.luaAst.LuaCompilationUnit;
 import de.peeeq.wurstscript.parser.WPos;
 import de.peeeq.wurstscript.utils.LineOffsets;
 import de.peeeq.wurstscript.utils.Utils;
+import net.moonlightflower.wc3libs.bin.Wc3BinOutputStream;
 import net.moonlightflower.wc3libs.bin.app.W3I;
 import net.moonlightflower.wc3libs.port.Orient;
 import org.apache.commons.lang.StringUtils;
@@ -36,6 +37,7 @@ import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -54,8 +56,7 @@ import java.util.stream.Collectors;
 
 public abstract class MapRequest extends UserRequest<Object> {
     protected final WurstLanguageServer langServer;
-    protected final @Nullable
-    Optional<File> map;
+    protected final Optional<File> map;
     protected final List<String> compileArgs;
     protected final WFile workspaceRoot;
     protected final RunArgs runArgs;
@@ -138,7 +139,7 @@ public abstract class MapRequest extends UserRequest<Object> {
             timeTaker.measure("Runinng Compiletime Functions", () -> compiler.runCompiletime(projectConfigData, isProd, runArgs.isCompiletimeCache()));
 
             if (runArgs.isLua()) {
-                print("translating program to Lua ... ");
+                print("Translating program to Lua ... ");
                 Optional<LuaCompilationUnit> luaCode = Optional.ofNullable(compiler.transformProgToLua());
 
                 if (!luaCode.isPresent()) {
@@ -156,7 +157,7 @@ public abstract class MapRequest extends UserRequest<Object> {
                 return outFile;
 
             } else {
-                print("translating program to jass ... ");
+                print("Translating program to jass ... ");
                 compiler.transformProgToJass();
 
                 Optional<JassProg> jassProg = Optional.ofNullable(compiler.getProg());
@@ -439,7 +440,7 @@ public abstract class MapRequest extends UserRequest<Object> {
         return scriptFile;
     }
 
-    private CompilationResult applyProjectConfig(WurstGui gui, Optional<File> testMap, File buildDir, WurstProjectConfigData projectConfig, File scriptFile) throws FileNotFoundException {
+    private CompilationResult applyProjectConfig(WurstGui gui, Optional<File> testMap, File buildDir, WurstProjectConfigData projectConfig, File scriptFile) {
         AtomicReference<CompilationResult> result = new AtomicReference<>();
         gui.sendProgress("Applying Map Config...");
         timeTaker.measure("Applying Map Config", () -> {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/printing/LuaPrinter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/printing/LuaPrinter.java
@@ -226,6 +226,10 @@ public class LuaPrinter {
         sb.append("/");
     }
 
+    public static void print(LuaOpFloorDiv luaOpFloorDiv, StringBuilder sb, int indent) {
+        sb.append("//");
+    }
+
     public static void print(LuaOpEquals luaOpEquals, StringBuilder sb, int indent) {
         sb.append("==");
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
@@ -3,10 +3,14 @@ package de.peeeq.wurstscript.translation.lua.translation;
 import de.peeeq.wurstscript.WurstOperator;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.luaAst.*;
+import de.peeeq.wurstscript.translation.imtranslation.CallType;
 import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
 import de.peeeq.wurstscript.types.TypesHelper;
 
 import java.util.Optional;
+
+import static de.peeeq.wurstscript.jassIm.JassIm.ImFunctionCall;
+import static de.peeeq.wurstscript.jassIm.JassIm.ImTypeArguments;
 
 public class ExprTranslation {
 
@@ -75,6 +79,8 @@ public class ExprTranslation {
         LuaFunction f = tr.luaFunc.getFor(e.getFunc());
         if (f.getName().equals(ImTranslator.$DEBUG_PRINT)) {
             f.setName("BJDebugMsg");
+        } else if (f.getName().equals("I2S")) {
+            f.setName("tostring");
         }
         return LuaAst.LuaExprFunctionCall(f, tr.translateExprList(e.getArguments()));
     }
@@ -128,9 +134,8 @@ public class ExprTranslation {
                 return LuaAst.LuaExprFunctionCallE(LuaAst.LuaLiteral("math.floor"),
                     LuaAst.LuaExprlist(LuaAst.LuaExprBinary(leftExpr, op, rightExpr)));
             } else if (e.getOp() == WurstOperator.DIV_INT) {
-                op = LuaAst.LuaOpDiv();
-                return LuaAst.LuaExprFunctionCallE(LuaAst.LuaLiteral("math.floor"),
-                    LuaAst.LuaExprlist(LuaAst.LuaExprBinary(leftExpr, op, rightExpr)));
+                op = LuaAst.LuaOpFloorDiv();
+                return LuaAst.LuaExprBinary(leftExpr, op, rightExpr);
             } else {
                 // TODO special cases for integer division and modulo
                 op = e.getOp().luaTranslateBinary();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -391,19 +391,20 @@ public class LuaTranslator {
         LuaFunction[] ensureTypeFunctions = {ensureIntFunction, ensureBoolFunction, ensureRealFunction, ensureStrFunction};
         String[] defaultValue = {"0", "false", "0.0", "\"\""};
         for(int i = 0; i < ensureTypeFunctions.length; ++i) {
+            LuaFunction ensureTypeFunction = ensureTypeFunctions[i];
             String[] code = {
                 "if x == nil then",
                 "    return " + defaultValue[i],
                 "else",
-                "    return x",
+                "    return " + (ensureTypeFunction == ensureIntFunction ? "math.tointeger(x)" : "x"),
                 "end"
             };
 
-            ensureTypeFunctions[i].getParams().add(LuaAst.LuaVariable("x", LuaAst.LuaNoExpr()));
+            ensureTypeFunction.getParams().add(LuaAst.LuaVariable("x", LuaAst.LuaNoExpr()));
             for (String c : code) {
-                ensureTypeFunctions[i].getBody().add(LuaAst.LuaLiteral(c));
+                ensureTypeFunction.getBody().add(LuaAst.LuaLiteral(c));
             }
-            luaModel.add(ensureTypeFunctions[i]);
+            luaModel.add(ensureTypeFunction);
         }
     }
 


### PR DESCRIPTION
- Lua config is now applied to w3i even if no buildMapData is present
- Player config gets correctly injected into the script in lua mode
- Use `//` floor division operator for translating integer division
- Use `math.tointeger` to ensure correct representation of integers, aligning them with Jass 