### PR TITLE
Fix generic field toIndex assignments

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrExprExpectedType.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrExprExpectedType.java
@@ -37,7 +37,7 @@ public class AttrExprExpectedType {
             } else if (parent instanceof StmtSet) {
                 StmtSet stmtSet = (StmtSet) parent;
                 if (stmtSet.getRight() == expr) {
-                    return stmtSet.getUpdatedExpr().attrTyp();
+                    return stmtSet.getUpdatedExpr().attrTypRaw();
                 } else if (stmtSet.getUpdatedExpr() == expr) {
                     return WurstTypeUnknown.instance();
                 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/GenericsTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/GenericsTests.java
@@ -959,6 +959,25 @@ public class GenericsTests extends WurstScriptTest {
     }
 
     @Test
+    public void genericToIndexFieldAssignment() { // #647
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "class C<T>",
+            "    T x",
+            "function stringToIndex(string s) returns int",
+            "    return 42",
+            "function stringFromIndex(int i) returns string",
+            "    return \"42\"",
+            "init",
+            "    C<string> c = new C<string>",
+            "    c.x = \"42\"",
+            "    if c.x == \"42\"",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
     public void extensionFunc() { // #718
         testAssertOkLines(false,
             "package test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -1374,6 +1374,25 @@ public class LuaTranslationTests extends WurstScriptTest {
     }
 
     @Test
+    public void legacyGenericToIndexFieldAssignmentRoundTripsInLua() {
+        test().testLua(true).executeProg().lines(
+            "package test",
+            "native testSuccess()",
+            "class C<T>",
+            "    T x",
+            "function stringToIndex(string s) returns int",
+            "    return 42",
+            "function stringFromIndex(int i) returns string",
+            "    return \"42\"",
+            "init",
+            "    C<string> c = new C<string>",
+            "    c.x = \"42\"",
+            "    if c.x == \"42\"",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
     public void genericOverrideChainBindsRootSlotToMostSpecificImplInLua() throws IOException {
         test().testLua(true).compilationUnits(genericOverrideReproUnits());
         String compiled = Files.toString(new File("test-output/lua/LuaTranslationTests_genericOverrideChainBindsRootSlotToMostSpecificImplInLua.lua"), Charsets.UTF_8);


### PR DESCRIPTION
## Summary

- preserve the raw expected type when translating assignment right-hand sides
- restore legacy generic `toIndex` conversion for field assignments
- cover the exact issue reproduction on Jass and Lua

## Root cause

Assignment expected-type inference normalized the target type before IM translation. For a legacy generic field, that erased the bound type parameter which carries the `stringToIndex` conversion, so Jass emitted a string assignment into an integer-backed field.

## Validation

- `./gradlew test --tests "tests.wurstscript.tests.GenericsTests.genericToIndexFieldAssignment" --tests "tests.wurstscript.tests.LuaTranslationTests.legacyGenericToIndexFieldAssignmentRoundTripsInLua"`
- `./gradlew test --tests "tests.wurstscript.tests.GenericsTests" --tests "tests.wurstscript.tests.LuaTranslationTests"`

Closes #647
