### PR TITLE
Migrate compiletime array state

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -543,7 +543,9 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
     }
 
     private void emitCompiletimeState() {
-        for (ImVar var : imProg.getGlobals()) {
+        // constantToExpr may materialize object handles as additional globals.
+        // Iterate over a snapshot to avoid modifying the collection in-flight.
+        for (ImVar var : new ArrayList<>(imProg.getGlobals())) {
             if (!(var.getType() instanceof ImArrayLikeType)) {
                 continue;
             }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -198,14 +198,12 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
     }
 
     private void partitionCompiletimeStateInitFunction() {
-        if (compiletimeStateInitFunction == null) {
-            if (compiletimeArrayStateInitFunction != null) {
-                FunctionSplitter.splitFunc(translator, compiletimeArrayStateInitFunction);
-            }
-        } else {
+        if (compiletimeStateInitFunction != null) {
             FunctionSplitter.splitFunc(translator, compiletimeStateInitFunction);
-            if (compiletimeArrayStateInitFunction != null) {
-                FunctionSplitter.splitFunc(translator, compiletimeArrayStateInitFunction);
+        }
+        for (ImFunction arrayStateFunction : arrayStateInitFunctions.values()) {
+            if (!arrayStateFunction.getBody().isEmpty()) {
+                FunctionSplitter.splitFunc(translator, arrayStateFunction);
             }
         }
     }
@@ -517,6 +515,8 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
 
     private ImFunction compiletimeStateInitFunction = null;
     private ImFunction compiletimeArrayStateInitFunction = null;
+    private final Map<ImFunction, ImFunction> arrayStateInitFunctions = new IdentityHashMap<>();
+    private final Map<ImFunction, Set<ImSet>> arrayStateInitializers = new IdentityHashMap<>();
     private int genericArrayStateInitCounter;
 
     private ImFunction getCompiletimeStateInitFunction() {
@@ -559,51 +559,53 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         getCompiletimeStateInitFunction().getBody().add(stmt);
     }
 
-    private ImFunction getCompiletimeArrayStateInitFunction() {
-        if (compiletimeArrayStateInitFunction == null) {
-            Element trace = imProg.getTrace();
-            ImFunction res = JassIm.ImFunction(trace, "initCompiletimeArrayState", JassIm.ImTypeVars(), JassIm.ImVars(),
-                JassIm.ImVoid(), JassIm.ImVars(), JassIm.ImStmts(), Collections.emptyList());
-            imProg.getFunctions().add(res);
-            compiletimeArrayStateInitFunction = res;
+    private ImFunction getCompiletimeArrayStateInitFunction(@Nullable ImFunction replayTarget) {
+        ImFunction existing = arrayStateInitFunctions.get(replayTarget);
+        if (existing != null) {
+            return existing;
         }
-        return compiletimeArrayStateInitFunction;
+        Element trace = imProg.getTrace();
+        String name = replayTarget == null
+            ? "initCompiletimeArrayState"
+            : "initCompiletimeArrayState_" + genericArrayStateInitCounter++;
+        ImFunction result = JassIm.ImFunction(trace, name, JassIm.ImTypeVars(), JassIm.ImVars(),
+            JassIm.ImVoid(), JassIm.ImVars(), JassIm.ImStmts(), Collections.emptyList());
+        imProg.getFunctions().add(result);
+        arrayStateInitFunctions.put(replayTarget, result);
+        if (replayTarget == null) {
+            compiletimeArrayStateInitFunction = result;
+        }
+        return result;
     }
 
     private void insertCompiletimeArrayStateInitCalls() {
-        if (compiletimeArrayStateInitFunction == null || compiletimeArrayStateInitFunction.getBody().isEmpty()) {
+        if (arrayStateInitFunctions.isEmpty()) {
             return;
         }
-
-        Set<ImSet> modifiedArrayInitializers = Collections.newSetFromMap(new IdentityHashMap<>());
-        for (ImVar var : globalState.getModifiedArrays()) {
-            for (ImSet initializer : imProg.getGlobalInits().getOrDefault(var, Collections.emptyList())) {
-                modifiedArrayInitializers.add(initializer);
-            }
-        }
-
         ImFunction globalInitFunction = translator.getGlobalInitFunc();
-        boolean insertedIntoPackage = false;
-        if (!modifiedArrayInitializers.isEmpty()
-            && insertReplayAfterInitializers(globalInitFunction, modifiedArrayInitializers)) {
-            insertedIntoPackage = true;
-        }
-        for (ImFunction initFunction : translator.initFuncMap.values()) {
-            if (initFunction.getBody().isEmpty()) {
+        List<ImFunction> packageTargets = new ArrayList<>(arrayStateInitFunctions.keySet());
+        packageTargets.remove(null);
+        packageTargets.sort(Comparator.comparing(ImFunction::getName));
+        for (ImFunction target : packageTargets) {
+            ImFunction replay = arrayStateInitFunctions.get(target);
+            if (replay.getBody().isEmpty()) {
                 continue;
             }
-            insertReplayAfterInitializers(initFunction, modifiedArrayInitializers);
-            insertedIntoPackage = true;
+            int insertionIndex = findLastArrayInitializer(target, arrayStateInitializers.get(target));
+            if (insertionIndex >= 0) {
+                target.getBody().add(insertionIndex + 1, newCompiletimeArrayStateInitCall(replay));
+            }
         }
 
-        if (!insertedIntoPackage) {
+        ImFunction mainReplay = arrayStateInitFunctions.get(null);
+        if (mainReplay != null && !mainReplay.getBody().isEmpty()) {
             ImStmts mainBody = translator.getMainFunc().getBody();
             ImFunction stateInit = compiletimeStateInitFunction;
             if (stateInit != null) {
                 for (int i = 0; i < mainBody.size(); i++) {
                     ImStmt stmt = mainBody.get(i);
                     if (stmt instanceof ImFunctionCall && ((ImFunctionCall) stmt).getFunc() == stateInit) {
-                        mainBody.add(i + 1, newCompiletimeArrayStateInitCall());
+                        mainBody.add(i + 1, newCompiletimeArrayStateInitCall(mainReplay));
                         return;
                     }
                 }
@@ -611,17 +613,17 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             for (int i = 0; i < mainBody.size(); i++) {
                 ImStmt stmt = mainBody.get(i);
                 if (stmt instanceof ImFunctionCall && ((ImFunctionCall) stmt).getFunc() == globalInitFunction) {
-                    mainBody.add(i + 1, newCompiletimeArrayStateInitCall());
+                    mainBody.add(i + 1, newCompiletimeArrayStateInitCall(mainReplay));
                     return;
                 }
             }
-            mainBody.add(0, newCompiletimeArrayStateInitCall());
+            mainBody.add(0, newCompiletimeArrayStateInitCall(mainReplay));
         }
     }
 
-    private boolean insertReplayAfterInitializers(ImFunction function, Set<ImSet> modifiedArrayInitializers) {
+    private int findLastArrayInitializer(ImFunction function, Set<ImSet> modifiedArrayInitializers) {
         if (function == null || function.getBody().isEmpty()) {
-            return false;
+            return -1;
         }
         int insertionIndex = -1;
         for (int i = 0; i < function.getBody().size(); i++) {
@@ -630,22 +632,18 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
                 insertionIndex = i + 1;
             }
         }
-        if (insertionIndex < 0) {
-            insertionIndex = 0;
-        }
-        function.getBody().add(insertionIndex, newCompiletimeArrayStateInitCall());
-        return true;
+        return insertionIndex;
     }
 
-    private ImFunctionCall newCompiletimeArrayStateInitCall() {
-        return JassIm.ImFunctionCall(imProg.getTrace(), compiletimeArrayStateInitFunction,
+    private ImFunctionCall newCompiletimeArrayStateInitCall(ImFunction replayFunction) {
+        return JassIm.ImFunctionCall(imProg.getTrace(), replayFunction,
             JassIm.ImTypeArguments(), JassIm.ImExprs(), true, CallType.NORMAL);
     }
 
     private void emitCompiletimeState() {
         // constantToExpr may materialize object handles as additional globals.
         // Iterate over a snapshot to avoid modifying the collection in-flight.
-        Set<ImVar> runtimeArrayWrites = findRuntimeArrayWrites();
+        Set<RuntimeArrayWrite> runtimeArrayWrites = findRuntimeArrayWrites();
         List<ImVar> modifiedArrays = new ArrayList<>(globalState.getModifiedArrays());
         Map<ImVar, Integer> globalOrder = new IdentityHashMap<>();
         for (int i = 0; i < imProg.getGlobals().size(); i++) {
@@ -661,22 +659,56 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             if (!(var.getType() instanceof ImArrayLikeType)) {
                 continue;
             }
+            ImFunction replayTarget = findArrayReplayTarget(var);
+            ImFunction replayFunction = getCompiletimeArrayStateInitFunction(replayTarget);
             for (ProgramState.ArrayState state : globalState.getArrayStates(var)) {
                 if (!state.isGeneric()) {
-                    emitCompiletimeArrayEntries(getCompiletimeArrayStateInitFunction(), var, state.getValue(),
+                    emitCompiletimeArrayEntries(replayFunction, var, state.getValue(),
                         new ArrayList<>(), ((ImArrayLikeType) var.getType()).getEntryType(), runtimeArrayWrites);
                 } else if (state.getTypeArguments().isEmpty()) {
                     throw new InterpreterException(var.getTrace(),
                         "Could not determine the generic specialization for compiletime array " + var.getName());
                 } else {
-                    emitCompiletimeGenericArrayState(var, state, ((ImArrayLikeType) var.getType()).getEntryType(), runtimeArrayWrites);
+                    emitCompiletimeGenericArrayState(replayFunction, var, state,
+                        ((ImArrayLikeType) var.getType()).getEntryType(), runtimeArrayWrites);
                 }
             }
         }
     }
 
-    private void emitCompiletimeGenericArrayState(ImVar var, ProgramState.ArrayState state, ImType entryType,
-                                                  Set<ImVar> runtimeArrayWrites) {
+    private @Nullable ImFunction findArrayReplayTarget(ImVar var) {
+        List<ImSet> initializers = imProg.getGlobalInits().getOrDefault(var, Collections.emptyList());
+        if (initializers.isEmpty()) {
+            return null;
+        }
+        List<ImFunction> candidates = new ArrayList<>();
+        candidates.add(translator.getGlobalInitFunc());
+        candidates.addAll(translator.initFuncMap.values());
+        for (ImFunction candidate : candidates) {
+            Set<ImSet> matching = Collections.newSetFromMap(new IdentityHashMap<>());
+            for (ImSet initializer : initializers) {
+                for (ImStmt statement : candidate.getBody()) {
+                    if (statement == initializer) {
+                        matching.add(initializer);
+                        break;
+                    }
+                }
+            }
+            if (!matching.isEmpty()) {
+                if (candidate != translator.getGlobalInitFunc()) {
+                    arrayStateInitializers.computeIfAbsent(candidate,
+                        ignored -> Collections.newSetFromMap(new IdentityHashMap<>())).addAll(matching);
+                    return candidate;
+                }
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private void emitCompiletimeGenericArrayState(ImFunction replayFunction, ImVar var,
+                                                   ProgramState.ArrayState state, ImType entryType,
+                                                  Set<RuntimeArrayWrite> runtimeArrayWrites) {
         List<ImTypeVar> typeVars = new ArrayList<>();
         for (int i = 0; i < state.getTypeArguments().size(); i++) {
             typeVars.add(JassIm.ImTypeVar("T" + i));
@@ -687,12 +719,14 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             JassIm.ImStmts(), Collections.emptyList());
         imProg.getFunctions().add(replay);
         emitCompiletimeArrayEntries(replay, var, state.getValue(), new ArrayList<>(), entryType, runtimeArrayWrites);
-        getCompiletimeArrayStateInitFunction().getBody().add(JassIm.ImFunctionCall(
-            var.getTrace(), replay, JassIm.ImTypeArguments(state.getTypeArguments()), JassIm.ImExprs(), true, CallType.NORMAL));
+        if (!replay.getBody().isEmpty()) {
+            replayFunction.getBody().add(JassIm.ImFunctionCall(
+                var.getTrace(), replay, JassIm.ImTypeArguments(state.getTypeArguments()), JassIm.ImExprs(), true, CallType.NORMAL));
+        }
     }
 
     private void emitCompiletimeArrayEntries(ImFunction target, ImVar var, ILconstArray values, List<ImExpr> indexes,
-                                             ImType entryType, Set<ImVar> runtimeArrayWrites) {
+                                             ImType entryType, Set<RuntimeArrayWrite> runtimeArrayWrites) {
         for (it.unimi.dsi.fastutil.ints.Int2ObjectMap.Entry<ILconst> entry : values.entries()) {
             List<ImExpr> nextIndexes = new ArrayList<>(indexes);
             nextIndexes.add(JassIm.ImIntVal(entry.getIntKey()));
@@ -706,7 +740,8 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             } else {
                 String message = "Unsupported compiletime array entry at index " + entry.getIntKey()
                     + " (" + entry.getValue() + ")";
-                if (runtimeArrayWrites.contains(var)) {
+                RuntimeArrayWrite runtimeWrite = runtimeArrayWrite(var, nextIndexes);
+                if (runtimeWrite != null && runtimeArrayWrites.stream().anyMatch(runtimeWrite::matches)) {
                     WLogger.warning(message + "; runtime initialization of " + var.getName()
                         + " remains authoritative at " + var.getTrace());
                 } else {
@@ -716,8 +751,8 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         }
     }
 
-    private Set<ImVar> findRuntimeArrayWrites() {
-        Set<ImVar> result = Collections.newSetFromMap(new IdentityHashMap<>());
+    private Set<RuntimeArrayWrite> findRuntimeArrayWrites() {
+        Set<RuntimeArrayWrite> result = new HashSet<>();
         Set<ImFunction> visited = Collections.newSetFromMap(new IdentityHashMap<>());
         Deque<ImFunction> pending = new ArrayDeque<>(translator.initFuncMap.values());
         pending.add(translator.getMainFunc());
@@ -731,13 +766,62 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
                 public void visit(ImSet set) {
                     super.visit(set);
                     if (set.getLeft() instanceof ImVarArrayAccess) {
-                        result.add(((ImVarArrayAccess) set.getLeft()).getVar());
+                        ImVarArrayAccess access = (ImVarArrayAccess) set.getLeft();
+                        List<Integer> indexes = new ArrayList<>();
+                        for (ImExpr index : access.getIndexes()) {
+                            indexes.add(index instanceof ImIntVal ? ((ImIntVal) index).getValI() : null);
+                        }
+                        result.add(new RuntimeArrayWrite(access.getVar(), indexes));
                     }
                 }
             });
             pending.addAll(UsedFunctions.calculate(function));
         }
         return result;
+    }
+
+    private static final class RuntimeArrayWrite {
+        private final ImVar var;
+        private final List<Integer> indexes;
+
+        private RuntimeArrayWrite(ImVar var, List<Integer> indexes) {
+            this.var = var;
+            this.indexes = new ArrayList<>(indexes);
+        }
+
+        private boolean matches(RuntimeArrayWrite other) {
+            if (var != other.var || indexes.size() != other.indexes.size()) {
+                return false;
+            }
+            for (int i = 0; i < indexes.size(); i++) {
+                Integer expected = indexes.get(i);
+                Integer actual = other.indexes.get(i);
+                if (expected != null && actual != null && !expected.equals(actual)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof RuntimeArrayWrite)) return false;
+            RuntimeArrayWrite that = (RuntimeArrayWrite) other;
+            return var == that.var && indexes.equals(that.indexes);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * System.identityHashCode(var) + indexes.hashCode();
+        }
+    }
+
+    private static RuntimeArrayWrite runtimeArrayWrite(ImVar var, List<ImExpr> indexes) {
+        List<Integer> constantIndexes = new ArrayList<>();
+        for (ImExpr index : indexes) {
+            constantIndexes.add(index instanceof ImIntVal ? ((ImIntVal) index).getValI() : null);
+        }
+        return new RuntimeArrayWrite(var, constantIndexes);
     }
 
     private boolean isPersistableCompiletimeValue(ILconst value) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -515,10 +515,31 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         }
     }
 
+    private static class ArrayReplayLocation {
+        private final @Nullable ImFunction target;
+        private final Set<ImSet> initializers;
+
+        private ArrayReplayLocation(@Nullable ImFunction target, Set<ImSet> initializers) {
+            this.target = target;
+            this.initializers = initializers;
+        }
+    }
+
+    private static class PackageArrayStateReplay {
+        private final ImFunction target;
+        private final Set<ImSet> initializers;
+        private final ImFunction replay;
+
+        private PackageArrayStateReplay(ImFunction target, Set<ImSet> initializers, ImFunction replay) {
+            this.target = target;
+            this.initializers = initializers;
+            this.replay = replay;
+        }
+    }
+
     private ImFunction compiletimeStateInitFunction = null;
     private ImFunction compiletimeArrayStateInitFunction = null;
-    private final Map<ImFunction, ImFunction> arrayStateInitFunctions = new IdentityHashMap<>();
-    private final Map<ImFunction, Set<ImSet>> arrayStateInitializers = new IdentityHashMap<>();
+    private final List<PackageArrayStateReplay> packageArrayStateReplays = new ArrayList<>();
     private final List<ImFunction> arrayStateSplitTargets = new ArrayList<>();
     private int genericArrayStateInitCounter;
 
@@ -562,46 +583,48 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         getCompiletimeStateInitFunction().getBody().add(stmt);
     }
 
-    private ImFunction getCompiletimeArrayStateInitFunction(@Nullable ImFunction replayTarget) {
-        ImFunction existing = arrayStateInitFunctions.get(replayTarget);
-        if (existing != null) {
-            return existing;
+    private ImFunction getCompiletimeArrayStateInitFunction(ArrayReplayLocation location) {
+        if (location.target == null && compiletimeArrayStateInitFunction != null) {
+            return compiletimeArrayStateInitFunction;
         }
         Element trace = imProg.getTrace();
-        String name = replayTarget == null
+        String name = location.target == null
             ? "initCompiletimeArrayState"
             : "initCompiletimeArrayState_" + genericArrayStateInitCounter++;
         ImFunction result = JassIm.ImFunction(trace, name, JassIm.ImTypeVars(), JassIm.ImVars(),
             JassIm.ImVoid(), JassIm.ImVars(), JassIm.ImStmts(), Collections.emptyList());
         imProg.getFunctions().add(result);
         arrayStateSplitTargets.add(result);
-        arrayStateInitFunctions.put(replayTarget, result);
-        if (replayTarget == null) {
+        if (location.target == null) {
             compiletimeArrayStateInitFunction = result;
+        } else {
+            packageArrayStateReplays.add(new PackageArrayStateReplay(
+                location.target, location.initializers, result));
         }
         return result;
     }
 
     private void insertCompiletimeArrayStateInitCalls() {
-        if (arrayStateInitFunctions.isEmpty()) {
+        if (packageArrayStateReplays.isEmpty() && compiletimeArrayStateInitFunction == null) {
             return;
         }
         ImFunction globalInitFunction = translator.getGlobalInitFunc();
-        List<ImFunction> packageTargets = new ArrayList<>(arrayStateInitFunctions.keySet());
-        packageTargets.remove(null);
-        packageTargets.sort(Comparator.comparing(ImFunction::getName));
-        for (ImFunction target : packageTargets) {
-            ImFunction replay = arrayStateInitFunctions.get(target);
-            if (replay.getBody().isEmpty()) {
+        List<PackageArrayStateReplay> packageReplays = new ArrayList<>(packageArrayStateReplays);
+        packageReplays.sort(Comparator
+            .comparing((PackageArrayStateReplay replay) -> replay.target.getName())
+            .thenComparing(replay -> replay.replay.getName()));
+        for (PackageArrayStateReplay packageReplay : packageReplays) {
+            if (packageReplay.replay.getBody().isEmpty()) {
                 continue;
             }
-            int insertionIndex = findLastArrayInitializer(target, arrayStateInitializers.get(target));
+            int insertionIndex = findLastArrayInitializer(packageReplay.target, packageReplay.initializers);
             if (insertionIndex >= 0) {
-                target.getBody().add(insertionIndex + 1, newCompiletimeArrayStateInitCall(replay));
+                packageReplay.target.getBody().add(
+                    insertionIndex + 1, newCompiletimeArrayStateInitCall(packageReplay.replay));
             }
         }
 
-        ImFunction mainReplay = arrayStateInitFunctions.get(null);
+        ImFunction mainReplay = compiletimeArrayStateInitFunction;
         if (mainReplay != null && !mainReplay.getBody().isEmpty()) {
             ImStmts mainBody = translator.getMainFunc().getBody();
             ImFunction stateInit = compiletimeStateInitFunction;
@@ -663,8 +686,8 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             if (!(var.getType() instanceof ImArrayLikeType)) {
                 continue;
             }
-            ImFunction replayTarget = findArrayReplayTarget(var);
-            ImFunction replayFunction = getCompiletimeArrayStateInitFunction(replayTarget);
+            ArrayReplayLocation replayLocation = findArrayReplayTarget(var);
+            ImFunction replayFunction = getCompiletimeArrayStateInitFunction(replayLocation);
             for (ProgramState.ArrayState state : globalState.getArrayStates(var)) {
                 if (!state.isGeneric()) {
                     emitCompiletimeArrayEntries(replayFunction, var, state.getValue(),
@@ -680,10 +703,10 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         }
     }
 
-    private @Nullable ImFunction findArrayReplayTarget(ImVar var) {
+    private ArrayReplayLocation findArrayReplayTarget(ImVar var) {
         List<ImSet> initializers = imProg.getGlobalInits().getOrDefault(var, Collections.emptyList());
         if (initializers.isEmpty()) {
-            return null;
+            return new ArrayReplayLocation(null, Collections.emptySet());
         }
         List<ImFunction> candidates = new ArrayList<>();
         candidates.add(translator.getGlobalInitFunc());
@@ -700,14 +723,12 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             }
             if (!matching.isEmpty()) {
                 if (candidate != translator.getGlobalInitFunc()) {
-                    arrayStateInitializers.computeIfAbsent(candidate,
-                        ignored -> Collections.newSetFromMap(new IdentityHashMap<>())).addAll(matching);
-                    return candidate;
+                    return new ArrayReplayLocation(candidate, matching);
                 }
-                return null;
+                return new ArrayReplayLocation(null, Collections.emptySet());
             }
         }
-        return null;
+        return new ArrayReplayLocation(null, Collections.emptySet());
     }
 
     private void emitCompiletimeGenericArrayState(ImFunction replayFunction, ImVar var,

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -571,7 +571,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
     }
 
     private void insertCompiletimeArrayStateInitCalls() {
-        if (compiletimeArrayStateInitFunction == null) {
+        if (compiletimeArrayStateInitFunction == null || compiletimeArrayStateInitFunction.getBody().isEmpty()) {
             return;
         }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -411,6 +411,8 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             return JassIm.ImRealVal("" + ((ILconstReal) value).getVal());
         } else if (value instanceof ILconstString) {
             return JassIm.ImStringVal(((ILconstString) value).getVal());
+        } else if (value instanceof ILconstNull) {
+            return ImHelper.nullExpr();
         } else if (value instanceof ILconstTuple) {
             List<ImExpr> list = new ArrayList<>();
             for (ILconst e : ((ILconstTuple) value).values()) {
@@ -501,6 +503,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
     }
 
     private ImFunction compiletimeStateInitFunction = null;
+    private ImFunction compiletimeArrayStateInitFunction = null;
 
     private ImFunction getCompiletimeStateInitFunction() {
         ImFunction res = this.compiletimeStateInitFunction;
@@ -542,6 +545,42 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         getCompiletimeStateInitFunction().getBody().add(stmt);
     }
 
+    private void addCompiletimeArrayStateInit(ImStmt stmt) {
+        getCompiletimeArrayStateInitFunction().getBody().add(stmt);
+    }
+
+    private ImFunction getCompiletimeArrayStateInitFunction() {
+        if (compiletimeArrayStateInitFunction == null) {
+            Element trace = imProg.getTrace();
+            ImFunction res = JassIm.ImFunction(trace, "initCompiletimeArrayState", JassIm.ImTypeVars(), JassIm.ImVars(),
+                JassIm.ImVoid(), JassIm.ImVars(), JassIm.ImStmts(), Collections.emptyList());
+            imProg.getFunctions().add(res);
+            compiletimeArrayStateInitFunction = res;
+            ImFunctionCall call = JassIm.ImFunctionCall(trace, res, JassIm.ImTypeArguments(), JassIm.ImExprs(), true, CallType.NORMAL);
+            ListIterator<ImStmt> iterator = translator.getMainFunc().getBody().listIterator();
+            while (iterator.hasNext()) {
+                ImStmt stmt = iterator.next();
+                if (stmt instanceof ImFunctionCall
+                    && ((ImFunctionCall) stmt).getFunc().getName().equals("DestroyTrigger")) {
+                    iterator.previous();
+                    iterator.add(call);
+                    return compiletimeArrayStateInitFunction;
+                }
+            }
+            ListIterator<ImStmt> endIterator = translator.getMainFunc().getBody().listIterator();
+            while (endIterator.hasNext()) {
+                ImStmt stmt = endIterator.next();
+                if (stmt instanceof ImReturn) {
+                    endIterator.previous();
+                    endIterator.add(call);
+                    return compiletimeArrayStateInitFunction;
+                }
+            }
+            translator.getMainFunc().getBody().add(call);
+        }
+        return compiletimeArrayStateInitFunction;
+    }
+
     private void emitCompiletimeState() {
         // constantToExpr may materialize object handles as additional globals.
         // Iterate over a snapshot to avoid modifying the collection in-flight.
@@ -562,7 +601,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
                 emitCompiletimeArrayEntries(var, (ILconstArray) entry.getValue(), nextIndexes,
                     ((ImArrayLikeType) entryType).getEntryType());
             } else if (isPersistableCompiletimeValue(entry.getValue())) {
-                addCompiletimeStateInit(JassIm.ImSet(var.getTrace(),
+                addCompiletimeArrayStateInit(JassIm.ImSet(var.getTrace(),
                     JassIm.ImVarArrayAccess(var.getTrace(), var, JassIm.ImExprs(nextIndexes)),
                     constantToExpr(var.getTrace(), entry.getValue(), entryType)));
             }
@@ -571,7 +610,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
 
     private boolean isPersistableCompiletimeValue(ILconst value) {
         if (value instanceof ILconstBool || value instanceof ILconstInt || value instanceof ILconstReal
-            || value instanceof ILconstString || value instanceof ILconstObject) {
+            || value instanceof ILconstString || value instanceof ILconstNull || value instanceof ILconstObject) {
             return true;
         }
         if (value instanceof ILconstTuple) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -591,8 +591,9 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             if (!(var.getType() instanceof ImArrayLikeType)) {
                 continue;
             }
-            ILconstArray values = globalState.getArrayValue(var);
-            emitCompiletimeArrayEntries(var, values, new ArrayList<>(), ((ImArrayLikeType) var.getType()).getEntryType());
+            for (ILconstArray values : globalState.getArrayValues(var)) {
+                emitCompiletimeArrayEntries(var, values, new ArrayList<>(), ((ImArrayLikeType) var.getType()).getEntryType());
+            }
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -113,6 +113,9 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             execute(toExecute);
             long tExecuted = System.nanoTime();
 
+            if (functionFlag == FunctionFlagToRun.CompiletimeFunctions) {
+                emitCompiletimeState();
+            }
 
             if (functionFlag == FunctionFlagToRun.CompiletimeFunctions) {
                 interpreter.writebackGlobalState(isInjectObjects());
@@ -396,6 +399,10 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
     };
 
     private ImExpr constantToExpr(Element trace, ILconst value) {
+        return constantToExpr(trace, value, null);
+    }
+
+    private ImExpr constantToExpr(Element trace, ILconst value, @Nullable ImType expectedType) {
         if (value instanceof ILconstBool) {
             return JassIm.ImBoolVal(((ILconstBool) value).getVal());
         } else if (value instanceof ILconstInt) {
@@ -533,6 +540,31 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
     // insert at the end
     private void addCompiletimeStateInit(ImStmt stmt) {
         getCompiletimeStateInitFunction().getBody().add(stmt);
+    }
+
+    private void emitCompiletimeState() {
+        for (ImVar var : imProg.getGlobals()) {
+            if (!(var.getType() instanceof ImArrayLikeType)) {
+                continue;
+            }
+            ILconstArray values = globalState.getArrayValue(var);
+            emitCompiletimeArrayEntries(var, values, new ArrayList<>(), ((ImArrayLikeType) var.getType()).getEntryType());
+        }
+    }
+
+    private void emitCompiletimeArrayEntries(ImVar var, ILconstArray values, List<ImExpr> indexes, ImType entryType) {
+        for (it.unimi.dsi.fastutil.ints.Int2ObjectMap.Entry<ILconst> entry : values.entries()) {
+            List<ImExpr> nextIndexes = new ArrayList<>(indexes);
+            nextIndexes.add(JassIm.ImIntVal(entry.getIntKey()));
+            if (entry.getValue() instanceof ILconstArray && entryType instanceof ImArrayLikeType) {
+                emitCompiletimeArrayEntries(var, (ILconstArray) entry.getValue(), nextIndexes,
+                    ((ImArrayLikeType) entryType).getEntryType());
+            } else {
+                addCompiletimeStateInit(JassIm.ImSet(var.getTrace(),
+                    JassIm.ImVarArrayAccess(var.getTrace(), var, JassIm.ImExprs(nextIndexes)),
+                    constantToExpr(var.getTrace(), entry.getValue(), entryType)));
+            }
+        }
     }
 
     /**

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -559,12 +559,29 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             if (entry.getValue() instanceof ILconstArray && entryType instanceof ImArrayLikeType) {
                 emitCompiletimeArrayEntries(var, (ILconstArray) entry.getValue(), nextIndexes,
                     ((ImArrayLikeType) entryType).getEntryType());
-            } else {
+            } else if (isPersistableCompiletimeValue(entry.getValue())) {
                 addCompiletimeStateInit(JassIm.ImSet(var.getTrace(),
                     JassIm.ImVarArrayAccess(var.getTrace(), var, JassIm.ImExprs(nextIndexes)),
                     constantToExpr(var.getTrace(), entry.getValue(), entryType)));
             }
         }
+    }
+
+    private boolean isPersistableCompiletimeValue(ILconst value) {
+        if (value instanceof ILconstBool || value instanceof ILconstInt || value instanceof ILconstReal
+            || value instanceof ILconstString || value instanceof ILconstObject) {
+            return true;
+        }
+        if (value instanceof ILconstTuple) {
+            for (ILconst element : ((ILconstTuple) value).values()) {
+                if (!isPersistableCompiletimeValue(element)) return false;
+            }
+            return true;
+        }
+        if (value instanceof IlConstHandle) {
+            return ((IlConstHandle) value).getObj() instanceof LinkedListMultimap;
+        }
+        return false;
     }
 
     /**

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -504,6 +504,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
 
     private ImFunction compiletimeStateInitFunction = null;
     private ImFunction compiletimeArrayStateInitFunction = null;
+    private int genericArrayStateInitCounter;
 
     private ImFunction getCompiletimeStateInitFunction() {
         ImFunction res = this.compiletimeStateInitFunction;
@@ -545,10 +546,6 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         getCompiletimeStateInitFunction().getBody().add(stmt);
     }
 
-    private void addCompiletimeArrayStateInit(ImStmt stmt) {
-        getCompiletimeArrayStateInitFunction().getBody().add(stmt);
-    }
-
     private ImFunction getCompiletimeArrayStateInitFunction() {
         if (compiletimeArrayStateInitFunction == null) {
             Element trace = imProg.getTrace();
@@ -557,26 +554,16 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             imProg.getFunctions().add(res);
             compiletimeArrayStateInitFunction = res;
             ImFunctionCall call = JassIm.ImFunctionCall(trace, res, JassIm.ImTypeArguments(), JassIm.ImExprs(), true, CallType.NORMAL);
-            ListIterator<ImStmt> iterator = translator.getMainFunc().getBody().listIterator();
-            while (iterator.hasNext()) {
-                ImStmt stmt = iterator.next();
-                if (stmt instanceof ImFunctionCall
-                    && ((ImFunctionCall) stmt).getFunc().getName().equals("DestroyTrigger")) {
-                    iterator.previous();
-                    iterator.add(call);
+            ImFunction globalInitFunc = translator.getGlobalInitFunc();
+            ImStmts mainBody = translator.getMainFunc().getBody();
+            for (int i = 0; i < mainBody.size(); i++) {
+                ImStmt stmt = mainBody.get(i);
+                if (stmt instanceof ImFunctionCall && ((ImFunctionCall) stmt).getFunc().getName().equals(globalInitFunc.getName())) {
+                    mainBody.add(i + 1, call);
                     return compiletimeArrayStateInitFunction;
                 }
             }
-            ListIterator<ImStmt> endIterator = translator.getMainFunc().getBody().listIterator();
-            while (endIterator.hasNext()) {
-                ImStmt stmt = endIterator.next();
-                if (stmt instanceof ImReturn) {
-                    endIterator.previous();
-                    endIterator.add(call);
-                    return compiletimeArrayStateInitFunction;
-                }
-            }
-            translator.getMainFunc().getBody().add(call);
+            mainBody.add(0, call);
         }
         return compiletimeArrayStateInitFunction;
     }
@@ -584,28 +571,56 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
     private void emitCompiletimeState() {
         // constantToExpr may materialize object handles as additional globals.
         // Iterate over a snapshot to avoid modifying the collection in-flight.
-        for (ImVar var : new ArrayList<>(globalState.getModifiedArrays())) {
+        List<ImVar> modifiedArrays = new ArrayList<>(globalState.getModifiedArrays());
+        Map<ImVar, Integer> globalOrder = new IdentityHashMap<>();
+        for (int i = 0; i < imProg.getGlobals().size(); i++) {
+            globalOrder.put(imProg.getGlobals().get(i), i);
+        }
+        modifiedArrays.sort(Comparator
+            .comparingInt((ImVar var) -> globalOrder.getOrDefault(var, Integer.MAX_VALUE))
+            .thenComparing(ImVar::getName));
+        for (ImVar var : modifiedArrays) {
             if (!imProg.getGlobals().contains(var)) {
                 continue;
             }
             if (!(var.getType() instanceof ImArrayLikeType)) {
                 continue;
             }
-            for (ILconstArray values : globalState.getArrayValues(var)) {
-                emitCompiletimeArrayEntries(var, values, new ArrayList<>(), ((ImArrayLikeType) var.getType()).getEntryType());
+            for (ProgramState.ArrayState state : globalState.getArrayStates(var)) {
+                if (state.getTypeArguments().isEmpty()) {
+                    emitCompiletimeArrayEntries(getCompiletimeArrayStateInitFunction(), var, state.getValue(),
+                        new ArrayList<>(), ((ImArrayLikeType) var.getType()).getEntryType());
+                } else {
+                    emitCompiletimeGenericArrayState(var, state, ((ImArrayLikeType) var.getType()).getEntryType());
+                }
             }
         }
     }
 
-    private void emitCompiletimeArrayEntries(ImVar var, ILconstArray values, List<ImExpr> indexes, ImType entryType) {
+    private void emitCompiletimeGenericArrayState(ImVar var, ProgramState.ArrayState state, ImType entryType) {
+        List<ImTypeVar> typeVars = new ArrayList<>();
+        for (int i = 0; i < state.getTypeArguments().size(); i++) {
+            typeVars.add(JassIm.ImTypeVar("T" + i));
+        }
+        ImFunction replay = JassIm.ImFunction(var.getTrace(),
+            "initCompiletimeArrayState_" + genericArrayStateInitCounter++,
+            JassIm.ImTypeVars(typeVars), JassIm.ImVars(), JassIm.ImVoid(), JassIm.ImVars(),
+            JassIm.ImStmts(), Collections.emptyList());
+        imProg.getFunctions().add(replay);
+        emitCompiletimeArrayEntries(replay, var, state.getValue(), new ArrayList<>(), entryType);
+        getCompiletimeArrayStateInitFunction().getBody().add(JassIm.ImFunctionCall(
+            var.getTrace(), replay, JassIm.ImTypeArguments(state.getTypeArguments()), JassIm.ImExprs(), true, CallType.NORMAL));
+    }
+
+    private void emitCompiletimeArrayEntries(ImFunction target, ImVar var, ILconstArray values, List<ImExpr> indexes, ImType entryType) {
         for (it.unimi.dsi.fastutil.ints.Int2ObjectMap.Entry<ILconst> entry : values.entries()) {
             List<ImExpr> nextIndexes = new ArrayList<>(indexes);
             nextIndexes.add(JassIm.ImIntVal(entry.getIntKey()));
             if (entry.getValue() instanceof ILconstArray && entryType instanceof ImArrayLikeType) {
-                emitCompiletimeArrayEntries(var, (ILconstArray) entry.getValue(), nextIndexes,
+                emitCompiletimeArrayEntries(target, var, (ILconstArray) entry.getValue(), nextIndexes,
                     ((ImArrayLikeType) entryType).getEntryType());
             } else if (isPersistableCompiletimeValue(entry.getValue())) {
-                addCompiletimeArrayStateInit(JassIm.ImSet(var.getTrace(),
+                target.getBody().add(JassIm.ImSet(var.getTrace(),
                     JassIm.ImVarArrayAccess(var.getTrace(), var, JassIm.ImExprs(nextIndexes)),
                     constantToExpr(var.getTrace(), entry.getValue(), entryType)));
             } else {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -201,7 +201,9 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         if (compiletimeStateInitFunction != null) {
             FunctionSplitter.splitFunc(translator, compiletimeStateInitFunction);
         }
-        for (ImFunction arrayStateFunction : arrayStateInitFunctions.values()) {
+        List<ImFunction> splitTargets = new ArrayList<>(arrayStateSplitTargets);
+        splitTargets.sort(Comparator.comparing(ImFunction::getName));
+        for (ImFunction arrayStateFunction : splitTargets) {
             if (!arrayStateFunction.getBody().isEmpty()) {
                 FunctionSplitter.splitFunc(translator, arrayStateFunction);
             }
@@ -517,6 +519,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
     private ImFunction compiletimeArrayStateInitFunction = null;
     private final Map<ImFunction, ImFunction> arrayStateInitFunctions = new IdentityHashMap<>();
     private final Map<ImFunction, Set<ImSet>> arrayStateInitializers = new IdentityHashMap<>();
+    private final List<ImFunction> arrayStateSplitTargets = new ArrayList<>();
     private int genericArrayStateInitCounter;
 
     private ImFunction getCompiletimeStateInitFunction() {
@@ -571,6 +574,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         ImFunction result = JassIm.ImFunction(trace, name, JassIm.ImTypeVars(), JassIm.ImVars(),
             JassIm.ImVoid(), JassIm.ImVars(), JassIm.ImStmts(), Collections.emptyList());
         imProg.getFunctions().add(result);
+        arrayStateSplitTargets.add(result);
         arrayStateInitFunctions.put(replayTarget, result);
         if (replayTarget == null) {
             compiletimeArrayStateInitFunction = result;
@@ -629,7 +633,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         for (int i = 0; i < function.getBody().size(); i++) {
             if (function.getBody().get(i) instanceof ImSet
                 && modifiedArrayInitializers.contains(function.getBody().get(i))) {
-                insertionIndex = i + 1;
+                insertionIndex = i;
             }
         }
         return insertionIndex;
@@ -718,6 +722,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             JassIm.ImTypeVars(typeVars), JassIm.ImVars(), JassIm.ImVoid(), JassIm.ImVars(),
             JassIm.ImStmts(), Collections.emptyList());
         imProg.getFunctions().add(replay);
+        arrayStateSplitTargets.add(replay);
         emitCompiletimeArrayEntries(replay, var, state.getValue(), new ArrayList<>(), entryType, runtimeArrayWrites);
         if (!replay.getBody().isEmpty()) {
             replayFunction.getBody().add(JassIm.ImFunctionCall(

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -584,7 +584,10 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
     private void emitCompiletimeState() {
         // constantToExpr may materialize object handles as additional globals.
         // Iterate over a snapshot to avoid modifying the collection in-flight.
-        for (ImVar var : new ArrayList<>(imProg.getGlobals())) {
+        for (ImVar var : new ArrayList<>(globalState.getModifiedArrays())) {
+            if (!imProg.getGlobals().contains(var)) {
+                continue;
+            }
             if (!(var.getType() instanceof ImArrayLikeType)) {
                 continue;
             }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -691,7 +691,8 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             for (ProgramState.ArrayState state : globalState.getArrayStates(var)) {
                 if (!state.isGeneric()) {
                     emitCompiletimeArrayEntries(replayFunction, var, state.getValue(),
-                        new ArrayList<>(), ((ImArrayLikeType) var.getType()).getEntryType(), runtimeArrayWrites);
+                        new ArrayList<>(), ((ImArrayLikeType) var.getType()).getEntryType(), runtimeArrayWrites,
+                        state.getModifiedIndexes());
                 } else if (state.getTypeArguments().isEmpty()) {
                     throw new InterpreterException(var.getTrace(),
                         "Could not determine the generic specialization for compiletime array " + var.getName());
@@ -744,29 +745,40 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             JassIm.ImStmts(), Collections.emptyList());
         imProg.getFunctions().add(replay);
         arrayStateSplitTargets.add(replay);
-        emitCompiletimeArrayEntries(replay, var, state.getValue(), new ArrayList<>(), entryType, runtimeArrayWrites);
+        emitCompiletimeArrayEntries(replay, var, state.getValue(), new ArrayList<>(), entryType,
+            runtimeArrayWrites, state.getModifiedIndexes());
         if (!replay.getBody().isEmpty()) {
             replayFunction.getBody().add(JassIm.ImFunctionCall(
                 var.getTrace(), replay, JassIm.ImTypeArguments(state.getTypeArguments()), JassIm.ImExprs(), true, CallType.NORMAL));
         }
     }
 
-    private void emitCompiletimeArrayEntries(ImFunction target, ImVar var, ILconstArray values, List<ImExpr> indexes,
-                                             ImType entryType, Set<RuntimeArrayWrite> runtimeArrayWrites) {
+    private void emitCompiletimeArrayEntries(ImFunction target, ImVar var, ILconstArray values, List<Integer> indexes,
+                                             ImType entryType, Set<RuntimeArrayWrite> runtimeArrayWrites,
+                                             Set<List<Integer>> modifiedIndexes) {
         for (it.unimi.dsi.fastutil.ints.Int2ObjectMap.Entry<ILconst> entry : values.entries()) {
-            List<ImExpr> nextIndexes = new ArrayList<>(indexes);
-            nextIndexes.add(JassIm.ImIntVal(entry.getIntKey()));
+            List<Integer> nextIndexes = new ArrayList<>(indexes);
+            nextIndexes.add(entry.getIntKey());
             if (entry.getValue() instanceof ILconstArray && entryType instanceof ImArrayLikeType) {
                 emitCompiletimeArrayEntries(target, var, (ILconstArray) entry.getValue(), nextIndexes,
-                    ((ImArrayLikeType) entryType).getEntryType(), runtimeArrayWrites);
+                    ((ImArrayLikeType) entryType).getEntryType(), runtimeArrayWrites, modifiedIndexes);
+            } else if (!modifiedIndexes.contains(nextIndexes)) {
+                continue;
             } else if (isPersistableCompiletimeValue(entry.getValue())) {
+                ImExprs indexExpressions = JassIm.ImExprs();
+                for (Integer index : nextIndexes) {
+                    indexExpressions.add(JassIm.ImIntVal(index));
+                }
                 target.getBody().add(JassIm.ImSet(var.getTrace(),
-                    JassIm.ImVarArrayAccess(var.getTrace(), var, JassIm.ImExprs(nextIndexes)),
+                    JassIm.ImVarArrayAccess(var.getTrace(), var, indexExpressions),
                     constantToExpr(var.getTrace(), entry.getValue(), entryType)));
             } else {
                 String message = "Unsupported compiletime array entry at index " + entry.getIntKey()
                     + " (" + entry.getValue() + ")";
-                RuntimeArrayWrite runtimeWrite = runtimeArrayWrite(var, nextIndexes);
+                List<ImExpr> indexExpressions = nextIndexes.stream()
+                    .map(JassIm::ImIntVal)
+                    .collect(Collectors.toList());
+                RuntimeArrayWrite runtimeWrite = runtimeArrayWrite(var, indexExpressions);
                 if (runtimeWrite != null && runtimeArrayWrites.stream().anyMatch(runtimeWrite::matches)) {
                     WLogger.warning(message + "; runtime initialization of " + var.getName()
                         + " remains authoritative at " + var.getTrace());

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -115,6 +115,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
 
             if (functionFlag == FunctionFlagToRun.CompiletimeFunctions) {
                 emitCompiletimeState();
+                insertCompiletimeArrayStateInitCalls();
             }
 
             if (functionFlag == FunctionFlagToRun.CompiletimeFunctions) {
@@ -553,19 +554,71 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
                 JassIm.ImVoid(), JassIm.ImVars(), JassIm.ImStmts(), Collections.emptyList());
             imProg.getFunctions().add(res);
             compiletimeArrayStateInitFunction = res;
-            ImFunctionCall call = JassIm.ImFunctionCall(trace, res, JassIm.ImTypeArguments(), JassIm.ImExprs(), true, CallType.NORMAL);
-            ImFunction globalInitFunc = translator.getGlobalInitFunc();
+        }
+        return compiletimeArrayStateInitFunction;
+    }
+
+    private void insertCompiletimeArrayStateInitCalls() {
+        if (compiletimeArrayStateInitFunction == null) {
+            return;
+        }
+
+        Set<ImSet> modifiedArrayInitializers = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (ImVar var : globalState.getModifiedArrays()) {
+            for (ImSet initializer : imProg.getGlobalInits().getOrDefault(var, Collections.emptyList())) {
+                modifiedArrayInitializers.add(initializer);
+            }
+        }
+
+        ImFunction globalInitFunction = translator.getGlobalInitFunc();
+        boolean insertedIntoPackage = false;
+        if (!modifiedArrayInitializers.isEmpty()
+            && insertReplayAfterInitializers(globalInitFunction, modifiedArrayInitializers)) {
+            insertedIntoPackage = true;
+        }
+        for (ImFunction initFunction : translator.initFuncMap.values()) {
+            if (initFunction.getBody().isEmpty()) {
+                continue;
+            }
+            insertReplayAfterInitializers(initFunction, modifiedArrayInitializers);
+            insertedIntoPackage = true;
+        }
+
+        if (!insertedIntoPackage) {
             ImStmts mainBody = translator.getMainFunc().getBody();
             for (int i = 0; i < mainBody.size(); i++) {
                 ImStmt stmt = mainBody.get(i);
-                if (stmt instanceof ImFunctionCall && ((ImFunctionCall) stmt).getFunc().getName().equals(globalInitFunc.getName())) {
-                    mainBody.add(i + 1, call);
-                    return compiletimeArrayStateInitFunction;
+                if (stmt instanceof ImFunctionCall
+                    && ((ImFunctionCall) stmt).getFunc().getName().equals(globalInitFunction.getName())) {
+                    mainBody.add(i + 1, newCompiletimeArrayStateInitCall());
+                    return;
                 }
             }
-            mainBody.add(0, call);
+            mainBody.add(0, newCompiletimeArrayStateInitCall());
         }
-        return compiletimeArrayStateInitFunction;
+    }
+
+    private boolean insertReplayAfterInitializers(ImFunction function, Set<ImSet> modifiedArrayInitializers) {
+        if (function == null || function.getBody().isEmpty()) {
+            return false;
+        }
+        int insertionIndex = -1;
+        for (int i = 0; i < function.getBody().size(); i++) {
+            if (function.getBody().get(i) instanceof ImSet
+                && modifiedArrayInitializers.contains(function.getBody().get(i))) {
+                insertionIndex = i + 1;
+            }
+        }
+        if (insertionIndex < 0) {
+            insertionIndex = 0;
+        }
+        function.getBody().add(insertionIndex, newCompiletimeArrayStateInitCall());
+        return true;
+    }
+
+    private ImFunctionCall newCompiletimeArrayStateInitCall() {
+        return JassIm.ImFunctionCall(imProg.getTrace(), compiletimeArrayStateInitFunction,
+            JassIm.ImTypeArguments(), JassIm.ImExprs(), true, CallType.NORMAL);
     }
 
     private void emitCompiletimeState() {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -608,6 +608,9 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
                 addCompiletimeArrayStateInit(JassIm.ImSet(var.getTrace(),
                     JassIm.ImVarArrayAccess(var.getTrace(), var, JassIm.ImExprs(nextIndexes)),
                     constantToExpr(var.getTrace(), entry.getValue(), entryType)));
+            } else {
+                WLogger.warning("Skipping unsupported compiletime array entry at index " + entry.getIntKey()
+                    + " (" + entry.getValue() + ") at " + var.getTrace());
             }
         }
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -115,7 +115,6 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
 
             if (functionFlag == FunctionFlagToRun.CompiletimeFunctions) {
                 emitCompiletimeState();
-                insertCompiletimeArrayStateInitCalls();
             }
 
             if (functionFlag == FunctionFlagToRun.CompiletimeFunctions) {
@@ -124,6 +123,9 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             long tWriteback = System.nanoTime();
             runDelayedActions();
             emitCompiletimeObjectAllocs();
+            if (functionFlag == FunctionFlagToRun.CompiletimeFunctions) {
+                insertCompiletimeArrayStateInitCalls();
+            }
             long tDelayed = System.nanoTime();
 
             partitionCompiletimeStateInitFunction();
@@ -197,10 +199,15 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
 
     private void partitionCompiletimeStateInitFunction() {
         if (compiletimeStateInitFunction == null) {
-            return;
+            if (compiletimeArrayStateInitFunction != null) {
+                FunctionSplitter.splitFunc(translator, compiletimeArrayStateInitFunction);
+            }
+        } else {
+            FunctionSplitter.splitFunc(translator, compiletimeStateInitFunction);
+            if (compiletimeArrayStateInitFunction != null) {
+                FunctionSplitter.splitFunc(translator, compiletimeArrayStateInitFunction);
+            }
         }
-
-        FunctionSplitter.splitFunc(translator, compiletimeStateInitFunction);
     }
 
     private boolean isUnitTestMode() {
@@ -413,12 +420,17 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         } else if (value instanceof ILconstString) {
             return JassIm.ImStringVal(((ILconstString) value).getVal());
         } else if (value instanceof ILconstNull) {
-            return ImHelper.nullExpr();
+            return expectedType == null ? ImHelper.nullExpr() : JassIm.ImNull(expectedType.copy());
         } else if (value instanceof ILconstTuple) {
             List<ImExpr> list = new ArrayList<>();
+            ImTupleType tupleType = expectedType instanceof ImTupleType ? (ImTupleType) expectedType : null;
+            int index = 0;
             for (ILconst e : ((ILconstTuple) value).values()) {
-                ImExpr imExpr = constantToExpr(trace, e);
+                ImType elementType = tupleType != null && index < tupleType.getTypes().size()
+                    ? tupleType.getTypes().get(index) : null;
+                ImExpr imExpr = constantToExpr(trace, e, elementType);
                 list.add(imExpr);
+                index++;
             }
             return JassIm.ImTupleExpr(
                     JassIm.ImExprs(
@@ -586,10 +598,19 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
 
         if (!insertedIntoPackage) {
             ImStmts mainBody = translator.getMainFunc().getBody();
+            ImFunction stateInit = compiletimeStateInitFunction;
+            if (stateInit != null) {
+                for (int i = 0; i < mainBody.size(); i++) {
+                    ImStmt stmt = mainBody.get(i);
+                    if (stmt instanceof ImFunctionCall && ((ImFunctionCall) stmt).getFunc() == stateInit) {
+                        mainBody.add(i + 1, newCompiletimeArrayStateInitCall());
+                        return;
+                    }
+                }
+            }
             for (int i = 0; i < mainBody.size(); i++) {
                 ImStmt stmt = mainBody.get(i);
-                if (stmt instanceof ImFunctionCall
-                    && ((ImFunctionCall) stmt).getFunc().getName().equals(globalInitFunction.getName())) {
+                if (stmt instanceof ImFunctionCall && ((ImFunctionCall) stmt).getFunc() == globalInitFunction) {
                     mainBody.add(i + 1, newCompiletimeArrayStateInitCall());
                     return;
                 }
@@ -624,6 +645,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
     private void emitCompiletimeState() {
         // constantToExpr may materialize object handles as additional globals.
         // Iterate over a snapshot to avoid modifying the collection in-flight.
+        Set<ImVar> runtimeArrayWrites = findRuntimeArrayWrites();
         List<ImVar> modifiedArrays = new ArrayList<>(globalState.getModifiedArrays());
         Map<ImVar, Integer> globalOrder = new IdentityHashMap<>();
         for (int i = 0; i < imProg.getGlobals().size(); i++) {
@@ -640,17 +662,21 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
                 continue;
             }
             for (ProgramState.ArrayState state : globalState.getArrayStates(var)) {
-                if (state.getTypeArguments().isEmpty()) {
+                if (!state.isGeneric()) {
                     emitCompiletimeArrayEntries(getCompiletimeArrayStateInitFunction(), var, state.getValue(),
-                        new ArrayList<>(), ((ImArrayLikeType) var.getType()).getEntryType());
+                        new ArrayList<>(), ((ImArrayLikeType) var.getType()).getEntryType(), runtimeArrayWrites);
+                } else if (state.getTypeArguments().isEmpty()) {
+                    throw new InterpreterException(var.getTrace(),
+                        "Could not determine the generic specialization for compiletime array " + var.getName());
                 } else {
-                    emitCompiletimeGenericArrayState(var, state, ((ImArrayLikeType) var.getType()).getEntryType());
+                    emitCompiletimeGenericArrayState(var, state, ((ImArrayLikeType) var.getType()).getEntryType(), runtimeArrayWrites);
                 }
             }
         }
     }
 
-    private void emitCompiletimeGenericArrayState(ImVar var, ProgramState.ArrayState state, ImType entryType) {
+    private void emitCompiletimeGenericArrayState(ImVar var, ProgramState.ArrayState state, ImType entryType,
+                                                  Set<ImVar> runtimeArrayWrites) {
         List<ImTypeVar> typeVars = new ArrayList<>();
         for (int i = 0; i < state.getTypeArguments().size(); i++) {
             typeVars.add(JassIm.ImTypeVar("T" + i));
@@ -660,27 +686,58 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             JassIm.ImTypeVars(typeVars), JassIm.ImVars(), JassIm.ImVoid(), JassIm.ImVars(),
             JassIm.ImStmts(), Collections.emptyList());
         imProg.getFunctions().add(replay);
-        emitCompiletimeArrayEntries(replay, var, state.getValue(), new ArrayList<>(), entryType);
+        emitCompiletimeArrayEntries(replay, var, state.getValue(), new ArrayList<>(), entryType, runtimeArrayWrites);
         getCompiletimeArrayStateInitFunction().getBody().add(JassIm.ImFunctionCall(
             var.getTrace(), replay, JassIm.ImTypeArguments(state.getTypeArguments()), JassIm.ImExprs(), true, CallType.NORMAL));
     }
 
-    private void emitCompiletimeArrayEntries(ImFunction target, ImVar var, ILconstArray values, List<ImExpr> indexes, ImType entryType) {
+    private void emitCompiletimeArrayEntries(ImFunction target, ImVar var, ILconstArray values, List<ImExpr> indexes,
+                                             ImType entryType, Set<ImVar> runtimeArrayWrites) {
         for (it.unimi.dsi.fastutil.ints.Int2ObjectMap.Entry<ILconst> entry : values.entries()) {
             List<ImExpr> nextIndexes = new ArrayList<>(indexes);
             nextIndexes.add(JassIm.ImIntVal(entry.getIntKey()));
             if (entry.getValue() instanceof ILconstArray && entryType instanceof ImArrayLikeType) {
                 emitCompiletimeArrayEntries(target, var, (ILconstArray) entry.getValue(), nextIndexes,
-                    ((ImArrayLikeType) entryType).getEntryType());
+                    ((ImArrayLikeType) entryType).getEntryType(), runtimeArrayWrites);
             } else if (isPersistableCompiletimeValue(entry.getValue())) {
                 target.getBody().add(JassIm.ImSet(var.getTrace(),
                     JassIm.ImVarArrayAccess(var.getTrace(), var, JassIm.ImExprs(nextIndexes)),
                     constantToExpr(var.getTrace(), entry.getValue(), entryType)));
             } else {
-                WLogger.warning("Skipping unsupported compiletime array entry at index " + entry.getIntKey()
-                    + " (" + entry.getValue() + ") at " + var.getTrace());
+                String message = "Unsupported compiletime array entry at index " + entry.getIntKey()
+                    + " (" + entry.getValue() + ")";
+                if (runtimeArrayWrites.contains(var)) {
+                    WLogger.warning(message + "; runtime initialization of " + var.getName()
+                        + " remains authoritative at " + var.getTrace());
+                } else {
+                    throw new InterpreterException(var.getTrace(), message);
+                }
             }
         }
+    }
+
+    private Set<ImVar> findRuntimeArrayWrites() {
+        Set<ImVar> result = Collections.newSetFromMap(new IdentityHashMap<>());
+        Set<ImFunction> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        Deque<ImFunction> pending = new ArrayDeque<>(translator.initFuncMap.values());
+        pending.add(translator.getMainFunc());
+        while (!pending.isEmpty()) {
+            ImFunction function = pending.removeFirst();
+            if (!visited.add(function)) {
+                continue;
+            }
+            function.accept(new ImFunction.DefaultVisitor() {
+                @Override
+                public void visit(ImSet set) {
+                    super.visit(set);
+                    if (set.getLeft() instanceof ImVarArrayAccess) {
+                        result.add(((ImVarArrayAccess) set.getLeft()).getVar());
+                    }
+                }
+            });
+            pending.addAll(UsedFunctions.calculate(function));
+        }
+        return result;
     }
 
     private boolean isPersistableCompiletimeValue(ILconst value) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/ILconstArray.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/ILconstArray.java
@@ -5,6 +5,8 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 
 public class ILconstArray extends ILconstAbstract {
@@ -70,6 +72,13 @@ public class ILconstArray extends ILconstAbstract {
         v = defaultValue.get();
         values.put(index, v);
         return v;
+    }
+
+    /** Returns the explicitly stored entries in deterministic index order. */
+    public List<Int2ObjectMap.Entry<ILconst>> entries() {
+        List<Int2ObjectMap.Entry<ILconst>> result = new ArrayList<>(values.int2ObjectEntrySet());
+        result.sort(java.util.Comparator.comparingInt(Int2ObjectMap.Entry::getIntKey));
+        return result;
     }
 
     private void checkIndex(int index) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
@@ -762,6 +762,11 @@ public class ProgramState extends State implements AutoCloseable {
         return r;
     }
 
+    /** Snapshot of an array's explicitly initialized entries for compiletime migration. */
+    public ILconstArray getArrayValue(ImVar v) {
+        return getArray(v);
+    }
+
 
     public Collection<ILconstObject> getAllObjects() {
         List<ILconstObject> values = new ArrayList<>();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
@@ -40,6 +40,7 @@ public class ProgramState extends State implements AutoCloseable {
     private final Map<ImVar, ImClass> genericStaticOwner = new HashMap<>();
 
     private final Object2ObjectOpenHashMap<String, ILconstArray> genericStaticArrays = new Object2ObjectOpenHashMap<>();
+    private final Set<String> modifiedGenericArrays = new HashSet<>();
     private final IdentityHashMap<ImVar, Object2ObjectOpenHashMap<String, ILconst>> genericStaticVals = new IdentityHashMap<>();
     private final Object2ObjectOpenHashMap<String, ILconst> genericStaticScalarVals = new Object2ObjectOpenHashMap<>();
 
@@ -762,9 +763,33 @@ public class ProgramState extends State implements AutoCloseable {
         return r;
     }
 
+    @Override
+    public void setArrayVal(ImVar v, List<Integer> indexes, ILconst val) {
+        String key = genericStaticKey(v);
+        super.setArrayVal(v, indexes, val);
+        if (key != null) {
+            modifiedGenericArrays.add(key);
+        }
+    }
+
     /** Snapshot of an array's explicitly initialized entries for compiletime migration. */
     public ILconstArray getArrayValue(ImVar v) {
         return getArray(v);
+    }
+
+    public Collection<ILconstArray> getArrayValues(ImVar v) {
+        String prefix = v.getName() + "|";
+        List<ILconstArray> result = new ArrayList<>();
+        for (String key : modifiedGenericArrays) {
+            if (key.startsWith(prefix)) {
+                ILconstArray value = genericStaticArrays.get(key);
+                if (value != null) result.add(value);
+            }
+        }
+        if (result.isEmpty() && genericStaticKey(v) == null) {
+            result.add(getArray(v));
+        }
+        return result;
     }
 
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
@@ -812,10 +812,16 @@ public class ProgramState extends State implements AutoCloseable {
     public static final class ArrayState {
         private final ILconstArray value;
         private final List<ImTypeArgument> typeArguments;
+        private final boolean generic;
 
         public ArrayState(ILconstArray value, List<ImTypeArgument> typeArguments) {
+            this(value, typeArguments, !typeArguments.isEmpty());
+        }
+
+        public ArrayState(ILconstArray value, List<ImTypeArgument> typeArguments, boolean generic) {
             this.value = value;
-            this.typeArguments = typeArguments;
+            this.typeArguments = Collections.unmodifiableList(new ArrayList<>(typeArguments));
+            this.generic = generic;
         }
 
         public ILconstArray getValue() {
@@ -824,6 +830,10 @@ public class ProgramState extends State implements AutoCloseable {
 
         public List<ImTypeArgument> getTypeArguments() {
             return typeArguments;
+        }
+
+        public boolean isGeneric() {
+            return generic;
         }
     }
 
@@ -836,7 +846,7 @@ public class ProgramState extends State implements AutoCloseable {
             if (key.startsWith(prefix)) {
                 ILconstArray value = genericStaticArrays.get(key);
                 if (value != null) {
-                    result.add(new ArrayState(value, genericArrayTypeArguments.getOrDefault(key, Collections.emptyList())));
+                    result.add(new ArrayState(value, genericArrayTypeArguments.getOrDefault(key, Collections.emptyList()), true));
                 }
             }
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
@@ -41,6 +41,7 @@ public class ProgramState extends State implements AutoCloseable {
 
     private final Object2ObjectOpenHashMap<String, ILconstArray> genericStaticArrays = new Object2ObjectOpenHashMap<>();
     private final Set<String> modifiedGenericArrays = new HashSet<>();
+    private final Map<String, Set<List<Integer>>> modifiedGenericArrayIndexes = new HashMap<>();
     private final Map<String, List<ImTypeArgument>> genericArrayTypeArguments = new HashMap<>();
     private final IdentityHashMap<ImVar, Object2ObjectOpenHashMap<String, ILconst>> genericStaticVals = new IdentityHashMap<>();
     private final Object2ObjectOpenHashMap<String, ILconst> genericStaticScalarVals = new Object2ObjectOpenHashMap<>();
@@ -770,6 +771,8 @@ public class ProgramState extends State implements AutoCloseable {
         super.setArrayVal(v, indexes, val);
         if (key != null) {
             modifiedGenericArrays.add(key);
+            modifiedGenericArrayIndexes.computeIfAbsent(key, ignored -> new HashSet<>())
+                .add(Collections.unmodifiableList(new ArrayList<>(indexes)));
             genericArrayTypeArguments.computeIfAbsent(key, ignored -> genericStaticTypeArguments(v));
         }
     }
@@ -813,15 +816,26 @@ public class ProgramState extends State implements AutoCloseable {
         private final ILconstArray value;
         private final List<ImTypeArgument> typeArguments;
         private final boolean generic;
+        private final Set<List<Integer>> modifiedIndexes;
 
         public ArrayState(ILconstArray value, List<ImTypeArgument> typeArguments) {
-            this(value, typeArguments, !typeArguments.isEmpty());
+            this(value, typeArguments, !typeArguments.isEmpty(), Collections.emptySet());
         }
 
         public ArrayState(ILconstArray value, List<ImTypeArgument> typeArguments, boolean generic) {
+            this(value, typeArguments, generic, Collections.emptySet());
+        }
+
+        public ArrayState(ILconstArray value, List<ImTypeArgument> typeArguments, boolean generic,
+                          Set<List<Integer>> modifiedIndexes) {
             this.value = value;
             this.typeArguments = Collections.unmodifiableList(new ArrayList<>(typeArguments));
             this.generic = generic;
+            Set<List<Integer>> indexSnapshot = new HashSet<>();
+            for (List<Integer> indexes : modifiedIndexes) {
+                indexSnapshot.add(Collections.unmodifiableList(new ArrayList<>(indexes)));
+            }
+            this.modifiedIndexes = Collections.unmodifiableSet(indexSnapshot);
         }
 
         public ILconstArray getValue() {
@@ -835,6 +849,10 @@ public class ProgramState extends State implements AutoCloseable {
         public boolean isGeneric() {
             return generic;
         }
+
+        public Set<List<Integer>> getModifiedIndexes() {
+            return modifiedIndexes;
+        }
     }
 
     public Collection<ArrayState> getArrayStates(ImVar v) {
@@ -846,12 +864,14 @@ public class ProgramState extends State implements AutoCloseable {
             if (key.startsWith(prefix)) {
                 ILconstArray value = genericStaticArrays.get(key);
                 if (value != null) {
-                    result.add(new ArrayState(value, genericArrayTypeArguments.getOrDefault(key, Collections.emptyList()), true));
+                    result.add(new ArrayState(value,
+                        genericArrayTypeArguments.getOrDefault(key, Collections.emptyList()), true,
+                        modifiedGenericArrayIndexes.getOrDefault(key, Collections.emptySet())));
                 }
             }
         }
         if (result.isEmpty() && genericStaticKey(v) == null) {
-            result.add(new ArrayState(getArray(v), Collections.emptyList()));
+            result.add(new ArrayState(getArray(v), Collections.emptyList(), false, getModifiedArrayIndexes(v)));
         }
         return result;
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
@@ -41,6 +41,7 @@ public class ProgramState extends State implements AutoCloseable {
 
     private final Object2ObjectOpenHashMap<String, ILconstArray> genericStaticArrays = new Object2ObjectOpenHashMap<>();
     private final Set<String> modifiedGenericArrays = new HashSet<>();
+    private final Map<String, List<ImTypeArgument>> genericArrayTypeArguments = new HashMap<>();
     private final IdentityHashMap<ImVar, Object2ObjectOpenHashMap<String, ILconst>> genericStaticVals = new IdentityHashMap<>();
     private final Object2ObjectOpenHashMap<String, ILconst> genericStaticScalarVals = new Object2ObjectOpenHashMap<>();
 
@@ -769,7 +770,38 @@ public class ProgramState extends State implements AutoCloseable {
         super.setArrayVal(v, indexes, val);
         if (key != null) {
             modifiedGenericArrays.add(key);
+            genericArrayTypeArguments.computeIfAbsent(key, ignored -> genericStaticTypeArguments(v));
         }
+    }
+
+    private List<ImTypeArgument> genericStaticTypeArguments(ImVar v) {
+        ImClass owner = genericStaticOwner.get(v);
+        if (owner == null) {
+            return Collections.emptyList();
+        }
+
+        ImClassType receiver = currentReceiverInstantiationFor(owner);
+        if (receiver != null && receiver.getClassDef() == owner) {
+            return copyTypeArguments(receiver.getTypeArguments());
+        }
+
+        List<ImTypeArgument> result = new ArrayList<>();
+        for (ImTypeVar typeVar : owner.getTypeVariables()) {
+            ImType resolved = resolveType(JassIm.ImTypeVarRef(typeVar));
+            if (resolved instanceof ImTypeVarRef) {
+                return Collections.emptyList();
+            }
+            result.add(JassIm.ImTypeArgument(resolved, Collections.emptyMap()));
+        }
+        return result;
+    }
+
+    private static List<ImTypeArgument> copyTypeArguments(ImTypeArguments typeArguments) {
+        List<ImTypeArgument> result = new ArrayList<>(typeArguments.size());
+        for (ImTypeArgument typeArgument : typeArguments) {
+            result.add(typeArgument.copy());
+        }
+        return result;
     }
 
     /** Snapshot of an array's explicitly initialized entries for compiletime migration. */
@@ -777,17 +809,39 @@ public class ProgramState extends State implements AutoCloseable {
         return getArray(v);
     }
 
-    public Collection<ILconstArray> getArrayValues(ImVar v) {
+    public static final class ArrayState {
+        private final ILconstArray value;
+        private final List<ImTypeArgument> typeArguments;
+
+        public ArrayState(ILconstArray value, List<ImTypeArgument> typeArguments) {
+            this.value = value;
+            this.typeArguments = typeArguments;
+        }
+
+        public ILconstArray getValue() {
+            return value;
+        }
+
+        public List<ImTypeArgument> getTypeArguments() {
+            return typeArguments;
+        }
+    }
+
+    public Collection<ArrayState> getArrayStates(ImVar v) {
         String prefix = v.getName() + "|";
-        List<ILconstArray> result = new ArrayList<>();
-        for (String key : modifiedGenericArrays) {
+        List<String> keys = new ArrayList<>(modifiedGenericArrays);
+        Collections.sort(keys);
+        List<ArrayState> result = new ArrayList<>();
+        for (String key : keys) {
             if (key.startsWith(prefix)) {
                 ILconstArray value = genericStaticArrays.get(key);
-                if (value != null) result.add(value);
+                if (value != null) {
+                    result.add(new ArrayState(value, genericArrayTypeArguments.getOrDefault(key, Collections.emptyList())));
+                }
             }
         }
         if (result.isEmpty() && genericStaticKey(v) == null) {
-            result.add(getArray(v));
+            result.add(new ArrayState(getArray(v), Collections.emptyList()));
         }
         return result;
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/State.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/State.java
@@ -10,6 +10,8 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 
 /**
  * Lazily allocates internal maps ONLY when needed.
@@ -19,6 +21,7 @@ public abstract class State {
     // in State:
     private @Nullable Object2ObjectOpenHashMap<ImVar, ILconst> values;
     private @Nullable Object2ObjectOpenHashMap<ImVar, ILconstArray> arrayValues;
+    private final Set<ImVar> modifiedArrays = new HashSet<>();
 
 
     private Object2ObjectOpenHashMap<ImVar, ILconst> ensureValues() {
@@ -77,11 +80,16 @@ public abstract class State {
     }
 
     public void setArrayVal(ImVar v, List<Integer> indexes, ILconst val) {
+        modifiedArrays.add(v);
         ILconstArray ar = getArray(v);
         for (int i = 0; i < indexes.size() - 1; i++) {
             ar = (ILconstArray) ar.get(indexes.get(i));
         }
         ar.set(indexes.get(indexes.size() - 1), val);
+    }
+
+    public Set<ImVar> getModifiedArrays() {
+        return modifiedArrays;
     }
 
     public @Nullable ILconst getArrayVal(ImVar v, List<Integer> indexes) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/State.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/State.java
@@ -8,10 +8,13 @@ import de.peeeq.wurstscript.jassIm.*;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.eclipse.jdt.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.HashSet;
 
 /**
  * Lazily allocates internal maps ONLY when needed.
@@ -21,7 +24,7 @@ public abstract class State {
     // in State:
     private @Nullable Object2ObjectOpenHashMap<ImVar, ILconst> values;
     private @Nullable Object2ObjectOpenHashMap<ImVar, ILconstArray> arrayValues;
-    private final Set<ImVar> modifiedArrays = new HashSet<>();
+    private final Map<ImVar, Set<List<Integer>>> modifiedArrayIndexes = new IdentityHashMap<>();
 
 
     private Object2ObjectOpenHashMap<ImVar, ILconst> ensureValues() {
@@ -80,7 +83,8 @@ public abstract class State {
     }
 
     public void setArrayVal(ImVar v, List<Integer> indexes, ILconst val) {
-        modifiedArrays.add(v);
+        modifiedArrayIndexes.computeIfAbsent(v, ignored -> new HashSet<>())
+            .add(Collections.unmodifiableList(new ArrayList<>(indexes)));
         ILconstArray ar = getArray(v);
         for (int i = 0; i < indexes.size() - 1; i++) {
             ar = (ILconstArray) ar.get(indexes.get(i));
@@ -89,7 +93,11 @@ public abstract class State {
     }
 
     public Set<ImVar> getModifiedArrays() {
-        return modifiedArrays;
+        return modifiedArrayIndexes.keySet();
+    }
+
+    public Set<List<Integer>> getModifiedArrayIndexes(ImVar v) {
+        return modifiedArrayIndexes.getOrDefault(v, Collections.emptySet());
     }
 
     public @Nullable ILconst getArrayVal(ImVar v, List<Integer> indexes) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/FunctionSplitter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/FunctionSplitter.java
@@ -34,7 +34,6 @@ public class FunctionSplitter {
     }
 
     private void optimize() {
-        Preconditions.checkArgument(func.getTypeVariables().isEmpty(), "func must not be generic");
         Preconditions.checkArgument(func.getParameters().isEmpty(), "func parameters must be empty");
         Preconditions.checkArgument(func.getReturnType() instanceof ImVoid, "func must return void");
         // run some basic optimizations first:
@@ -47,6 +46,10 @@ public class FunctionSplitter {
         Set<ImVar> usedVars = UsedVariables.calculate(func);
         func.getLocals().removeIf(v -> !usedVars.contains(v));
         func.flatten(tr);
+        boolean generic = !func.getTypeVariables().isEmpty();
+        Preconditions.checkArgument(!generic || func.getLocals().isEmpty(),
+            "generic split functions must not have locals");
+        ImFunction genericTemplate = generic ? func.copyWithRefs() : null;
         List<List<ImStmt>> splitResult = split(func.getBody().removeAll());
 
         ImProg prog = tr.getImProg();
@@ -55,19 +58,29 @@ public class FunctionSplitter {
 
         // create helper functions
         List<ImFunction> helperFuncs = new ArrayList<>();
+        int statementOffset = 0;
         for (int i = 0; i < splitResult.size(); i++) {
             List<ImStmt> stmts = splitResult.get(i);
-            ImFunction helperFunc = JassIm.ImFunction(
-                func.getTrace(),
-                func.getName() + "_" + i,
-                JassIm.ImTypeVars(),
-                JassIm.ImVars(),
-                JassIm.ImVoid(),
-                JassIm.ImVars(),
-                JassIm.ImStmts(stmts),
-                Collections.emptyList()
-            );
+            ImFunction helperFunc;
+            if (generic) {
+                helperFunc = genericTemplate.copyWithRefs();
+                List<ImStmt> copiedStatements = helperFunc.getBody().removeAll();
+                helperFunc.getBody().addAll(copiedStatements.subList(statementOffset, statementOffset + stmts.size()));
+                helperFunc.setName(func.getName() + "_" + i);
+            } else {
+                helperFunc = JassIm.ImFunction(
+                    func.getTrace(),
+                    func.getName() + "_" + i,
+                    JassIm.ImTypeVars(),
+                    JassIm.ImVars(),
+                    JassIm.ImVoid(),
+                    JassIm.ImVars(),
+                    JassIm.ImStmts(stmts),
+                    Collections.emptyList()
+                );
+            }
             helperFuncs.add(helperFunc);
+            statementOffset += stmts.size();
         }
         prog.getFunctions().addAll(helperFuncs);
 
@@ -76,12 +89,20 @@ public class FunctionSplitter {
             func.getBody().add(JassIm.ImFunctionCall(
                 func.getTrace(),
                 helperFunc,
-                JassIm.ImTypeArguments(),
+                typeArgumentsForCurrentFunction(),
                 JassIm.ImExprs(),
                 false,
                 CallType.EXECUTE
             ));
         }
+    }
+
+    private ImTypeArguments typeArgumentsForCurrentFunction() {
+        ImTypeArguments result = JassIm.ImTypeArguments();
+        for (ImTypeVar typeVar : func.getTypeVariables()) {
+            result.add(JassIm.ImTypeArgument(JassIm.ImTypeVarRef(typeVar), Collections.emptyMap()));
+        }
+        return result;
     }
 
     private List<List<ImStmt>> split(List<ImStmt> body) {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -76,8 +76,39 @@ public class CompiletimeTests extends WurstScriptTest {
     }
 
     @Test
+    public void testCompiletimeArrayStateLua() {
+        test().testLua(true).executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("package Test",
+                   "native testSuccess()",
+                   "int array source",
+                   "@compiletime function fill()",
+                   "    source[0] = 42",
+                   "init",
+                   "    if source[0] == 42",
+                   "        testSuccess()");
+    }
+
+    @Test
     public void testCompiletimeGenericArrayState() {
         test().executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("package Test",
+                   "native testSuccess()",
+                   "class Box<T:>",
+                   "    static T array store",
+                   "    static function set(int index, T value)",
+                   "        store[index] = value",
+                   "    static function get(int index) returns T",
+                   "        return store[index]",
+                   "@compiletime function fill()",
+                   "    Box<int>.set(0, 42)",
+                   "init",
+                   "    if Box<int>.get(0) == 42",
+                   "        testSuccess()");
+    }
+
+    @Test
+    public void testCompiletimeGenericArrayStateLua() {
+        test().testLua(true).executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
             .lines("package Test",
                    "native testSuccess()",
                    "class Box<T:>",
@@ -96,7 +127,7 @@ public class CompiletimeTests extends WurstScriptTest {
 
     @Test
     public void testCompiletimeHashtable() {
-        test()
+        test().executeProg(true).executeProgOnlyAfterTransforms()
                 .runCompiletimeFunctions(true)
                 .lines("type agent extends handle",
                         "type hashtable extends agent",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -64,7 +64,7 @@ public class CompiletimeTests extends WurstScriptTest {
 
     @Test
     public void testCompiletimeArrayState() {
-        test().runCompiletimeFunctions(true)
+        test().executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
             .lines("package Test",
                    "native testSuccess()",
                    "int array source",
@@ -73,6 +73,24 @@ public class CompiletimeTests extends WurstScriptTest {
                    "init",
                    "    if source[0] == 42",
                        "        testSuccess()");
+    }
+
+    @Test
+    public void testCompiletimeGenericArrayState() {
+        test().executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("package Test",
+                   "native testSuccess()",
+                   "class Box<T:>",
+                   "    static T array store",
+                   "    static function set(int index, T value)",
+                   "        store[index] = value",
+                   "    static function get(int index) returns T",
+                   "        return store[index]",
+                   "@compiletime function fill()",
+                   "    Box<int>.set(0, 42)",
+                   "init",
+                   "    if Box<int>.get(0) == 42",
+                   "        testSuccess()");
     }
 
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -137,6 +137,67 @@ public class CompiletimeTests extends WurstScriptTest {
                    "        testSuccess()");
     }
 
+    @Test
+    public void testCompiletimeObjectArrayState() {
+        test().executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("package Test",
+                   "native testSuccess()",
+                   "class A",
+                   "    int value",
+                   "A array source",
+                   "@compiletime function fill()",
+                   "    source[0] = new A",
+                   "    source[0].value = 42",
+                   "init",
+                   "    if source[0].value == 42",
+                   "        testSuccess()");
+    }
+
+    @Test
+    public void testCompiletimeHashtableArrayState() {
+        test().executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("type agent extends handle",
+                   "type hashtable extends agent",
+                   "package Test",
+                   "native testSuccess()",
+                   "@extern native InitHashtable() returns hashtable",
+                   "@extern native LoadInteger(hashtable h, int p, int c) returns int",
+                   "@extern native SaveInteger(hashtable h, int p, int c, int i)",
+                   "hashtable array source",
+                   "@compiletime function fill()",
+                   "    source[0] = InitHashtable()",
+                   "    SaveInteger(source[0], 2, 3, 42)",
+                   "init",
+                   "    if LoadInteger(source[0], 2, 3) == 42",
+                   "        testSuccess()");
+    }
+
+    @Test
+    public void testCompiletimeNullArrayState() {
+        test().executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("package Test",
+                   "native testSuccess()",
+                   "string array source = [\"value\"]",
+                   "@compiletime function clear()",
+                   "    source[0] = null",
+                   "init",
+                   "    if source[0] == null",
+                   "        testSuccess()");
+    }
+
+    @Test
+    public void testCompiletimeTupleArrayState() {
+        test().executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("package Test",
+                   "native testSuccess()",
+                   "tuple pair(int left, int right)",
+                   "pair array source",
+                   "@compiletime function fill()",
+                   "    source[0] = pair(42, 7)",
+                   "init",
+                   "    if source[0].left == 42 and source[0].right == 7",
+                   "        testSuccess()");
+    }
 
     @Test
     public void testCompiletimeHashtable() {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -62,12 +62,26 @@ public class CompiletimeTests extends WurstScriptTest {
                         "        testSuccess()");
     }
 
+    @Test
+    public void testCompiletimeArrayState() {
+        test().executeProg(true)
+            .runCompiletimeFunctions(true)
+            .executeProgOnlyAfterTransforms()
+            .lines("package Test",
+                   "native testSuccess()",
+                   "int array source",
+                   "@compiletime function fill()",
+                   "    source[3] = 42",
+                   "init",
+                   "    if source[3] == 42",
+                       "        testSuccess()");
+    }
+
 
     @Test
     public void testCompiletimeHashtable() {
-        test().executeProg(true)
+        test()
                 .runCompiletimeFunctions(true)
-                .executeProgOnlyAfterTransforms()
                 .lines("type agent extends handle",
                         "type hashtable extends agent",
                         "package Test",
@@ -175,6 +189,26 @@ public class CompiletimeTests extends WurstScriptTest {
                         "init",
                         "    if a.x == \"schwardemage\" and a.y == 42",
                         "        testSuccess()");
+    }
+
+    @Test
+    public void testPersistCompiletimeNewGenericClass() {
+        // Translation is the assertion here: executing the synthesized generic
+        // runtime global through the interpreter still needs a separate attachment fix.
+        test()
+                .runCompiletimeFunctions(true)
+                .lines("package Test",
+                        "class PureMap<T:>",
+                        "    T value",
+                        "    function put(T value)",
+                        "        this.value = value",
+                        "    function get() returns T",
+                        "        return value",
+                        "function compiletime<T:>(T value) returns T",
+                        "    return value",
+                        "PureMap<int> map = compiletime(new PureMap<int>)",
+                        "@compiletime function populate()",
+                        "    map.put(42)");
     }
 
     @Test

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -64,16 +64,14 @@ public class CompiletimeTests extends WurstScriptTest {
 
     @Test
     public void testCompiletimeArrayState() {
-        test().executeProg(true)
-            .runCompiletimeFunctions(true)
-            .executeProgOnlyAfterTransforms()
+        test().runCompiletimeFunctions(true)
             .lines("package Test",
                    "native testSuccess()",
                    "int array source",
                    "@compiletime function fill()",
-                   "    source[3] = 42",
+                   "    source[0] = 42",
                    "init",
-                   "    if source[3] == 42",
+                   "    if source[0] == 42",
                        "        testSuccess()");
     }
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -240,6 +240,22 @@ public class CompiletimeTests extends WurstScriptTest {
     }
 
     @Test
+    public void testCompiletimeArrayReplayPrecedesDependentInitializer() {
+        test().testLua(true).executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("package Test",
+                   "native testSuccess()",
+                   "int array first = [1]",
+                   "int observed = first[0]",
+                   "int array second = [2]",
+                   "@compiletime function fill()",
+                   "    first[0] = 42",
+                   "    second[0] = 9",
+                   "init",
+                   "    if observed == 42 and first[0] == 42 and second[0] == 9",
+                   "        testSuccess()");
+    }
+
+    @Test
     public void testCompiletimeHashtable() {
         test().executeProg(true).executeProgOnlyAfterTransforms()
                 .runCompiletimeFunctions(true)

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -256,6 +256,25 @@ public class CompiletimeTests extends WurstScriptTest {
     }
 
     @Test
+    public void testCompiletimeArrayReplayOnlyWrittenEntries() {
+        test().testLua(true).executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("package A",
+                   "public int seed = 1",
+                   "init",
+                   "    seed = 2",
+                   "endpackage",
+                   "package B",
+                   "import A",
+                   "native testSuccess()",
+                   "int array source = [seed, 0]",
+                   "@compiletime function fill()",
+                   "    source[1] = 42",
+                   "init",
+                   "    if source[0] == 2 and source[1] == 42",
+                   "        testSuccess()");
+    }
+
+    @Test
     public void testCompiletimeHashtable() {
         test().executeProg(true).executeProgOnlyAfterTransforms()
                 .runCompiletimeFunctions(true)

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -76,11 +76,24 @@ public class CompiletimeTests extends WurstScriptTest {
     }
 
     @Test
+    public void testCompiletimeArrayStateAfterSourceInitializer() {
+        test().executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("package Test",
+                   "native testSuccess()",
+                   "int array source = [1]",
+                   "@compiletime function fill()",
+                   "    source[0] = 42",
+                   "init",
+                   "    if source[0] == 42",
+                   "        testSuccess()");
+    }
+
+    @Test
     public void testCompiletimeArrayStateLua() {
         test().testLua(true).executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
             .lines("package Test",
                    "native testSuccess()",
-                   "int array source",
+                   "int array source = [1]",
                    "@compiletime function fill()",
                    "    source[0] = 42",
                    "init",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompiletimeTests.java
@@ -200,6 +200,46 @@ public class CompiletimeTests extends WurstScriptTest {
     }
 
     @Test
+    public void testCompiletimeArrayStateAcrossPackages() {
+        test().executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("package A",
+                   "public int array source = [1]",
+                   "@compiletime function fillA()",
+                   "    source[0] = 42",
+                   "init",
+                   "    source[0] = 7",
+                   "endpackage",
+                   "package B",
+                   "import A",
+                   "native testSuccess()",
+                   "init",
+                   "    if source[0] == 7",
+                   "        testSuccess()");
+    }
+
+    @Test
+    public void testCompiletimeArrayStateAcrossPackagesWithTwoInitializers() {
+        test().executeProg(true).executeProgOnlyAfterTransforms().runCompiletimeFunctions(true)
+            .lines("package A",
+                   "public int array source = [1]",
+                   "@compiletime function fillA()",
+                   "    source[0] = 42",
+                   "init",
+                   "    source[0] = 7",
+                   "endpackage",
+                   "package B",
+                   "import A",
+                   "int array other = [2]",
+                   "@compiletime function fillB()",
+                   "    other[0] = 9",
+                   "native testSuccess()",
+                   "init",
+                   "    if source[0] == 7 and other[0] == 9",
+                   "        testSuccess()",
+                   "endpackage");
+    }
+
+    @Test
     public void testCompiletimeHashtable() {
         test().executeProg(true).executeProgOnlyAfterTransforms()
                 .runCompiletimeFunctions(true)

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -54,6 +54,59 @@ public class LuaBackendAuditTests extends WurstScriptTest {
     }
 
     @Test
+    public void compiletimeGenericArrayReplayLeavesAreSplit() {
+        String compiled = compileLuaWithRunArgs(
+            "compiletimeGenericArrayReplayLeavesAreSplit",
+            new RunArgs().with("-lua", "-runcompiletimefunctions", "-functionSplitLimit", "1"),
+            "package Test",
+            "class Box<T:>",
+            "    static T array store",
+            "    static function set(int index, T value)",
+            "        store[index] = value",
+            "    static function get(int index) returns T",
+            "        return store[index]",
+            "@compiletime function fill()",
+            "    Box<int>.set(0, 10)",
+            "    Box<int>.set(1, 20)",
+            "    Box<int>.set(2, 30)",
+            "native testSuccess()",
+            "init",
+            "    if Box<int>.get(0) + Box<int>.get(1) + Box<int>.get(2) == 60",
+            "        testSuccess()"
+        );
+
+        java.util.regex.Matcher replayBody = java.util.regex.Pattern
+            .compile("function initCompiletimeArrayState[^\\n]*\\n(.*?)\\nend", java.util.regex.Pattern.DOTALL)
+            .matcher(compiled);
+        int persistedAssignments = 0;
+        while (replayBody.find()) {
+            int assignmentsInFunction = countOccurrences(replayBody.group(1), "Box_store[");
+            assertTrue("each generic replay leaf must honor the configured split limit:\n" + replayBody.group(),
+                assignmentsInFunction <= 1);
+            persistedAssignments += assignmentsInFunction;
+        }
+        assertEquals("all generic compiletime array entries must still be emitted", 3, persistedAssignments);
+    }
+
+    @Test
+    public void compiletimeArrayReplaySplittingIsDeterministicAcrossPackages() {
+        RunArgs runArgs = new RunArgs().with(
+            "-lua", "-runcompiletimefunctions", "-functionSplitLimit", "1");
+        String[] source = {
+            "package A", "public int array a = [1]", "@compiletime function fillA()", "    a[0] = 10", "endpackage",
+            "package B", "public int array b = [1]", "@compiletime function fillB()", "    b[0] = 20", "endpackage",
+            "package C", "public int array c = [1]", "@compiletime function fillC()", "    c[0] = 30", "endpackage",
+            "package D", "public int array d = [1]", "@compiletime function fillD()", "    d[0] = 40", "endpackage",
+            "package Test", "import A", "import B", "import C", "import D", "native testSuccess()", "init",
+            "    if a[0] + b[0] + c[0] + d[0] == 100", "        testSuccess()"
+        };
+
+        String first = compileLuaWithRunArgs("compiletimeArrayReplaySplittingIsDeterministicAcrossPackages", runArgs, source);
+        String second = compileLuaWithRunArgs("compiletimeArrayReplaySplittingIsDeterministicAcrossPackages", runArgs, source);
+        assertEquals("compiletime replay splitting must not depend on identity-hash iteration", first, second);
+    }
+
+    @Test
     public void localPlayerEffectfulBooleanOperandSurvivesOptimization() {
         String compiled = compileOptimizedLua(
             "localPlayerEffectfulBooleanOperandSurvivesOptimization",


### PR DESCRIPTION
Adds runtime migration for explicitly initialized global array state produced by compiletime functions, including nested arrays, with deterministic emission. Documents the behavior and adds compiletime array plus generic-object translation coverage.

Focused test:
`./gradlew.bat test --tests "tests.wurstscript.tests.CompiletimeTests.testCompiletimeArrayState"`
