### PR TITLE
Fix SCC dataflow worklist ordering

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/controlflow/SccForwardExecution.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/controlflow/SccForwardExecution.java
@@ -3,6 +3,7 @@ package de.peeeq.wurstscript.validation.controlflow;
 import de.peeeq.datastructures.GraphInterpreter;
 import de.peeeq.wurstscript.ast.AstElementWithBody;
 import de.peeeq.wurstscript.ast.WStatement;
+import de.peeeq.wurstscript.utils.Utils;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 
@@ -62,7 +63,13 @@ public class SccForwardExecution<T, Target extends AstElementWithBody> {
 
         // 4. Analyze each SCC in topological order
         for (List<WStatement> scc : sccs) {
-            analyzeComponent(scc);
+            // Nodes are popped from the SCC stack in reverse discovery order.
+            // Restore forward CFG order so facts propagate through the component
+            // without requiring a separate pass for nearly every statement.
+            Collections.reverse(scc);
+            if (!analyzeComponent(scc)) {
+                return;
+            }
         }
 
 
@@ -72,19 +79,25 @@ public class SccForwardExecution<T, Target extends AstElementWithBody> {
         method.checkFinal(finalState);
     }
 
-    private void analyzeComponent(List<WStatement> scc) {
+    private boolean analyzeComponent(List<WStatement> scc) {
         Queue<WStatement> worklist = new ArrayDeque<>(scc);
+        Set<WStatement> queued = new ObjectOpenHashSet<>(scc);
+        Set<WStatement> componentMembers = new ObjectOpenHashSet<>(scc);
 
         int iterations = 0;
         int maxIterations = scc.size() * scc.size() + 100; // Heuristic limit to prevent infinite loops
 
         while (!worklist.isEmpty()) {
             if (iterations++ > maxIterations) {
-                // This should ideally not happen in a correct CFG with a monotonic transfer function
-                throw new RuntimeException("Dataflow analysis did not converge. Possible infinite loop in component.");
+                f.addError("Internal compiler error: " + method.getClass().getSimpleName()
+                    + " did not converge while analyzing " + Utils.printElement(f)
+                    + " (component size " + scc.size() + ", " + iterations
+                    + " worklist iterations). Further dataflow checks for this body were skipped.");
+                return false;
             }
 
             WStatement s = worklist.poll();
+            queued.remove(s);
 
             // Merge states from all predecessors
             Collection<T> predecessorStates = get(s.attrPreviousStatements());
@@ -98,12 +111,13 @@ public class SccForwardExecution<T, Target extends AstElementWithBody> {
 
                 // If the value changed, add successors within the same SCC to the worklist
                 for (WStatement succ : s.attrNextStatements()) {
-                    if (scc.contains(succ)) {
+                    if (componentMembers.contains(succ) && queued.add(succ)) {
                         worklist.add(succ);
                     }
                 }
             }
         }
+        return true;
     }
 
     private List<WStatement> getAllStatements() {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FlowAnalysisTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FlowAnalysisTests.java
@@ -132,4 +132,45 @@ public class FlowAnalysisTests extends WurstScriptTest {
         );
     }
 
+    @Test
+    public void dataflowConvergesForManyMutatedLoopLocals() {
+        testAssertOkLines(false,
+                "package test",
+                "function probe()",
+                "    int a01 = 0",
+                "    int a02 = 0",
+                "    int a03 = 0",
+                "    int a04 = 0",
+                "    int a05 = 0",
+                "    int a06 = 0",
+                "    int a07 = 0",
+                "    int a08 = 0",
+                "    int a09 = 0",
+                "    int a10 = 0",
+                "    int a11 = 0",
+                "    int a12 = 0",
+                "    int a13 = 0",
+                "    int a14 = 0",
+                "    int a15 = 0",
+                "    int a16 = 0",
+                "    while true",
+                "        a01++",
+                "        a02++",
+                "        a03++",
+                "        a04++",
+                "        a05++",
+                "        a06++",
+                "        a07++",
+                "        a08++",
+                "        a09++",
+                "        a10++",
+                "        a11++",
+                "        a12++",
+                "        a13++",
+                "        a14++",
+                "        a15++",
+                "        a16++"
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary

- process statements within each strongly connected component in forward discovery order so dataflow facts propagate with the CFG
- deduplicate queued statements and use constant-time SCC membership checks
- report a source-located internal compiler error and skip only the affected analysis body if the convergence watchdog is ever reached
- add a regression with sixteen mutated locals inside a loop

## Root cause

The Gabow SCC implementation emits components in reverse topological order and emits the nodes inside each component in reverse discovery order. The executor corrected the component order but retained the reversed node order. For the reported 17-node loop SCC, valid dataflow analysis required 561 worklist iterations while the watchdog allowed only 389, producing a false non-convergence failure. Forward node order reduced the same analysis to 51 iterations.

## Impact

Large loop bodies no longer incur near-quadratic backward propagation or fail the convergence heuristic. Any future watchdog failure is attached to the analyzed source body and does not abort validation of unrelated functions.

## Validation

- `./gradlew test --tests "tests.wurstscript.tests.FlowAnalysisTests.dataflowConvergesForManyMutatedLoopLocals"`
- `./gradlew test --tests "tests.wurstscript.tests.FlowAnalysisTests"`
- `./gradlew test` — 1,455 tests, 0 failures, 0 errors