### PR TITLE
Deliver the interpreter output of tests to RunTests

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/intermediateLang/interpreter/ProgramStateIO.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/intermediateLang/interpreter/ProgramStateIO.java
@@ -40,7 +40,6 @@ public class ProgramStateIO extends ProgramState {
     private final Map<String, Set<String>> createdObjectDefinitionIds = Maps.newLinkedHashMap();
     private int id = 0;
     private final Map<String, ObjMod.Obj> objDefinitions = Maps.newLinkedHashMap();
-    private PrintStream outStream = System.err;
     private @Nullable WTS trigStrings = null;
     private final Optional<File> mapFile;
 
@@ -946,13 +945,4 @@ public class ProgramStateIO extends ProgramState {
         return folder;
     }
 
-    @Override
-    public PrintStream getOutStream() {
-        return outStream;
-    }
-
-    @Override
-    public void setOutStream(PrintStream os) {
-        outStream = os;
-    }
 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/ReflectionNativeProvider.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/ReflectionNativeProvider.java
@@ -10,10 +10,14 @@ import de.peeeq.wurstscript.intermediatelang.interpreter.NoSuchNativeException;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 public class ReflectionNativeProvider implements NativesProvider {
     private final HashMap<String, NativeJassFunction> methodMap = new HashMap<>();
+    /** Providers that print to the interpreter output, so that redirecting it reaches them. */
+    private final List<OutputProvider> outputProviders = new ArrayList<>();
 
     public ReflectionNativeProvider(AbstractInterpreter interpreter) {
         addProvider(new AbilityProvider(interpreter));
@@ -51,6 +55,9 @@ public class ReflectionNativeProvider implements NativesProvider {
     }
 
     private void addProvider(Provider provider) {
+        if (provider instanceof OutputProvider) {
+            outputProviders.add((OutputProvider) provider);
+        }
         for (Method method : provider.getClass().getMethods()) {
             Implements annotation = method.getAnnotation(Implements.class);
             if (annotation != null) {
@@ -103,6 +110,8 @@ public class ReflectionNativeProvider implements NativesProvider {
 
     @Override
     public void setOutStream(PrintStream outStream) {
-
+        for (OutputProvider provider : outputProviders) {
+            provider.setOutStream(outStream);
+        }
     }
 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/providers/OutputProvider.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/jassinterpreter/providers/OutputProvider.java
@@ -18,6 +18,10 @@ public class OutputProvider extends Provider {
         super(interpreter);
     }
 
+    public void setOutStream(PrintStream outStream) {
+        this.outStream = outStream;
+    }
+
     public void DisplayTextToForce(IlConstHandle force, ILconstString msg) {
         outStream.println(msg.getVal());
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunTests.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunTests.java
@@ -370,7 +370,7 @@ public class RunTests extends UserRequest<Object> {
             @Override
             public void write(byte[] b, int off, int len) throws IOException {
                 if (!compactOutput) {
-                    println(new String(b, off, len, StandardCharsets.UTF_8));
+                    print(new String(b, off, len, StandardCharsets.UTF_8));
                 }
             }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunTests.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/RunTests.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.lsp4j.MessageType;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.*;
@@ -369,13 +370,15 @@ public class RunTests extends UserRequest<Object> {
             @Override
             public void write(byte[] b, int off, int len) throws IOException {
                 if (!compactOutput) {
-                    println(new String(b, off, len));
+                    println(new String(b, off, len, StandardCharsets.UTF_8));
                 }
             }
 
 
         };
-        globalState.setOutStream(new PrintStream(os));
+        // autoflush, so that the output of a test is delivered while that test is running
+        // instead of being left in the buffer of the PrintStream
+        globalState.setOutStream(new PrintStream(os, true, StandardCharsets.UTF_8));
     }
 
     private String qualifiedTestName(ImFunction f) {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/RunTestsOutputRedirectTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/RunTestsOutputRedirectTests.java
@@ -1,0 +1,79 @@
+package tests.wurstscript.tests;
+
+import de.peeeq.wurstio.WurstCompilerJassImpl;
+import de.peeeq.wurstio.languageserver.requests.RunTests;
+import de.peeeq.wurstscript.RunArgs;
+import de.peeeq.wurstscript.ast.WurstModel;
+import de.peeeq.wurstscript.gui.WurstGui;
+import de.peeeq.wurstscript.gui.WurstGuiCliImpl;
+import de.peeeq.wurstscript.jassIm.ImProg;
+import de.peeeq.wurstscript.utils.Utils;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests that RunTests.redirectInterpreterOutput actually captures what the tests print,
+ * instead of it going to System.err unnoticed.
+ */
+public class RunTestsOutputRedirectTests extends WurstScriptTest {
+
+    private static final String[] PROGRAM = {
+        "package test",
+        "native testFail(string msg)",
+        "native println(string msg)",
+        "@test function passingTest()",
+        "	println(\"output of the passing test\")",
+        "@test function failingTest()",
+        "	println(\"output of the failing test\")",
+        "	testFail(\"assertion message\")",
+    };
+
+    @Test
+    public void interpreterOutputIsRedirected() {
+        String output = runTests(false);
+        assertTrue(output.contains("output of the passing test"), output);
+        assertTrue(output.contains("output of the failing test"), output);
+    }
+
+    @Test
+    public void interpreterOutputIsSuppressedWithCompactOutput() {
+        String output = runTests(true);
+        assertFalse(output.contains("output of the passing test"), output);
+        assertFalse(output.contains("output of the failing test"), output);
+    }
+
+    @Test
+    public void testResultsAreStillReported() {
+        String output = runTests(false);
+        assertTrue(output.contains("Tests succeeded: 1/2"), output);
+        assertTrue(output.contains("assertion message"), output);
+    }
+
+    private String runTests(boolean compactOutput) {
+        RunArgs runArgs = new RunArgs();
+        WurstGui gui = new WurstGuiCliImpl();
+        WurstCompilerJassImpl compiler = new WurstCompilerJassImpl(null, gui, null, runArgs);
+        WurstModel model = parseFiles(null,
+            Collections.singletonList(new CU("test", Utils.join(PROGRAM, "\n") + "\n")), false, compiler);
+        compiler.checkProg(model);
+        if (!gui.getErrorList().isEmpty()) {
+            throw gui.getErrorList().get(0);
+        }
+        ImProg imProg = compiler.translateProgToIm(model);
+
+        StringBuilder output = new StringBuilder();
+        RunTests runTests = new RunTests(Optional.empty(), 0, 0, Optional.empty(), 20, Optional.empty(), compactOutput) {
+            @Override
+            protected void print(String message) {
+                output.append(message);
+            }
+        };
+        runTests.runTests(compiler.getImTranslator(), imProg, Optional.empty(), Optional.empty());
+        return output.toString();
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/RunTestsOutputRedirectTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/RunTestsOutputRedirectTests.java
@@ -36,8 +36,9 @@ public class RunTestsOutputRedirectTests extends WurstScriptTest {
     @Test
     public void interpreterOutputIsRedirected() {
         String output = runTests(false);
-        assertTrue(output.contains("output of the passing test"), output);
-        assertTrue(output.contains("output of the failing test"), output);
+        String lineSeparator = System.lineSeparator();
+        assertTrue(output.contains("output of the passing test" + lineSeparator + "\tOK!"), output);
+        assertTrue(output.contains("output of the failing test" + lineSeparator + "\tFAILED assertion:"), output);
     }
 
     @Test


### PR DESCRIPTION
`RunTests.redirectInterpreterOutput` installs a stream so that whatever the tests print
goes to `RunTests`' own output. That stream never received anything: the output went
straight to `System.err`, bypassing `RunTests` entirely. A side effect is that
`-compactOutput` cannot suppress it either, so it still shows up in CI logs.

Three independent reasons, each fixed here:

- **`ProgramStateIO` shadows the stream.** It declares its own `private PrintStream
  outStream` and overrides `getOutStream`/`setOutStream` on top of `ProgramState`, which
  already has both. The base implementation forwards the new stream to every registered
  `NativesProvider`; the override did not, so the providers kept their old stream. The
  field and the two overrides are removed and the base class does the work.

- **`ReflectionNativeProvider.setOutStream` is empty.** It is the provider that owns
  `OutputProvider`, which implements `println`, `BJDebugMsg`, `DisplayTextToPlayer` and the
  other printing natives. Because the setter did nothing, `OutputProvider` kept its
  default `System.err`. It now forwards to the `OutputProvider` instances it holds, and
  `OutputProvider` gets the corresponding setter.

- **The `PrintStream` has no autoflush.** Even with the two fixes above, output sat in the
  8 KB buffer of `new PrintStream(os)` and was never flushed, so a normal test run
  delivered nothing. It now autoflushes, with an explicit UTF-8 charset on the encoding
  side and the matching `new String(bytes, UTF_8)` on the decoding side, which also fixes
  non-ASCII output being decoded with the platform default charset.

## Effect

Output printed by tests during `-runtests` now reaches the stream `RunTests` prints to
(stdout on the CLI) instead of `System.err`, which is what the redirection was written to
do, and `-compactOutput` suppresses it as intended.

## Tests

`RunTestsOutputRedirectTests` compiles a package with one passing and one failing test that
both print, and asserts the printed output arrives in `RunTests`' sink, that
`-compactOutput` suppresses it, and that the summary and assertion message are unaffected.
`interpreterOutputIsRedirected` fails on unmodified master and passes with this change;
the full `./gradlew test` suite passes.
