### PR TITLE
Enforce Jass vararg parameter limit

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
@@ -407,6 +407,12 @@ public class WurstCompilerJassImpl implements WurstCompiler {
         printDebugImProg("./test-output/im " + stage++ + "_classesEliminated.im");
         timeTaker.endPhase();
 
+        if (!runArgs.isNoDebugMessages() && runArgs.isIncludeStacktraces()) {
+            beginPhase(4, "add stack traces");
+            new StackTraceInjector2(imProg2, imTranslator2).transform(timeTaker);
+            timeTaker.endPhase();
+        }
+
         new VarargEliminator(imProg2).run();
         printDebugImProg("./test-output/im " + stage++ + "_varargEliminated.im");
         imTranslator2.assertProperties();
@@ -417,14 +423,8 @@ public class WurstCompilerJassImpl implements WurstCompiler {
             beginPhase(3, "remove debug messages");
             DebugMessageRemover.removeDebugMessages(imProg2);
             timeTaker.endPhase();
-        } else {
-            // debug: add stacktraces
-            if (runArgs.isIncludeStacktraces()) {
-                beginPhase(4, "add stack traces");
-                new StackTraceInjector2(imProg2, imTranslator2).transform(timeTaker);
-                timeTaker.endPhase();
-            }
         }
+
         imTranslator2.assertProperties();
 
         ImOptimizer optimizer = new ImOptimizer(timeTaker, imTranslator2);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/VarargEliminator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/VarargEliminator.java
@@ -2,6 +2,7 @@ package de.peeeq.wurstscript.translation.imtranslation;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
+import de.peeeq.wurstscript.attributes.CompileError;
 import de.peeeq.wurstscript.jassIm.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,6 +19,7 @@ import static de.peeeq.wurstscript.translation.imtranslation.FunctionFlagEnum.IS
  */
 public class VarargEliminator {
 
+    private static final int JASS_MAX_PARAMETERS = 31;
     private final ImProg prog;
     // original + number of args --> new function
     private final Table<ImFunction, Integer, ImFunction> varargFuncs = HashBasedTable.create();
@@ -30,7 +32,7 @@ public class VarargEliminator {
         // create new vararg functions
         for (ImFunctionCall c : collectVarargCalls()) {
             if (c.getFunc().hasFlag(IS_VARARG)) {
-                generateVarargFunc(c.getFunc(), c.getArguments().size());
+                generateVarargFunc(c);
             }
         }
 
@@ -66,7 +68,14 @@ public class VarargEliminator {
      * Generates a function based on the vararg function with the appropriate amount of parameters
      * for the function call.
      */
-    private void generateVarargFunc(ImFunction func, int numberOfParams) {
+    private void generateVarargFunc(ImFunctionCall sourceCall) {
+        ImFunction func = sourceCall.getFunc();
+        int numberOfParams = sourceCall.getArguments().size();
+        if (numberOfParams > JASS_MAX_PARAMETERS) {
+            throw new CompileError(sourceCall, "Vararg call would generate " + numberOfParams
+                + " Jass parameters; the maximum is " + JASS_MAX_PARAMETERS
+                + ". Use multiple calls (for example with the cascade operator) or pass a collection instead.");
+        }
         if (varargFuncs.contains(func, numberOfParams)) {
             // already generated
             return;
@@ -118,7 +127,7 @@ public class VarargEliminator {
             params.addAll(list);
 
             // generate function for this new call
-            generateVarargFunc(call.getFunc(), call.getArguments().size());
+            generateVarargFunc(call);
         }
 
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/VarargEliminator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/VarargEliminator.java
@@ -71,8 +71,11 @@ public class VarargEliminator {
     private void generateVarargFunc(ImFunctionCall sourceCall) {
         ImFunction func = sourceCall.getFunc();
         int numberOfParams = sourceCall.getArguments().size();
-        if (numberOfParams > JASS_MAX_PARAMETERS) {
-            throw new CompileError(sourceCall, "Vararg call would generate " + numberOfParams
+        int jassParameterCount = sourceCall.getArguments().stream()
+            .mapToInt(argument -> flattenedJassArity(argument.attrTyp()))
+            .sum();
+        if (jassParameterCount > JASS_MAX_PARAMETERS) {
+            throw new CompileError(sourceCall, "Vararg call would generate " + jassParameterCount
                 + " Jass parameters; the maximum is " + JASS_MAX_PARAMETERS
                 + ". Use multiple calls (for example with the cascade operator) or pass a collection instead.");
         }
@@ -142,6 +145,15 @@ public class VarargEliminator {
         // Add new function to prog
         prog.getFunctions().add(newFunc);
         varargFuncs.put(func, numberOfParams, newFunc);
+    }
+
+    private int flattenedJassArity(ImType type) {
+        if (type instanceof ImTupleType) {
+            return ((ImTupleType) type).getTypes().stream()
+                .mapToInt(this::flattenedJassArity)
+                .sum();
+        }
+        return 1;
     }
 
     @NotNull

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -41,6 +41,8 @@ import static de.peeeq.wurstscript.attributes.SmallHelpers.superArgs;
  * attributes
  */
 public class WurstValidator {
+    private static final int JASS_MAX_PARAMETERS = 31;
+
     private enum Phase { LIGHT, HEAVY }
     private Phase phase = Phase.LIGHT;
     private boolean isHeavy() { return phase == Phase.HEAVY; }
@@ -1852,7 +1854,24 @@ public class WurstValidator {
             throw new Error("unhandled case: " + Utils.printElement(call));
         }
 
-        call.attrCallSignature().checkSignatureCompatibility(call.attrFunctionSignature(), funcName, call);
+        FunctionSignature signature = call.attrFunctionSignature();
+        call.attrCallSignature().checkSignatureCompatibility(signature, funcName, call);
+        checkVarargJassParameterLimit(call, signature);
+    }
+
+    private void checkVarargJassParameterLimit(StmtCall call, FunctionSignature signature) {
+        if (!signature.isVararg()) {
+            return;
+        }
+        int generatedParameterCount = call.getArgs().size();
+        if (signature.getReceiverType() != null || call instanceof ExprNewObject) {
+            generatedParameterCount++;
+        }
+        if (generatedParameterCount > JASS_MAX_PARAMETERS) {
+            call.addError("Vararg call would generate " + generatedParameterCount
+                + " Jass parameters; the maximum is " + JASS_MAX_PARAMETERS
+                + ". Use multiple calls (for example with the cascade operator) or pass a collection instead.");
+        }
     }
 
     /** Error when a field in this class hides a field from a superclass. */

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -41,8 +41,6 @@ import static de.peeeq.wurstscript.attributes.SmallHelpers.superArgs;
  * attributes
  */
 public class WurstValidator {
-    private static final int JASS_MAX_PARAMETERS = 31;
-
     private enum Phase { LIGHT, HEAVY }
     private Phase phase = Phase.LIGHT;
     private boolean isHeavy() { return phase == Phase.HEAVY; }
@@ -1854,24 +1852,7 @@ public class WurstValidator {
             throw new Error("unhandled case: " + Utils.printElement(call));
         }
 
-        FunctionSignature signature = call.attrFunctionSignature();
-        call.attrCallSignature().checkSignatureCompatibility(signature, funcName, call);
-        checkVarargJassParameterLimit(call, signature);
-    }
-
-    private void checkVarargJassParameterLimit(StmtCall call, FunctionSignature signature) {
-        if (!signature.isVararg()) {
-            return;
-        }
-        int generatedParameterCount = call.getArgs().size();
-        if (signature.getReceiverType() != null || call instanceof ExprNewObject) {
-            generatedParameterCount++;
-        }
-        if (generatedParameterCount > JASS_MAX_PARAMETERS) {
-            call.addError("Vararg call would generate " + generatedParameterCount
-                + " Jass parameters; the maximum is " + JASS_MAX_PARAMETERS
-                + ". Use multiple calls (for example with the cascade operator) or pass a collection instead.");
-        }
+        call.attrCallSignature().checkSignatureCompatibility(call.attrFunctionSignature(), funcName, call);
     }
 
     /** Error when a field in this class hides a field from a superclass. */

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/VarargTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/VarargTests.java
@@ -67,6 +67,32 @@ public class VarargTests extends WurstScriptTest {
     }
 
     @Test
+    public void stacktracedVarargRejectsMoreThan31JassParameters() {
+        testAssertErrorsLines(false, "would generate 32 Jass parameters; the maximum is 31",
+                "package Test",
+                "function getStackTraceString() returns string",
+                "    return \"\"",
+                "function foo(vararg int ints)",
+                "    getStackTraceString()",
+                "init",
+                "    foo(" + arguments(31) + ")"
+        );
+    }
+
+    @Test
+    public void stacktracedVarargAllows31JassParameters() {
+        testAssertOkLines(false,
+                "package Test",
+                "function getStackTraceString() returns string",
+                "    return \"\"",
+                "function foo(vararg int ints)",
+                "    getStackTraceString()",
+                "init",
+                "    foo(" + arguments(30) + ")"
+        );
+    }
+
+    @Test
     public void varargRejectsMoreThan31JassParameters() {
         testAssertErrorsLines(false, "would generate 32 Jass parameters; the maximum is 31",
                 "package Test",
@@ -104,13 +130,13 @@ public class VarargTests extends WurstScriptTest {
     }
 
     @Test
-    public void varargReceiverAllows31JassParameters() {
+    public void varargReceiverAllows31JassParametersWithStacktraces() {
         testAssertOkLines(false,
                 "package Test",
                 "class C",
                 "    function foo(vararg int ints)",
                 "init",
-                "    new C.foo(" + arguments(30) + ")"
+                "    new C.foo(" + arguments(29) + ")"
         );
     }
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/VarargTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/VarargTests.java
@@ -152,6 +152,17 @@ public class VarargTests extends WurstScriptTest {
     }
 
     @Test
+    public void varargDelegatingConstructorCountsConstructedObject() {
+        testAssertErrorsLines(false, "would generate 32 Jass parameters; the maximum is 31",
+                "package Test",
+                "class C",
+                "    construct()",
+                "        this(" + arguments(31) + ")",
+                "    construct(vararg int ints)"
+        );
+    }
+
+    @Test
     public void testVarargForeach() {
         testAssertOkLines(true,
                 "package Test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/VarargTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/VarargTests.java
@@ -15,6 +15,17 @@ public class VarargTests extends WurstScriptTest {
         return result.toString();
     }
 
+    private String tupleArguments(int count) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < count; i++) {
+            if (i > 0) {
+                result.append(",");
+            }
+            result.append("pair(1,2)");
+        }
+        return result.toString();
+    }
+
 
     @Test
     public void testVarargSyntax() {
@@ -99,6 +110,28 @@ public class VarargTests extends WurstScriptTest {
                 "function foo(vararg int ints)",
                 "init",
                 "    foo(" + arguments(32) + ")"
+        );
+    }
+
+    @Test
+    public void varargCountsFlattenedTupleParameters() {
+        testAssertErrorsLines(false, "would generate 32 Jass parameters; the maximum is 31",
+                "package Test",
+                "tuple pair(int x, int y)",
+                "function foo(vararg pair pairs)",
+                "init",
+                "    foo(" + tupleArguments(16) + ")"
+        );
+    }
+
+    @Test
+    public void varargAllowsFlattenedTupleParametersWithinLimit() {
+        testAssertOkLines(false,
+                "package Test",
+                "tuple pair(int x, int y)",
+                "function foo(vararg pair pairs)",
+                "init",
+                "    foo(" + tupleArguments(15) + ")"
         );
     }
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/VarargTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/VarargTests.java
@@ -4,6 +4,17 @@ import org.testng.annotations.Test;
 
 public class VarargTests extends WurstScriptTest {
 
+    private String arguments(int count) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 1; i <= count; i++) {
+            if (i > 1) {
+                result.append(",");
+            }
+            result.append(i);
+        }
+        return result.toString();
+    }
+
 
     @Test
     public void testVarargSyntax() {
@@ -42,6 +53,59 @@ public class VarargTests extends WurstScriptTest {
                 "function foo(vararg int ints)",
                 "init",
                 "    foo(1,2,3)"
+        );
+    }
+
+    @Test
+    public void varargAllows31JassParameters() {
+        testAssertOkLines(false,
+                "package Test",
+                "function foo(vararg int ints)",
+                "init",
+                "    foo(" + arguments(31) + ")"
+        );
+    }
+
+    @Test
+    public void varargRejectsMoreThan31JassParameters() {
+        testAssertErrorsLines(false, "would generate 32 Jass parameters; the maximum is 31",
+                "package Test",
+                "function foo(vararg int ints)",
+                "init",
+                "    foo(" + arguments(32) + ")"
+        );
+    }
+
+    @Test
+    public void varargReceiverCountsAsJassParameter() {
+        testAssertErrorsLines(false, "would generate 32 Jass parameters; the maximum is 31",
+                "package Test",
+                "class C",
+                "    function foo(vararg int ints)",
+                "init",
+                "    new C.foo(" + arguments(31) + ")"
+        );
+    }
+
+    @Test
+    public void varargReceiverAllows31JassParameters() {
+        testAssertOkLines(false,
+                "package Test",
+                "class C",
+                "    function foo(vararg int ints)",
+                "init",
+                "    new C.foo(" + arguments(30) + ")"
+        );
+    }
+
+    @Test
+    public void varargConstructedObjectCountsAsJassParameter() {
+        testAssertErrorsLines(false, "would generate 32 Jass parameters; the maximum is 31",
+                "package Test",
+                "class C",
+                "    construct(vararg int ints)",
+                "init",
+                "    new C(" + arguments(31) + ")"
         );
     }
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/VarargTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/VarargTests.java
@@ -77,6 +77,22 @@ public class VarargTests extends WurstScriptTest {
     }
 
     @Test
+    public void varargAllowsMoreThan31ArgumentsInLua() {
+        test().testLua(true).executeProg().lines(
+                "package Test",
+                "native testSuccess()",
+                "function foo(vararg int ints)",
+                "    var sum = 0",
+                "    for i in ints",
+                "        sum += i",
+                "    if sum == 528",
+                "        testSuccess()",
+                "init",
+                "    foo(" + arguments(32) + ")"
+        );
+    }
+
+    @Test
     public void varargReceiverCountsAsJassParameter() {
         testAssertErrorsLines(false, "would generate 32 Jass parameters; the maximum is 31",
                 "package Test",


### PR DESCRIPTION
Fixes #729.

Vararg calls now fail at the source location when lowering would exceed Jass's 31-parameter limit. Receivers and constructed objects count toward the generated total, and the diagnostic suggests multiple/cascade calls or passing a collection.

Tests cover free functions, methods, constructors, and both sides of the boundary. The full Gradle suite passes.