### PR TITLE
Reject null for enum values

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/WurstTypeEnum.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/WurstTypeEnum.java
@@ -68,4 +68,9 @@ public class WurstTypeEnum extends WurstTypeNamedScope {
         return true;
     }
 
+    @Override
+    protected boolean isNullable() {
+        return false;
+    }
+
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/EnumTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/EnumTests.java
@@ -67,4 +67,59 @@ public class EnumTests extends WurstScriptTest {
         );
     }
 
+    @Test
+    public void enumCannotBeAssignedNull() {
+        testAssertErrorsLines(false, "Cannot assign null to Blub",
+            "package test",
+            "enum Blub",
+            "    A",
+            "    B",
+            "init",
+            "    Blub value = null"
+        );
+    }
+
+    @Test
+    public void enumCannotBeComparedWithNull() {
+        testAssertErrorsLines(false, "Cannot compare types Blub with null",
+            "package test",
+            "enum Blub",
+            "    A",
+            "    B",
+            "init",
+            "    if Blub.A == null",
+            "        skip"
+        );
+    }
+
+    @Test
+    public void nullCannotBeComparedWithEnum() {
+        testAssertErrorsLines(false, "Cannot compare types null with Blub",
+            "package test",
+            "enum Blub",
+            "    A",
+            "    B",
+            "init",
+            "    if null != Blub.B",
+            "        skip"
+        );
+    }
+
+    @Test
+    public void enumDefaultValueRemainsFirstMember() {
+        test().testLua(true).executeProg().lines(
+            "package test",
+            "native testSuccess()",
+            "enum Blub",
+            "    A",
+            "    B",
+            "class Holder",
+            "    Blub value",
+            "init",
+            "    let holder = new Holder()",
+            "    if holder.value == Blub.A",
+            "        testSuccess()"
+        );
+    }
+
 }


### PR DESCRIPTION
Enums lower to integers, so nullable enums let `null` compare equal to the first member. Mark enums non-nullable and cover assignment, comparison, and default-value behavior.

Tests:
- `./gradlew.bat test --tests tests.wurstscript.tests.EnumTests`
- `./gradlew.bat test --tests tests.wurstscript.tests.SimpleFunctionTests --tests tests.wurstscript.tests.SimpleStatementTests`