### PR TITLE
Add compile-time field iteration for serialization

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManagerImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManagerImpl.java
@@ -7,6 +7,7 @@ import de.peeeq.wurstio.ModelChangedException;
 import de.peeeq.wurstio.WurstCompilerJassImpl;
 import de.peeeq.wurstio.utils.FileUtils;
 import de.peeeq.wurstscript.RunArgs;
+import de.peeeq.wurstscript.SyntacticSugar;
 import de.peeeq.wurstscript.WLogger;
 import de.peeeq.wurstscript.ast.*;
 import de.peeeq.wurstscript.attributes.CompileError;
@@ -97,6 +98,7 @@ public class ModelManagerImpl implements ModelManager {
                 }
             }
             GlobalCaches.clearLookupCacheFor(toRemove);
+            toRemove.forEach(SyntacticSugar::restoreDirectFieldIterations);
             model2.removeAll(toRemove);
         }
 
@@ -117,6 +119,7 @@ public class ModelManagerImpl implements ModelManager {
 
     @Override
     public void clean() {
+        SyntacticSugar.clearDirectFieldIterations();
         fileHashcodes.clear();
         parseErrors.clear();
         model = null;
@@ -267,6 +270,7 @@ public class ModelManagerImpl implements ModelManager {
     }
 
     private void clearCompilationUnit(CompilationUnit cu) {
+        SyntacticSugar.restoreDirectFieldIterations(cu);
         cu.clearAttributes();
         // clear module instantiations
         for (WPackage p : cu.getPackages()) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManagerImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ModelManagerImpl.java
@@ -119,7 +119,6 @@ public class ModelManagerImpl implements ModelManager {
 
     @Override
     public void clean() {
-        SyntacticSugar.clearDirectFieldIterations();
         fileHashcodes.clear();
         parseErrors.clear();
         model = null;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -3,6 +3,7 @@ package de.peeeq.wurstscript;
 import com.google.common.collect.Maps;
 import de.peeeq.wurstscript.ast.*;
 import de.peeeq.wurstscript.parser.WPos;
+import de.peeeq.wurstscript.types.WurstTypeClass;
 
 import java.util.*;
 
@@ -24,9 +25,17 @@ public class SyntacticSugar {
         }
         rewriteNegatedInts(root);
         addDefaultConstructors(root);
-        expandFieldIterations(root);
         addEndFunctionStatements(root);
         replaceTypeIdUse(root);
+    }
+
+    /**
+     * Expands field iteration after module methods have been copied into their consuming classes.
+     * This must run after {@link ModuleExpander#expandModules(CompilationUnit)} so a module callback can
+     * see all fields of the concrete class using it.
+     */
+    public void expandFieldIterations(CompilationUnit root) {
+        expandFieldIterationsInTree(root);
     }
 
     /**
@@ -39,7 +48,7 @@ public class SyntacticSugar {
      * __wurst_mapFields((name, value) -> reader.read(name, value))
      * </pre>
      */
-    private void expandFieldIterations(CompilationUnit root) {
+    private void expandFieldIterationsInTree(CompilationUnit root) {
         List<ExprFunctionCall> calls = new ArrayList<>();
         root.accept(new WurstModel.DefaultVisitor() {
             @Override
@@ -63,7 +72,18 @@ public class SyntacticSugar {
             return;
         }
         ClassDef classDef = call.attrNearestClassDef();
-        if (classDef == null || !call.attrIsDynamicContext()) {
+        ClassOrModule owner = call.attrNearestClassOrModule();
+        if (!call.attrIsDynamicContext()) {
+            call.addError(call.getFuncName() + " can only be used in an instance method or constructor.");
+            return;
+        }
+        if (owner instanceof ModuleDef) {
+            // Module bodies are templates. Their copies were made by ModuleExpander; validate and
+            // expand those concrete copies instead of type-checking this uninstantiated template.
+            statements.remove(call);
+            return;
+        }
+        if (classDef == null) {
             call.addError(call.getFuncName() + " can only be used in an instance method or constructor.");
             return;
         }
@@ -95,12 +115,7 @@ public class SyntacticSugar {
             call.addError("forFields closure must produce a statement expression.");
             return;
         }
-        List<GlobalVarDef> fields = new ArrayList<>();
-        for (GlobalVarDef field : classDef.getVars()) {
-            if (!field.attrIsStatic()) {
-                fields.add(field);
-            }
-        }
+        List<GlobalVarDef> fields = collectInstanceFields(classDef, owner);
         if (fields.isEmpty()) {
             call.addError(call.getFuncName() + " requires at least one instance field.");
             return;
@@ -119,6 +134,36 @@ public class SyntacticSugar {
                 expanded = (WStatement) implementation;
             }
             statements.add(statementIndex++, expanded);
+        }
+    }
+
+    private List<GlobalVarDef> collectInstanceFields(ClassDef classDef, ClassOrModule owner) {
+        List<GlobalVarDef> fields = new ArrayList<>();
+        if (classDef != null) {
+            collectInheritedFields(classDef.attrTypC(), fields, Collections.newSetFromMap(new IdentityHashMap<>()));
+        } else if (owner instanceof ModuleDef moduleDef) {
+            addInstanceFields(moduleDef.getVars(), fields);
+        }
+        return fields;
+    }
+
+    private void collectInheritedFields(WurstTypeClass type,
+                                        List<GlobalVarDef> fields, Set<ClassDef> visited) {
+        if (!visited.add(type.getClassDef())) {
+            return;
+        }
+        WurstTypeClass superType = type.extendedClass();
+        if (superType != null) {
+            collectInheritedFields(superType, fields, visited);
+        }
+        addInstanceFields(type.getClassDef().getVars(), fields);
+    }
+
+    private void addInstanceFields(Iterable<GlobalVarDef> declarations, List<GlobalVarDef> fields) {
+        for (GlobalVarDef field : declarations) {
+            if (!field.attrIsStatic()) {
+                fields.add(field);
+            }
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -18,16 +18,42 @@ public class SyntacticSugar {
     /** Compiler-reserved spelling keeps ordinary user functions named forFields/mapFields valid. */
     private static final String FOR_FIELDS = "__wurst_forFields";
     private static final String MAP_FIELDS = "__wurst_mapFields";
+    private static final Map<CompilationUnit, List<DeferredModuleCall>> DETACHED_DIRECT_CALLS =
+        Collections.synchronizedMap(new WeakHashMap<>());
 
     public static final class DeferredModuleCall {
         private final WStatements statements;
         private final int index;
         private final ExprFunctionCall call;
+        private final List<WStatement> generatedStatements;
 
         private DeferredModuleCall(WStatements statements, int index, ExprFunctionCall call) {
+            this(statements, index, call, List.of());
+        }
+
+        private DeferredModuleCall(WStatements statements, int index, ExprFunctionCall call,
+                                   List<WStatement> generatedStatements) {
             this.statements = statements;
             this.index = index;
             this.call = call;
+            this.generatedStatements = generatedStatements;
+        }
+    }
+
+    private static final class FieldInfo {
+        private final GlobalVarDef declaration;
+        private final List<String> modulePath;
+
+        private FieldInfo(GlobalVarDef declaration, List<String> modulePath) {
+            this.declaration = declaration;
+            this.modulePath = List.copyOf(modulePath);
+        }
+
+        private String key() {
+            if (modulePath.isEmpty()) {
+                return declaration.getName();
+            }
+            return String.join(".", modulePath) + "." + declaration.getName();
         }
     }
 
@@ -57,7 +83,23 @@ public class SyntacticSugar {
      * see all fields of the concrete class using it.
      */
     public void expandFieldIterations(CompilationUnit root) {
-        expandFieldIterationsInTree(root);
+        List<DeferredModuleCall> detached = expandFieldIterationsInTree(root);
+        if (!detached.isEmpty()) {
+            DETACHED_DIRECT_CALLS.put(root, detached);
+        }
+    }
+
+    /** Restores source intrinsics before an incremental compilation-unit recheck. */
+    public static void restoreDirectFieldIterations(CompilationUnit root) {
+        List<DeferredModuleCall> detached = DETACHED_DIRECT_CALLS.remove(root);
+        if (detached != null) {
+            new SyntacticSugar().restoreModuleTemplateFieldIterations(detached);
+        }
+    }
+
+    /** Drops saved source intrinsics when the whole language-server model is discarded. */
+    public static void clearDirectFieldIterations() {
+        DETACHED_DIRECT_CALLS.clear();
     }
 
     /** Temporarily removes template intrinsics while validation runs; callers must restore them. */
@@ -84,6 +126,9 @@ public class SyntacticSugar {
     public void restoreModuleTemplateFieldIterations(List<DeferredModuleCall> detached) {
         for (int i = detached.size() - 1; i >= 0; i--) {
             DeferredModuleCall state = detached.get(i);
+            for (WStatement generated : state.generatedStatements) {
+                state.statements.remove(generated);
+            }
             int index = Math.min(state.index, state.statements.size());
             state.statements.add(index, state.call);
         }
@@ -99,7 +144,7 @@ public class SyntacticSugar {
      * __wurst_mapFields((name, value) -> reader.read(name, value))
      * </pre>
      */
-    private void expandFieldIterationsInTree(CompilationUnit root) {
+    private List<DeferredModuleCall> expandFieldIterationsInTree(CompilationUnit root) {
         List<ExprFunctionCall> calls = new ArrayList<>();
         root.accept(new WurstModel.DefaultVisitor() {
             @Override
@@ -111,12 +156,16 @@ public class SyntacticSugar {
             }
         });
 
+        List<DeferredModuleCall> detached = new ArrayList<>();
         for (ExprFunctionCall call : calls) {
-            expandFieldIteration(call, MAP_FIELDS.equals(call.getFuncName()));
+            expandFieldIteration(call, MAP_FIELDS.equals(call.getFuncName()), detached);
         }
+        return detached;
     }
 
-    private void expandFieldIteration(ExprFunctionCall call, boolean assignsResult) {
+    private void expandFieldIteration(ExprFunctionCall call,
+                                      boolean assignsResult,
+                                      List<DeferredModuleCall> detached) {
         if (!(call.getParent() instanceof WStatements statements)) {
             call.addError(call.getFuncName() + " can only be used as a statement.");
             return;
@@ -164,42 +213,48 @@ public class SyntacticSugar {
             call.addError("forFields closure must produce a statement expression.");
             return;
         }
-        List<GlobalVarDef> fields = collectInstanceFields(classDef, owner);
+        List<FieldInfo> fields = collectInstanceFields(classDef, owner);
         if (fields.isEmpty()) {
             call.addError(call.getFuncName() + " requires at least one instance field.");
             return;
         }
         int statementIndex = statements.indexOf(call);
+        detached.add(new DeferredModuleCall(statements, statementIndex, call));
         statements.remove(statementIndex);
 
-        for (GlobalVarDef field : fields) {
-            Expr fieldAccess = fieldAccess(call.getSource(), field.getName());
+        List<WStatement> generatedStatements = new ArrayList<>(fields.size());
+        for (FieldInfo field : fields) {
+            String fieldKey = field.key();
+            Expr fieldAccess = fieldAccess(call.getSource(), field);
             Expr implementation = substituteFieldParameters(
-                closure.getImplementation().copy(), nameParameter, valueParameter, field.getName());
+                closure.getImplementation().copy(), nameParameter, valueParameter, fieldKey, field);
             WStatement expanded;
             if (assignsResult) {
                 expanded = Ast.StmtSet(call.getSource(), (LExpr) fieldAccess, implementation);
             } else {
                 expanded = (WStatement) implementation;
             }
+            generatedStatements.add(expanded);
             statements.add(statementIndex++, expanded);
         }
+        detached.set(detached.size() - 1,
+            new DeferredModuleCall(statements, statementIndex - fields.size(), call, generatedStatements));
     }
 
-    private List<GlobalVarDef> collectInstanceFields(ClassDef classDef, ClassOrModule owner) {
-        List<GlobalVarDef> fields = new ArrayList<>();
+    private List<FieldInfo> collectInstanceFields(ClassDef classDef, ClassOrModule owner) {
+        List<FieldInfo> fields = new ArrayList<>();
         if (classDef != null) {
             collectInheritedFields(classDef.attrTypC(), fields, classDef,
                 Collections.newSetFromMap(new IdentityHashMap<>()),
                 Collections.newSetFromMap(new IdentityHashMap<>()));
         } else if (owner instanceof ModuleDef moduleDef) {
-            addInstanceFields(moduleDef.getVars(), fields, null);
+            addInstanceFields(moduleDef.getVars(), fields, null, List.of());
         }
         return fields;
     }
 
     private void collectInheritedFields(WurstTypeClass type,
-                                        List<GlobalVarDef> fields,
+                                        List<FieldInfo> fields,
                                         ClassDef concreteClass,
                                         Set<ClassDef> visitedClasses,
                                         Set<ModuleInstanciation> visitedModules) {
@@ -210,32 +265,40 @@ public class SyntacticSugar {
         if (superType != null) {
             collectInheritedFields(superType, fields, concreteClass, visitedClasses, visitedModules);
         }
-        addModuleFields(type.getClassDef().getModuleInstanciations(), fields, concreteClass, visitedModules);
-        addInstanceFields(type.getClassDef().getVars(), fields, concreteClass);
+        addModuleFields(type.getClassDef().getModuleInstanciations(), fields, concreteClass,
+            visitedModules, List.of());
+        addInstanceFields(type.getClassDef().getVars(), fields, concreteClass, List.of());
     }
 
     private void addModuleFields(Iterable<ModuleInstanciation> modules,
-                                 List<GlobalVarDef> fields,
+                                 List<FieldInfo> fields,
                                  ClassDef concreteClass,
-                                 Set<ModuleInstanciation> visited) {
+                                 Set<ModuleInstanciation> visited,
+                                 List<String> parentPath) {
         for (ModuleInstanciation module : modules) {
             if (!visited.add(module)) {
                 continue;
             }
-            addModuleFields(module.getModuleInstanciations(), fields, concreteClass, visited);
-            addInstanceFields(module.getVars(), fields, concreteClass);
+            // A nested module's fields are exposed through the outer module instance (the
+            // inner instance is not a member receiver in the consuming class).
+            List<String> modulePath = parentPath.isEmpty()
+                ? List.of(module.getName())
+                : parentPath;
+            addModuleFields(module.getModuleInstanciations(), fields, concreteClass, visited, modulePath);
+            addInstanceFields(module.getVars(), fields, concreteClass, modulePath);
         }
     }
 
     private void addInstanceFields(Iterable<GlobalVarDef> declarations,
-                                   List<GlobalVarDef> fields,
-                                   ClassDef concreteClass) {
+                                   List<FieldInfo> fields,
+                                   ClassDef concreteClass,
+                                   List<String> modulePath) {
         for (GlobalVarDef field : declarations) {
             boolean privateFromAnotherClass = field.attrIsPrivate()
                 && concreteClass != null
                 && field.attrNearestClassDef() != concreteClass;
             if (!field.attrIsStatic() && !privateFromAnotherClass) {
-                fields.add(field);
+                fields.add(new FieldInfo(field, modulePath));
             }
         }
     }
@@ -260,13 +323,13 @@ public class SyntacticSugar {
     }
 
     private Expr substituteFieldParameters(Expr expression, String nameParameter,
-                                           String valueParameter, String fieldName) {
+                                           String valueParameter, String fieldName, FieldInfo field) {
         if (expression instanceof ExprVarAccess access) {
             if (access.getVarName().equals(nameParameter)) {
                 return Ast.ExprStringVal(access.getSource(), fieldName);
             }
             if (access.getVarName().equals(valueParameter)) {
-                return fieldAccess(access.getSource(), fieldName);
+                return fieldAccess(access.getSource(), field);
             }
         }
 
@@ -368,14 +431,25 @@ public class SyntacticSugar {
         for (ExprVarAccess access : accesses) {
             Expr replacement = access.getVarName().equals(nameParameter)
                 ? Ast.ExprStringVal(access.getSource(), fieldName)
-                : fieldAccess(access.getSource(), fieldName);
+                : fieldAccess(access.getSource(), field);
             access.replaceBy(replacement);
         }
         return expression;
     }
 
-    private ExprMemberVarDot fieldAccess(WPos source, String fieldName) {
-        return Ast.ExprMemberVarDot(source, Ast.ExprThis(source), Ast.Identifier(source, fieldName));
+    private ExprMemberVarDot fieldAccess(WPos source, FieldInfo field) {
+        Expr left;
+        if (field.modulePath.isEmpty()) {
+            left = Ast.ExprThis(source);
+        } else {
+            left = Ast.ExprVarAccess(source, Ast.Identifier(source, field.modulePath.get(0)));
+            for (int i = 1; i < field.modulePath.size(); i++) {
+                left = Ast.ExprMemberVarDot(source, left,
+                    Ast.Identifier(source, field.modulePath.get(i)));
+            }
+        }
+        return Ast.ExprMemberVarDot(source, left,
+            Ast.Identifier(source, field.declaration.getName()));
     }
 
     private void replaceTypeIdUse(CompilationUnit root) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -20,8 +20,113 @@ public class SyntacticSugar {
         }
         rewriteNegatedInts(root);
         addDefaultConstructors(root);
+        expandFieldIterations(root);
         addEndFunctionStatements(root);
         replaceTypeIdUse(root);
+    }
+
+    /**
+     * Expands field-wise operations before name and overload resolution. This gives serializers a
+     * reflection-like API while keeping the generated program equivalent to handwritten direct
+     * field accesses.
+     *
+     * <pre>
+     * forFields((name, value) -> writer.write(name, value))
+     * mapFields((name, value) -> reader.read(name, value))
+     * </pre>
+     */
+    private void expandFieldIterations(CompilationUnit root) {
+        List<ExprFunctionCall> calls = new ArrayList<>();
+        root.accept(new WurstModel.DefaultVisitor() {
+            @Override
+            public void visit(ExprFunctionCall call) {
+                super.visit(call);
+                String name = call.getFuncName();
+                if ("forFields".equals(name) || "mapFields".equals(name)) {
+                    calls.add(call);
+                }
+            }
+        });
+
+        for (ExprFunctionCall call : calls) {
+            expandFieldIteration(call, "mapFields".equals(call.getFuncName()));
+        }
+    }
+
+    private void expandFieldIteration(ExprFunctionCall call, boolean assignsResult) {
+        if (!(call.getParent() instanceof WStatements statements)) {
+            call.addError(call.getFuncName() + " can only be used as a statement.");
+            return;
+        }
+        ClassDef classDef = call.attrNearestClassDef();
+        if (classDef == null || !call.attrIsDynamicContext()) {
+            call.addError(call.getFuncName() + " can only be used in an instance method or constructor.");
+            return;
+        }
+        if (call.getArgs().size() != 1 || !(call.getArgs().get(0) instanceof ExprClosure closure)
+            || closure.getShortParameters().size() != 2) {
+            call.addError(call.getFuncName() + " expects a closure with (fieldName, fieldValue) parameters.");
+            return;
+        }
+
+        String nameParameter = closure.getShortParameters().get(0).getName();
+        String valueParameter = closure.getShortParameters().get(1).getName();
+        if (!assignsResult && !(closure.getImplementation() instanceof WStatement)) {
+            call.addError("forFields closure must produce a statement expression.");
+            return;
+        }
+        int statementIndex = statements.indexOf(call);
+        statements.remove(statementIndex);
+
+        for (GlobalVarDef field : classDef.getVars()) {
+            if (field.attrIsStatic()) {
+                continue;
+            }
+            Expr fieldAccess = fieldAccess(call.getSource(), field.getName());
+            Expr implementation = substituteFieldParameters(
+                closure.getImplementation().copy(), nameParameter, valueParameter, field.getName());
+            WStatement expanded;
+            if (assignsResult) {
+                expanded = Ast.StmtSet(call.getSource(), (LExpr) fieldAccess, implementation);
+            } else {
+                expanded = (WStatement) implementation;
+            }
+            statements.add(statementIndex++, expanded);
+        }
+    }
+
+    private Expr substituteFieldParameters(Expr expression, String nameParameter,
+                                           String valueParameter, String fieldName) {
+        if (expression instanceof ExprVarAccess access) {
+            if (access.getVarName().equals(nameParameter)) {
+                return Ast.ExprStringVal(access.getSource(), fieldName);
+            }
+            if (access.getVarName().equals(valueParameter)) {
+                return fieldAccess(access.getSource(), fieldName);
+            }
+        }
+
+        List<ExprVarAccess> accesses = new ArrayList<>();
+        expression.accept(new WurstModel.DefaultVisitor() {
+            @Override
+            public void visit(ExprVarAccess access) {
+                super.visit(access);
+                if (access.getVarName().equals(nameParameter) || access.getVarName().equals(valueParameter)) {
+                    accesses.add(access);
+                }
+            }
+        });
+        for (ExprVarAccess access : accesses) {
+            Expr replacement = access.getVarName().equals(nameParameter)
+                ? Ast.ExprStringVal(access.getSource(), fieldName)
+                : fieldAccess(access.getSource(), fieldName);
+            access.replaceBy(replacement);
+        }
+        return expression;
+    }
+
+    private ExprMemberVarDot fieldAccess(WPos source, String fieldName) {
+        return Ast.ExprMemberVarDot(source, Ast.ExprThis(source), Ast.Identifier(source, fieldName));
     }
 
     private void replaceTypeIdUse(CompilationUnit root) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -70,11 +70,14 @@ public class SyntacticSugar {
                 if (isUninstantiatedModuleFieldIteration(call)
                     && call.getParent() instanceof WStatements statements) {
                     int index = statements.indexOf(call);
-                    statements.remove(index);
                     detached.add(new DeferredModuleCall(statements, index, call));
                 }
             }
         });
+        for (int i = detached.size() - 1; i >= 0; i--) {
+            DeferredModuleCall state = detached.get(i);
+            state.statements.remove(state.index);
+        }
         return detached;
     }
 
@@ -186,17 +189,18 @@ public class SyntacticSugar {
     private List<GlobalVarDef> collectInstanceFields(ClassDef classDef, ClassOrModule owner) {
         List<GlobalVarDef> fields = new ArrayList<>();
         if (classDef != null) {
-            collectInheritedFields(classDef.attrTypC(), fields,
+            collectInheritedFields(classDef.attrTypC(), fields, classDef,
                 Collections.newSetFromMap(new IdentityHashMap<>()),
                 Collections.newSetFromMap(new IdentityHashMap<>()));
         } else if (owner instanceof ModuleDef moduleDef) {
-            addInstanceFields(moduleDef.getVars(), fields);
+            addInstanceFields(moduleDef.getVars(), fields, null);
         }
         return fields;
     }
 
     private void collectInheritedFields(WurstTypeClass type,
                                         List<GlobalVarDef> fields,
+                                        ClassDef concreteClass,
                                         Set<ClassDef> visitedClasses,
                                         Set<ModuleInstanciation> visitedModules) {
         if (!visitedClasses.add(type.getClassDef())) {
@@ -204,27 +208,33 @@ public class SyntacticSugar {
         }
         WurstTypeClass superType = type.extendedClass();
         if (superType != null) {
-            collectInheritedFields(superType, fields, visitedClasses, visitedModules);
+            collectInheritedFields(superType, fields, concreteClass, visitedClasses, visitedModules);
         }
-        addModuleFields(type.getClassDef().getModuleInstanciations(), fields, visitedModules);
-        addInstanceFields(type.getClassDef().getVars(), fields);
+        addModuleFields(type.getClassDef().getModuleInstanciations(), fields, concreteClass, visitedModules);
+        addInstanceFields(type.getClassDef().getVars(), fields, concreteClass);
     }
 
     private void addModuleFields(Iterable<ModuleInstanciation> modules,
                                  List<GlobalVarDef> fields,
+                                 ClassDef concreteClass,
                                  Set<ModuleInstanciation> visited) {
         for (ModuleInstanciation module : modules) {
             if (!visited.add(module)) {
                 continue;
             }
-            addModuleFields(module.getModuleInstanciations(), fields, visited);
-            addInstanceFields(module.getVars(), fields);
+            addModuleFields(module.getModuleInstanciations(), fields, concreteClass, visited);
+            addInstanceFields(module.getVars(), fields, concreteClass);
         }
     }
 
-    private void addInstanceFields(Iterable<GlobalVarDef> declarations, List<GlobalVarDef> fields) {
+    private void addInstanceFields(Iterable<GlobalVarDef> declarations,
+                                   List<GlobalVarDef> fields,
+                                   ClassDef concreteClass) {
         for (GlobalVarDef field : declarations) {
-            if (!field.attrIsStatic()) {
+            boolean privateFromAnotherClass = field.attrIsPrivate()
+                && concreteClass != null
+                && field.attrNearestClassDef() != concreteClass;
+            if (!field.attrIsStatic() && !privateFromAnotherClass) {
                 fields.add(field);
             }
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -19,6 +19,28 @@ public class SyntacticSugar {
     private static final String FOR_FIELDS = "__wurst_forFields";
     private static final String MAP_FIELDS = "__wurst_mapFields";
 
+    public static final class DeferredModuleCall {
+        private final WStatements statements;
+        private final int index;
+        private final ExprFunctionCall call;
+
+        private DeferredModuleCall(WStatements statements, int index, ExprFunctionCall call) {
+            this.statements = statements;
+            this.index = index;
+            this.call = call;
+        }
+    }
+
+    public static boolean isFieldIterationIntrinsic(ExprFunctionCall call) {
+        return FOR_FIELDS.equals(call.getFuncName()) || MAP_FIELDS.equals(call.getFuncName());
+    }
+
+    public static boolean isUninstantiatedModuleFieldIteration(ExprFunctionCall call) {
+        return isFieldIterationIntrinsic(call)
+            && call.attrNearestClassDef() == null
+            && call.attrNearestClassOrModule() instanceof ModuleDef;
+    }
+
     public void removeSyntacticSugar(CompilationUnit root, boolean hasCommonJ) {
         if (hasCommonJ) {
             addDefaultImports(root);
@@ -38,6 +60,32 @@ public class SyntacticSugar {
         expandFieldIterationsInTree(root);
     }
 
+    /** Temporarily removes template intrinsics while validation runs; callers must restore them. */
+    public List<DeferredModuleCall> detachModuleTemplateFieldIterations(CompilationUnit root) {
+        List<DeferredModuleCall> detached = new ArrayList<>();
+        root.accept(new WurstModel.DefaultVisitor() {
+            @Override
+            public void visit(ExprFunctionCall call) {
+                super.visit(call);
+                if (isUninstantiatedModuleFieldIteration(call)
+                    && call.getParent() instanceof WStatements statements) {
+                    int index = statements.indexOf(call);
+                    statements.remove(index);
+                    detached.add(new DeferredModuleCall(statements, index, call));
+                }
+            }
+        });
+        return detached;
+    }
+
+    public void restoreModuleTemplateFieldIterations(List<DeferredModuleCall> detached) {
+        for (int i = detached.size() - 1; i >= 0; i--) {
+            DeferredModuleCall state = detached.get(i);
+            int index = Math.min(state.index, state.statements.size());
+            state.statements.add(index, state.call);
+        }
+    }
+
     /**
      * Expands field-wise operations before name and overload resolution. This gives serializers a
      * reflection-like API while keeping the generated program equivalent to handwritten direct
@@ -54,8 +102,7 @@ public class SyntacticSugar {
             @Override
             public void visit(ExprFunctionCall call) {
                 super.visit(call);
-                String name = call.getFuncName();
-                if (FOR_FIELDS.equals(name) || MAP_FIELDS.equals(name)) {
+                if (isFieldIterationIntrinsic(call)) {
                     calls.add(call);
                 }
             }
@@ -80,7 +127,6 @@ public class SyntacticSugar {
         if (owner instanceof ModuleDef) {
             // Module bodies are templates. Their copies were made by ModuleExpander; validate and
             // expand those concrete copies instead of type-checking this uninstantiated template.
-            statements.remove(call);
             return;
         }
         if (classDef == null) {
@@ -140,7 +186,9 @@ public class SyntacticSugar {
     private List<GlobalVarDef> collectInstanceFields(ClassDef classDef, ClassOrModule owner) {
         List<GlobalVarDef> fields = new ArrayList<>();
         if (classDef != null) {
-            collectInheritedFields(classDef.attrTypC(), fields, Collections.newSetFromMap(new IdentityHashMap<>()));
+            collectInheritedFields(classDef.attrTypC(), fields,
+                Collections.newSetFromMap(new IdentityHashMap<>()),
+                Collections.newSetFromMap(new IdentityHashMap<>()));
         } else if (owner instanceof ModuleDef moduleDef) {
             addInstanceFields(moduleDef.getVars(), fields);
         }
@@ -148,15 +196,30 @@ public class SyntacticSugar {
     }
 
     private void collectInheritedFields(WurstTypeClass type,
-                                        List<GlobalVarDef> fields, Set<ClassDef> visited) {
-        if (!visited.add(type.getClassDef())) {
+                                        List<GlobalVarDef> fields,
+                                        Set<ClassDef> visitedClasses,
+                                        Set<ModuleInstanciation> visitedModules) {
+        if (!visitedClasses.add(type.getClassDef())) {
             return;
         }
         WurstTypeClass superType = type.extendedClass();
         if (superType != null) {
-            collectInheritedFields(superType, fields, visited);
+            collectInheritedFields(superType, fields, visitedClasses, visitedModules);
         }
+        addModuleFields(type.getClassDef().getModuleInstanciations(), fields, visitedModules);
         addInstanceFields(type.getClassDef().getVars(), fields);
+    }
+
+    private void addModuleFields(Iterable<ModuleInstanciation> modules,
+                                 List<GlobalVarDef> fields,
+                                 Set<ModuleInstanciation> visited) {
+        for (ModuleInstanciation module : modules) {
+            if (!visited.add(module)) {
+                continue;
+            }
+            addModuleFields(module.getModuleInstanciations(), fields, visited);
+            addInstanceFields(module.getVars(), fields);
+        }
     }
 
     private void addInstanceFields(Iterable<GlobalVarDef> declarations, List<GlobalVarDef> fields) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -14,6 +14,10 @@ import java.util.*;
  */
 public class SyntacticSugar {
 
+    /** Compiler-reserved spelling keeps ordinary user functions named forFields/mapFields valid. */
+    private static final String FOR_FIELDS = "__wurst_forFields";
+    private static final String MAP_FIELDS = "__wurst_mapFields";
+
     public void removeSyntacticSugar(CompilationUnit root, boolean hasCommonJ) {
         if (hasCommonJ) {
             addDefaultImports(root);
@@ -31,8 +35,8 @@ public class SyntacticSugar {
      * field accesses.
      *
      * <pre>
-     * forFields((name, value) -> writer.write(name, value))
-     * mapFields((name, value) -> reader.read(name, value))
+     * __wurst_forFields((name, value) -> writer.write(name, value))
+     * __wurst_mapFields((name, value) -> reader.read(name, value))
      * </pre>
      */
     private void expandFieldIterations(CompilationUnit root) {
@@ -42,14 +46,14 @@ public class SyntacticSugar {
             public void visit(ExprFunctionCall call) {
                 super.visit(call);
                 String name = call.getFuncName();
-                if ("forFields".equals(name) || "mapFields".equals(name)) {
+                if (FOR_FIELDS.equals(name) || MAP_FIELDS.equals(name)) {
                     calls.add(call);
                 }
             }
         });
 
         for (ExprFunctionCall call : calls) {
-            expandFieldIteration(call, "mapFields".equals(call.getFuncName()));
+            expandFieldIteration(call, MAP_FIELDS.equals(call.getFuncName()));
         }
     }
 
@@ -108,10 +112,24 @@ public class SyntacticSugar {
 
         List<ExprVarAccess> accesses = new ArrayList<>();
         expression.accept(new WurstModel.DefaultVisitor() {
+            private final Set<String> shadowed = new HashSet<>();
+
+            @Override
+            public void visit(ExprClosure nestedClosure) {
+                Set<String> previous = new HashSet<>(shadowed);
+                for (WShortParameter parameter : nestedClosure.getShortParameters()) {
+                    shadowed.add(parameter.getName());
+                }
+                super.visit(nestedClosure);
+                shadowed.clear();
+                shadowed.addAll(previous);
+            }
+
             @Override
             public void visit(ExprVarAccess access) {
                 super.visit(access);
-                if (access.getVarName().equals(nameParameter) || access.getVarName().equals(valueParameter)) {
+                if (!shadowed.contains(access.getVarName())
+                    && (access.getVarName().equals(nameParameter) || access.getVarName().equals(valueParameter))) {
                     accesses.add(access);
                 }
             }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -72,6 +72,12 @@ public class SyntacticSugar {
             call.addError(call.getFuncName() + " expects a closure with (fieldName, fieldValue) parameters.");
             return;
         }
+        for (WShortParameter parameter : closure.getShortParameters()) {
+            if (!(parameter.getTypOpt() instanceof NoTypeExpr)) {
+                parameter.addError("Field iteration closure parameters must use inferred types.");
+                return;
+            }
+        }
 
         String nameParameter = closure.getShortParameters().get(0).getName();
         String valueParameter = closure.getShortParameters().get(1).getName();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -143,6 +143,48 @@ public class SyntacticSugar {
                 shadowedScopes.pop();
             }
 
+            private void visitLoopVariable(LocalVarDef loopVariable) {
+                loopVariable.getModifiers().accept(this);
+                loopVariable.getOptTyp().accept(this);
+                loopVariable.getInitialExpr().accept(this);
+            }
+
+            private void visitLoopBody(LocalVarDef loopVariable, WStatements body) {
+                shadowedScopes.push(Set.of(loopVariable.getName()));
+                body.accept(this);
+                shadowedScopes.pop();
+            }
+
+            @Override
+            public void visit(StmtForRangeUp loop) {
+                visitLoopVariable(loop.getLoopVar());
+                loop.getTo().accept(this);
+                loop.getStep().accept(this);
+                visitLoopBody(loop.getLoopVar(), loop.getBody());
+            }
+
+            @Override
+            public void visit(StmtForRangeDown loop) {
+                visitLoopVariable(loop.getLoopVar());
+                loop.getTo().accept(this);
+                loop.getStep().accept(this);
+                visitLoopBody(loop.getLoopVar(), loop.getBody());
+            }
+
+            @Override
+            public void visit(StmtForIn loop) {
+                visitLoopVariable(loop.getLoopVar());
+                loop.getIn().accept(this);
+                visitLoopBody(loop.getLoopVar(), loop.getBody());
+            }
+
+            @Override
+            public void visit(StmtForFrom loop) {
+                visitLoopVariable(loop.getLoopVar());
+                loop.getIn().accept(this);
+                visitLoopBody(loop.getLoopVar(), loop.getBody());
+            }
+
             @Override
             public void visit(ExprClosure nestedClosure) {
                 Set<String> shadowed = new HashSet<>();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -18,9 +18,6 @@ public class SyntacticSugar {
     /** Compiler-reserved spelling keeps ordinary user functions named forFields/mapFields valid. */
     private static final String FOR_FIELDS = "__wurst_forFields";
     private static final String MAP_FIELDS = "__wurst_mapFields";
-    private static final Map<CompilationUnit, List<DeferredModuleCall>> DETACHED_DIRECT_CALLS =
-        Collections.synchronizedMap(new WeakHashMap<>());
-
     public static final class DeferredModuleCall {
         private final WStatements statements;
         private final int index;
@@ -37,6 +34,14 @@ public class SyntacticSugar {
             this.index = index;
             this.call = call;
             this.generatedStatements = generatedStatements;
+        }
+    }
+
+    public static final class DirectFieldIterationState {
+        private final List<DeferredModuleCall> detached;
+
+        private DirectFieldIterationState(List<DeferredModuleCall> detached) {
+            this.detached = detached;
         }
     }
 
@@ -84,22 +89,20 @@ public class SyntacticSugar {
      */
     public void expandFieldIterations(CompilationUnit root) {
         List<DeferredModuleCall> detached = expandFieldIterationsInTree(root);
-        if (!detached.isEmpty()) {
-            DETACHED_DIRECT_CALLS.put(root, detached);
+        if (!detached.isEmpty() && root.getCuInfo() != null) {
+            root.getCuInfo().setDirectFieldIterationState(new DirectFieldIterationState(detached));
         }
     }
 
     /** Restores source intrinsics before an incremental compilation-unit recheck. */
     public static void restoreDirectFieldIterations(CompilationUnit root) {
-        List<DeferredModuleCall> detached = DETACHED_DIRECT_CALLS.remove(root);
-        if (detached != null) {
-            new SyntacticSugar().restoreModuleTemplateFieldIterations(detached);
+        if (root.getCuInfo() != null) {
+            DirectFieldIterationState state = root.getCuInfo().getDirectFieldIterationState();
+            root.getCuInfo().setDirectFieldIterationState(null);
+            if (state != null) {
+                new SyntacticSugar().restoreModuleTemplateFieldIterations(state.detached);
+            }
         }
-    }
-
-    /** Drops saved source intrinsics when the whole language-server model is discarded. */
-    public static void clearDirectFieldIterations() {
-        DETACHED_DIRECT_CALLS.clear();
     }
 
     /** Temporarily removes template intrinsics while validation runs; callers must restore them. */
@@ -172,19 +175,6 @@ public class SyntacticSugar {
         }
         ClassDef classDef = call.attrNearestClassDef();
         ClassOrModule owner = call.attrNearestClassOrModule();
-        if (!call.attrIsDynamicContext()) {
-            call.addError(call.getFuncName() + " can only be used in an instance method or constructor.");
-            return;
-        }
-        if (owner instanceof ModuleDef) {
-            // Module bodies are templates. Their copies were made by ModuleExpander; validate and
-            // expand those concrete copies instead of type-checking this uninstantiated template.
-            return;
-        }
-        if (classDef == null) {
-            call.addError(call.getFuncName() + " can only be used in an instance method or constructor.");
-            return;
-        }
         if (call.getArgs().size() != 1 || !(call.getArgs().get(0) instanceof ExprClosure closure)
             || closure.getShortParameters().size() != 2) {
             call.addError(call.getFuncName() + " expects a closure with (fieldName, fieldValue) parameters.");
@@ -211,6 +201,19 @@ public class SyntacticSugar {
         }
         if (!assignsResult && !(closure.getImplementation() instanceof WStatement)) {
             call.addError("forFields closure must produce a statement expression.");
+            return;
+        }
+        if (!call.attrIsDynamicContext()) {
+            call.addError(call.getFuncName() + " can only be used in an instance method or constructor.");
+            return;
+        }
+        if (owner instanceof ModuleDef) {
+            // Module bodies are templates. Their copies were made by ModuleExpander; validate and
+            // expand those concrete copies instead of type-checking this uninstantiated template.
+            return;
+        }
+        if (classDef == null) {
+            call.addError(call.getFuncName() + " can only be used in an instance method or constructor.");
             return;
         }
         List<FieldInfo> fields = collectInstanceFields(classDef, owner);
@@ -248,7 +251,7 @@ public class SyntacticSugar {
                 Collections.newSetFromMap(new IdentityHashMap<>()),
                 Collections.newSetFromMap(new IdentityHashMap<>()));
         } else if (owner instanceof ModuleDef moduleDef) {
-            addInstanceFields(moduleDef.getVars(), fields, null, List.of());
+            addInstanceFields(moduleDef.getVars(), fields, null, List.of(), moduleDef);
         }
         return fields;
     }
@@ -267,7 +270,7 @@ public class SyntacticSugar {
         }
         addModuleFields(type.getClassDef().getModuleInstanciations(), fields, concreteClass,
             visitedModules, List.of());
-        addInstanceFields(type.getClassDef().getVars(), fields, concreteClass, List.of());
+        addInstanceFields(type.getClassDef().getVars(), fields, concreteClass, List.of(), null);
     }
 
     private void addModuleFields(Iterable<ModuleInstanciation> modules,
@@ -285,19 +288,21 @@ public class SyntacticSugar {
                 ? List.of(module.getName())
                 : parentPath;
             addModuleFields(module.getModuleInstanciations(), fields, concreteClass, visited, modulePath);
-            addInstanceFields(module.getVars(), fields, concreteClass, modulePath);
+            addInstanceFields(module.getVars(), fields, concreteClass, modulePath, module.attrModuleOrigin());
         }
     }
 
     private void addInstanceFields(Iterable<GlobalVarDef> declarations,
                                    List<FieldInfo> fields,
                                    ClassDef concreteClass,
-                                   List<String> modulePath) {
+                                   List<String> modulePath,
+                                   ModuleDef declaringModule) {
         for (GlobalVarDef field : declarations) {
             boolean privateFromAnotherClass = field.attrIsPrivate()
                 && concreteClass != null
                 && field.attrNearestClassDef() != concreteClass;
-            if (!field.attrIsStatic() && !privateFromAnotherClass) {
+            boolean privateFromAnotherModule = field.attrIsPrivate() && declaringModule != null;
+            if (!field.attrIsStatic() && !privateFromAnotherClass && !privateFromAnotherModule) {
                 fields.add(new FieldInfo(field, modulePath));
             }
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -81,17 +81,29 @@ public class SyntacticSugar {
 
         String nameParameter = closure.getShortParameters().get(0).getName();
         String valueParameter = closure.getShortParameters().get(1).getName();
+        if (nameParameter.equals(valueParameter)) {
+            closure.getShortParameters().get(1).addError(
+                "Field iteration closure parameters must have distinct names.");
+            return;
+        }
         if (!assignsResult && !(closure.getImplementation() instanceof WStatement)) {
             call.addError("forFields closure must produce a statement expression.");
+            return;
+        }
+        List<GlobalVarDef> fields = new ArrayList<>();
+        for (GlobalVarDef field : classDef.getVars()) {
+            if (!field.attrIsStatic()) {
+                fields.add(field);
+            }
+        }
+        if (fields.isEmpty()) {
+            call.addError(call.getFuncName() + " requires at least one instance field.");
             return;
         }
         int statementIndex = statements.indexOf(call);
         statements.remove(statementIndex);
 
-        for (GlobalVarDef field : classDef.getVars()) {
-            if (field.attrIsStatic()) {
-                continue;
-            }
+        for (GlobalVarDef field : fields) {
             Expr fieldAccess = fieldAccess(call.getSource(), field.getName());
             Expr implementation = substituteFieldParameters(
                 closure.getImplementation().copy(), nameParameter, valueParameter, field.getName());

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -130,23 +130,44 @@ public class SyntacticSugar {
 
         List<ExprVarAccess> accesses = new ArrayList<>();
         expression.accept(new WurstModel.DefaultVisitor() {
-            private final Set<String> shadowed = new HashSet<>();
+            private final Deque<Set<String>> shadowedScopes = new ArrayDeque<>();
+
+            private boolean isShadowed(String name) {
+                return shadowedScopes.stream().anyMatch(scope -> scope.contains(name));
+            }
+
+            @Override
+            public void visit(WStatements statements) {
+                shadowedScopes.push(new HashSet<>());
+                super.visit(statements);
+                shadowedScopes.pop();
+            }
 
             @Override
             public void visit(ExprClosure nestedClosure) {
-                Set<String> previous = new HashSet<>(shadowed);
+                Set<String> shadowed = new HashSet<>();
                 for (WShortParameter parameter : nestedClosure.getShortParameters()) {
                     shadowed.add(parameter.getName());
                 }
+                shadowedScopes.push(shadowed);
                 super.visit(nestedClosure);
-                shadowed.clear();
-                shadowed.addAll(previous);
+                shadowedScopes.pop();
+            }
+
+            @Override
+            public void visit(LocalVarDef localVarDef) {
+                super.visit(localVarDef);
+                if (!shadowedScopes.isEmpty()
+                    && (localVarDef.getName().equals(nameParameter)
+                        || localVarDef.getName().equals(valueParameter))) {
+                    shadowedScopes.peek().add(localVarDef.getName());
+                }
             }
 
             @Override
             public void visit(ExprVarAccess access) {
                 super.visit(access);
-                if (!shadowed.contains(access.getVarName())
+                if (!isShadowed(access.getVarName())
                     && (access.getVarName().equals(nameParameter) || access.getVarName().equals(valueParameter))) {
                     accesses.add(access);
                 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/SyntacticSugar.java
@@ -86,6 +86,11 @@ public class SyntacticSugar {
                 "Field iteration closure parameters must have distinct names.");
             return;
         }
+        if (hasShadowingLocal(closure, nameParameter, valueParameter)) {
+            call.addError("Field iteration callbacks cannot declare locals or loop variables named "
+                + nameParameter + " or " + valueParameter + ".");
+            return;
+        }
         if (!assignsResult && !(closure.getImplementation() instanceof WStatement)) {
             call.addError("forFields closure must produce a statement expression.");
             return;
@@ -117,6 +122,25 @@ public class SyntacticSugar {
         }
     }
 
+    private boolean hasShadowingLocal(ExprClosure closure, String nameParameter, String valueParameter) {
+        final boolean[] result = {false};
+        closure.getImplementation().accept(new WurstModel.DefaultVisitor() {
+            @Override
+            public void visit(ExprClosure nestedClosure) {
+                // Nested closures have independent parameter scopes.
+            }
+
+            @Override
+            public void visit(LocalVarDef localVarDef) {
+                super.visit(localVarDef);
+                if (localVarDef.getName().equals(nameParameter) || localVarDef.getName().equals(valueParameter)) {
+                    result[0] = true;
+                }
+            }
+        });
+        return result[0];
+    }
+
     private Expr substituteFieldParameters(Expr expression, String nameParameter,
                                            String valueParameter, String fieldName) {
         if (expression instanceof ExprVarAccess access) {
@@ -138,7 +162,15 @@ public class SyntacticSugar {
 
             @Override
             public void visit(WStatements statements) {
-                shadowedScopes.push(new HashSet<>());
+                Set<String> blockBindings = new HashSet<>();
+                for (WStatement statement : statements) {
+                    if (statement instanceof LocalVarDef localVarDef
+                        && (localVarDef.getName().equals(nameParameter)
+                            || localVarDef.getName().equals(valueParameter))) {
+                        blockBindings.add(localVarDef.getName());
+                    }
+                }
+                shadowedScopes.push(blockBindings);
                 super.visit(statements);
                 shadowedScopes.pop();
             }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/WurstChecker.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/WurstChecker.java
@@ -10,7 +10,9 @@ import de.peeeq.wurstscript.validation.GlobalCaches;
 import de.peeeq.wurstscript.validation.TRVEHelper;
 import de.peeeq.wurstscript.validation.WurstValidator;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 public class WurstChecker {
 
@@ -47,19 +49,24 @@ public class WurstChecker {
 
         if (errorHandler.getErrorCount() > 0) return;
 
+        SyntacticSugar syntacticSugar = new SyntacticSugar();
+        List<SyntacticSugar.DeferredModuleCall> detachedTemplates = new ArrayList<>();
         for (CompilationUnit cu : toCheck) {
-            new SyntacticSugar().expandFieldIterations(cu);
+            syntacticSugar.expandFieldIterations(cu);
+            detachedTemplates.addAll(syntacticSugar.detachModuleTemplateFieldIterations(cu));
         }
+        try {
+            // compute the flow attributes
+            for (CompilationUnit cu : toCheck) {
+                WurstValidator.computeFlowAttributes(cu);
+            }
 
-        // compute the flow attributes
-        for (CompilationUnit cu : toCheck) {
-            WurstValidator.computeFlowAttributes(cu);
+            // validate the resource:
+            WurstValidator validator = new WurstValidator(root, legacyJassTypeChecks);
+            validator.validate(toCheck);
+        } finally {
+            syntacticSugar.restoreModuleTemplateFieldIterations(detachedTemplates);
         }
-
-
-        // validate the resource:
-        WurstValidator validator = new WurstValidator(root, legacyJassTypeChecks);
-        validator.validate(toCheck);
     }
 
     private void clearGlobalCaches(WurstModel root, Collection<CompilationUnit> toCheck) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/WurstChecker.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/WurstChecker.java
@@ -47,6 +47,10 @@ public class WurstChecker {
 
         if (errorHandler.getErrorCount() > 0) return;
 
+        for (CompilationUnit cu : toCheck) {
+            new SyntacticSugar().expandFieldIterations(cu);
+        }
+
         // compute the flow attributes
         for (CompilationUnit cu : toCheck) {
             WurstValidator.computeFlowAttributes(cu);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/CompilationUnitInfo.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/CompilationUnitInfo.java
@@ -1,5 +1,6 @@
 package de.peeeq.wurstscript.attributes;
 
+import de.peeeq.wurstscript.SyntacticSugar;
 import de.peeeq.wurstscript.parser.TriviaIndex;
 import de.peeeq.wurstscript.utils.Utils;
 
@@ -12,6 +13,7 @@ public class CompilationUnitInfo {
     private IndentationMode indentationMode = IndentationMode.spaces(4);
     private TriviaIndex triviaIndex = TriviaIndex.empty();
     private boolean library;
+    private SyntacticSugar.DirectFieldIterationState directFieldIterationState;
 
     public CompilationUnitInfo(ErrorHandler cuErrorHandler) {
         this.cuErrorHandler = cuErrorHandler;
@@ -55,6 +57,14 @@ public class CompilationUnitInfo {
 
     public void setLibrary(boolean library) {
         this.library = library;
+    }
+
+    public SyntacticSugar.DirectFieldIterationState getDirectFieldIterationState() {
+        return directFieldIterationState;
+    }
+
+    public void setDirectFieldIterationState(SyntacticSugar.DirectFieldIterationState state) {
+        this.directFieldIterationState = state;
     }
 
     public interface IndentationMode {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -407,4 +407,45 @@ public class FieldIterationTests extends WurstScriptTest {
                 "endpackage"
             );
     }
+
+    @Test
+    public void excludesPrivateModuleFields() {
+        test()
+            .executeProg()
+            .lines(
+                "package FieldIterationTest",
+                "    native testSuccess()",
+                "    class Acc",
+                "        int total",
+                "        function add(int value)",
+                "            total = total + value",
+                "    module State",
+                "        private int hidden = 100",
+                "        int visible = 2",
+                "    class Data",
+                "        use State",
+                "        function save(Acc acc)",
+                "            __wurst_forFields((name, value) -> acc.add(value))",
+                "    init",
+                "        let acc = new Acc",
+                "        let data = new Data",
+                "        data.save(acc)",
+                "        if acc.total == 2",
+                "            testSuccess()",
+                "endpackage"
+            );
+    }
+
+    @Test
+    public void validatesUnusedModuleFieldIteration() {
+        test()
+            .expectError("expects a closure with (fieldName, fieldValue) parameters")
+            .lines(
+                "package FieldIterationTest",
+                "    module Unused",
+                "        function save()",
+                "            __wurst_forFields(value -> value)",
+                "endpackage"
+            );
+    }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -230,4 +230,31 @@ public class FieldIterationTests extends WurstScriptTest {
                 "endpackage"
             );
     }
+
+    @Test
+    public void keepsLoopBindingsInsideLoopBody() {
+        test()
+            .executeProg()
+            .lines(
+                "package FieldIterationTest",
+                "    native testSuccess()",
+                "    class Data",
+                "        int first = 1",
+                "        int second = 2",
+                "",
+                "        function load()",
+                "            __wurst_mapFields((name, value) -> begin",
+                "                for int value = 0 to 1",
+                "                    continue",
+                "                return 42 + value - value",
+                "            end)",
+                "",
+                "    init",
+                "        let data = new Data",
+                "        data.load()",
+                "        if data.first == 42 and data.second == 42",
+                "            testSuccess()",
+                "endpackage"
+            );
+    }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -159,4 +159,19 @@ public class FieldIterationTests extends WurstScriptTest {
                 "endpackage"
             );
     }
+
+    @Test
+    public void rejectsExplicitFieldIterationParameterTypes() {
+        test()
+            .expectError("must use inferred types")
+            .lines(
+                "package FieldIterationTest",
+                "    class Data",
+                "        int value",
+                "",
+                "        function save()",
+                "            __wurst_forFields((NoSuch name, NoSuch value) -> value)",
+                "endpackage"
+            );
+    }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -336,4 +336,37 @@ public class FieldIterationTests extends WurstScriptTest {
                 "endpackage"
             );
     }
+
+    @Test
+    public void includesInstanceFieldsFromModules() {
+        test()
+            .executeProg()
+            .lines(
+                "package FieldIterationTest",
+                "    native testSuccess()",
+                "    class Acc",
+                "        int total = 0",
+                "        function add(int value)",
+                "            total = total + value",
+                "    module BaseState",
+                "        int baseValue = 2",
+                "    module State",
+                "        use BaseState",
+                "        int moduleValue = 4",
+                "    class Data",
+                "        use State",
+                "        int local = 5",
+                "",
+                "        function save(Acc acc)",
+                "            __wurst_forFields((name, value) -> acc.add(value))",
+                "",
+                "    init",
+                "        let acc = new Acc",
+                "        let data = new Data",
+                "        data.save(acc)",
+                "        if acc.total == 11",
+                "            testSuccess()",
+                "endpackage"
+            );
+    }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -371,4 +371,40 @@ public class FieldIterationTests extends WurstScriptTest {
                 "endpackage"
             );
     }
+
+    @Test
+    public void qualifiesFieldsFromSiblingModules() {
+        test()
+            .testLua(true)
+            .luaOnly(false)
+            .executeProg()
+            .lines(
+                "package FieldIterationTest",
+                "    native testSuccess()",
+                "    class Acc",
+                "        int left",
+                "        int right",
+                "        function add(string name, int value)",
+                "            if name == \"Left.x\"",
+                "                left = value",
+                "            if name == \"Right.x\"",
+                "                right = value",
+                "    module Left",
+                "        int x = 1",
+                "    module Right",
+                "        int x = 2",
+                "    class Data",
+                "        use Left",
+                "        use Right",
+                "        function save(Acc acc)",
+                "            __wurst_forFields((name, value) -> acc.add(name, value))",
+                "    init",
+                "        let acc = new Acc",
+                "        let data = new Data",
+                "        data.save(acc)",
+                "        if acc.left == 1 and acc.right == 2",
+                "            testSuccess()",
+                "endpackage"
+            );
+    }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -1,0 +1,107 @@
+package tests.wurstscript.tests;
+
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class FieldIterationTests extends WurstScriptTest {
+
+    @Test
+    public void serializesAndDeserializesFieldsWithoutRuntimeReflection() throws IOException {
+        test()
+            .testLua(true)
+            .executeProg()
+            .lines(
+                "package FieldIterationTest",
+                "    native testSuccess()",
+                "",
+                "    class Codec",
+                "        int writtenInt",
+                "        string writtenString",
+                "        string writtenIntName",
+                "        string writtenStringName",
+                "",
+                "        function write(string fieldName, int value)",
+                "            writtenInt = value",
+                "            writtenIntName = fieldName",
+                "",
+                "        function write(string fieldName, string value)",
+                "            writtenString = value",
+                "            writtenStringName = fieldName",
+                "",
+                "        function read(string fieldName, int oldValue) returns int",
+                "            if fieldName == \"score\"",
+                "                return 42",
+                "            return -1",
+                "",
+                "        function read(string fieldName, string oldValue) returns string",
+                "            if fieldName == \"name\"",
+                "                return \"loaded\"",
+                "            return \"wrong field\"",
+                "",
+                "    class Data",
+                "        int score = 7",
+                "        string name = \"initial\"",
+                "        static int schemaVersion = 1",
+                "",
+                "        function save(Codec codec)",
+                "            forFields((fieldName, value) -> codec.write(fieldName, value))",
+                "",
+                "        function load(Codec codec)",
+                "            mapFields((fieldName, value) -> codec.read(fieldName, value))",
+                "",
+                "    init",
+                "        let codec = new Codec",
+                "        let data = new Data",
+                "        data.save(codec)",
+                "        if codec.writtenInt == 7 and codec.writtenString == \"initial\" and codec.writtenIntName == \"score\" and codec.writtenStringName == \"name\"",
+                "            data.load(codec)",
+                "            if data.score == 42 and data.name == \"loaded\"",
+                "                testSuccess()",
+                "endpackage"
+            );
+
+        String lua = Files.readString(new File(TEST_OUTPUT_PATH +
+            "lua/FieldIterationTests_serializesAndDeserializesFieldsWithoutRuntimeReflection.lua").toPath());
+        assertFalse(lua.contains("forFields"));
+        assertFalse(lua.contains("mapFields"));
+        assertTrue(lua.contains("Codec_Codec_write(codec, \"score\", this"));
+        assertTrue(lua.contains("Codec_Codec_write1(codec, \"name\", this"));
+        assertTrue(lua.contains("Data_score = Codec_Codec_read(codec1, \"score\""));
+        assertTrue(lua.contains("Data_name = Codec_Codec_read1(codec1, \"name\""));
+    }
+
+    @Test
+    public void rejectsFieldIterationOutsideInstanceContext() {
+        test()
+            .expectError("can only be used in an instance method or constructor")
+            .lines(
+                "package FieldIterationTest",
+                "    function consume(string name, int value)",
+                "",
+                "    init",
+                "        forFields((name, value) -> consume(name, value))",
+                "endpackage"
+            );
+    }
+
+    @Test
+    public void rejectsInvalidFieldIterationClosure() {
+        test()
+            .expectError("expects a closure with (fieldName, fieldValue) parameters")
+            .lines(
+                "package FieldIterationTest",
+                "    class Data",
+                "        int value",
+                "",
+                "        function save()",
+                "            forFields(value -> value)",
+                "endpackage"
+            );
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -174,4 +174,34 @@ public class FieldIterationTests extends WurstScriptTest {
                 "endpackage"
             );
     }
+
+    @Test
+    public void rejectsFieldIterationWithoutInstanceFields() {
+        test()
+            .expectError("requires at least one instance field")
+            .lines(
+                "package FieldIterationTest",
+                "    class Data",
+                "        static int schemaVersion = 1",
+                "",
+                "        function save()",
+                "            __wurst_forFields((name, value) -> noSuchFunction(name, value))",
+                "endpackage"
+            );
+    }
+
+    @Test
+    public void rejectsDuplicateFieldIterationParameterNames() {
+        test()
+            .expectError("must have distinct names")
+            .lines(
+                "package FieldIterationTest",
+                "    class Data",
+                "        int value",
+                "",
+                "        function save()",
+                "            __wurst_mapFields((value, value) -> 42)",
+                "endpackage"
+            );
+    }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -15,6 +15,7 @@ public class FieldIterationTests extends WurstScriptTest {
     public void serializesAndDeserializesFieldsWithoutRuntimeReflection() throws IOException {
         test()
             .testLua(true)
+            .luaOnly(false)
             .executeProg()
             .lines(
                 "package FieldIterationTest",
@@ -50,10 +51,10 @@ public class FieldIterationTests extends WurstScriptTest {
                 "        static int schemaVersion = 1",
                 "",
                 "        function save(Codec codec)",
-                "            forFields((fieldName, value) -> codec.write(fieldName, value))",
+                "            __wurst_forFields((fieldName, value) -> codec.write(fieldName, value))",
                 "",
                 "        function load(Codec codec)",
-                "            mapFields((fieldName, value) -> codec.read(fieldName, value))",
+                "            __wurst_mapFields((fieldName, value) -> codec.read(fieldName, value))",
                 "",
                 "    init",
                 "        let codec = new Codec",
@@ -68,8 +69,8 @@ public class FieldIterationTests extends WurstScriptTest {
 
         String lua = Files.readString(new File(TEST_OUTPUT_PATH +
             "lua/FieldIterationTests_serializesAndDeserializesFieldsWithoutRuntimeReflection.lua").toPath());
-        assertFalse(lua.contains("forFields"));
-        assertFalse(lua.contains("mapFields"));
+        assertFalse(lua.contains("__wurst_forFields"));
+        assertFalse(lua.contains("__wurst_mapFields"));
         assertTrue(lua.contains("Codec_Codec_write(codec, \"score\", this"));
         assertTrue(lua.contains("Codec_Codec_write1(codec, \"name\", this"));
         assertTrue(lua.contains("Data_score = Codec_Codec_read(codec1, \"score\""));
@@ -85,7 +86,7 @@ public class FieldIterationTests extends WurstScriptTest {
                 "    function consume(string name, int value)",
                 "",
                 "    init",
-                "        forFields((name, value) -> consume(name, value))",
+                "        __wurst_forFields((name, value) -> consume(name, value))",
                 "endpackage"
             );
     }
@@ -100,7 +101,61 @@ public class FieldIterationTests extends WurstScriptTest {
                 "        int value",
                 "",
                 "        function save()",
-                "            forFields(value -> value)",
+                "            __wurst_forFields(value -> value)",
+                "endpackage"
+            );
+    }
+
+    @Test
+    public void ordinaryFieldHelperNamesRemainUserFunctions() {
+        test()
+            .executeProg()
+            .lines(
+                "package FieldIterationTest",
+                "    native testSuccess()",
+                "",
+                "    function forFields(int value) returns int",
+                "        return value + 1",
+                "",
+                "    init",
+                "        if forFields(1) == 2",
+                "            testSuccess()",
+                "endpackage"
+            );
+    }
+
+    @Test
+    public void nestedClosureParametersAreNotSubstituted() {
+        test()
+            .executeProg()
+            .lines(
+                "package FieldIterationTest",
+                "    native testSuccess()",
+                "    interface IntFunc",
+                "        function apply(int value) returns int",
+                "",
+                "    function consume(IntFunc callback) returns int",
+                "        return callback.apply(5)",
+                "",
+                "    class Codec",
+                "        int total",
+                "",
+                "        function write(string fieldName, int value)",
+                "            total = total + value",
+                "",
+                "    class Data",
+                "        int first = 1",
+                "        int second = 2",
+                "",
+                "        function save(Codec codec)",
+                "            __wurst_forFields((fieldName, value) -> codec.write(fieldName, consume((int value) -> value)))",
+                "",
+                "    init",
+                "        let codec = new Codec",
+                "        let data = new Data",
+                "        data.save(codec)",
+                "        if codec.total == 10",
+                "            testSuccess()",
                 "endpackage"
             );
     }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -276,4 +276,64 @@ public class FieldIterationTests extends WurstScriptTest {
                 "endpackage"
             );
     }
+
+    @Test
+    public void includesInheritedInstanceFields() {
+        test()
+            .executeProg()
+            .lines(
+                "package FieldIterationTest",
+                "    native testSuccess()",
+                "    class Acc",
+                "        int total = 0",
+                "        function add(int value)",
+                "            total = total + value",
+                "    class Base",
+                "        int inherited = 1",
+                "    class Data extends Base",
+                "        int local = 2",
+                "",
+                "        function save(Acc acc)",
+                "            __wurst_forFields((name, value) -> acc.add(value))",
+                "",
+                "    init",
+                "        let acc = new Acc",
+                "        let data = new Data",
+                "        data.save(acc)",
+                "        if acc.total == 3",
+                "            testSuccess()",
+                "endpackage"
+            );
+    }
+
+    @Test
+    public void expandsFieldIterationInModuleMethodsAfterInstantiation() {
+        test()
+            .executeProg()
+            .lines(
+                "package FieldIterationTest",
+                "    native testSuccess()",
+                "    class Acc",
+                "        int total = 0",
+                "        function add(int value)",
+                "            total = total + value",
+                "    module Serializer",
+                "        function save(Acc acc)",
+                "            __wurst_forFields((name, value) -> acc.add(value))",
+                "",
+                "    class Data",
+                "        use Serializer",
+                "        int inherited = 1",
+                "        int local = 2",
+                "        int count = 0",
+                "",
+                "    init",
+                "        let acc = new Acc",
+                "        let data = new Data",
+                "        data.save(acc)",
+                "        if acc.total == 3",
+                "            testSuccess()",
+                "endpackage"
+            );
+    }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -289,6 +289,7 @@ public class FieldIterationTests extends WurstScriptTest {
                 "        function add(int value)",
                 "            total = total + value",
                 "    class Base",
+                "        private int hidden = 100",
                 "        int inherited = 1",
                 "    class Data extends Base",
                 "        int local = 2",
@@ -320,6 +321,7 @@ public class FieldIterationTests extends WurstScriptTest {
                 "    module Serializer",
                 "        function save(Acc acc)",
                 "            __wurst_forFields((name, value) -> acc.add(value))",
+                "            __wurst_forFields((name, value) -> acc.add(value))",
                 "",
                 "    class Data",
                 "        use Serializer",
@@ -331,7 +333,7 @@ public class FieldIterationTests extends WurstScriptTest {
                 "        let acc = new Acc",
                 "        let data = new Data",
                 "        data.save(acc)",
-                "        if acc.total == 3",
+                "        if acc.total == 6",
                 "            testSuccess()",
                 "endpackage"
             );

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -204,4 +204,30 @@ public class FieldIterationTests extends WurstScriptTest {
                 "endpackage"
             );
     }
+
+    @Test
+    public void preservesLocalBindingsInBlockCallbacks() {
+        test()
+            .executeProg()
+            .lines(
+                "package FieldIterationTest",
+                "    native testSuccess()",
+                "    class Data",
+                "        int first = 1",
+                "        int second = 2",
+                "",
+                "        function load()",
+                "            __wurst_mapFields((name, value) -> begin",
+                "                let value = 42",
+                "                return value",
+                "            end)",
+                "",
+                "    init",
+                "        let data = new Data",
+                "        data.load()",
+                "        if data.first == 42 and data.second == 42",
+                "            testSuccess()",
+                "endpackage"
+            );
+    }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -218,8 +218,8 @@ public class FieldIterationTests extends WurstScriptTest {
                 "",
                 "        function load()",
                 "            __wurst_mapFields((name, value) -> begin",
-                "                let value = 42",
-                "                return value",
+                "                let temporary = 42",
+                "                return temporary",
                 "            end)",
                 "",
                 "    init",
@@ -244,7 +244,7 @@ public class FieldIterationTests extends WurstScriptTest {
                 "",
                 "        function load()",
                 "            __wurst_mapFields((name, value) -> begin",
-                "                for int value = 0 to 1",
+                "                for int index = 0 to 1",
                 "                    continue",
                 "                return 42 + value - value",
                 "            end)",
@@ -254,6 +254,25 @@ public class FieldIterationTests extends WurstScriptTest {
                 "        data.load()",
                 "        if data.first == 42 and data.second == 42",
                 "            testSuccess()",
+                "endpackage"
+            );
+    }
+
+    @Test
+    public void rejectsBlockLocalShadowingBeforeExpansion() {
+        test()
+            .expectError("cannot declare locals or loop variables")
+            .lines(
+                "package FieldIterationTest",
+                "    class Data",
+                "        int value",
+                "",
+                "        function load()",
+                "            __wurst_mapFields((name, value) -> begin",
+                "                let old = value",
+                "                let value = 42",
+                "                return old",
+                "            end)",
                 "endpackage"
             );
     }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ModelManagerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ModelManagerTests.java
@@ -125,6 +125,66 @@ public class ModelManagerTests {
     }
 
     @Test
+    public void incrementalRecheckRestoresFieldIterationIntrinsic() throws IOException {
+        File projectFolder = new File("./temp/testProject_field_iteration_incremental/");
+        File wurstFolder = new File(projectFolder, "wurst");
+        newCleanFolder(wurstFolder);
+
+        WFile fileBase = WFile.create(new File(wurstFolder, "Base.wurst"));
+        WFile fileData = WFile.create(new File(wurstFolder, "Data.wurst"));
+        WFile fileWurst = WFile.create(new File(wurstFolder, "Wurst.wurst"));
+        writeFile(fileBase, string(
+            "package Base",
+            "public class Base",
+            "    int oldValue = 1"
+        ));
+        writeFile(fileData, string(
+            "package Data",
+            "import Base",
+            "native consume(string name, int value)",
+            "class Data extends Base",
+            "    function save()",
+            "        __wurst_forFields((name, value) -> consume(name, value))"
+        ));
+        writeFile(fileWurst, "package Wurst\n");
+
+        ModelManagerImpl manager = new ModelManagerImpl(projectFolder, new BufferManager());
+        manager.buildProject();
+
+        ClassDef data = findClass(manager.getCompilationUnit(fileData), "Data");
+        FuncDef save = findFunction(data, "save");
+        int initialBodySize = save.getBody().size();
+
+        manager.reconcile(manager.syncCompilationUnitContent(fileBase, string(
+            "package Base",
+            "public class Base",
+            "    int oldValue = 1",
+            "    int newValue = 2"
+        )));
+
+        data = findClass(manager.getCompilationUnit(fileData), "Data");
+        save = findFunction(data, "save");
+        assertEquals(save.getBody().size(), initialBodySize + 1);
+    }
+
+    private ClassDef findClass(CompilationUnit cu, String name) {
+        return cu.getPackages().stream()
+            .flatMap(p -> p.getElements().stream())
+            .filter(e -> e instanceof ClassDef && name.equals(((ClassDef) e).getName()))
+            .map(e -> (ClassDef) e)
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private FuncDef findFunction(ClassDef clazz, String name) {
+        return clazz.getMethods().stream()
+            .filter(f -> name.equals(f.getName()))
+            .map(f -> (FuncDef) f)
+            .findFirst()
+            .orElseThrow();
+    }
+
+    @Test
     public void movingFiles() throws IOException { // #712
         File projectFolder = new File("./temp/testProject2/");
         File wurstFolder = new File(projectFolder, "wurst");


### PR DESCRIPTION
## What changed

Adds two compile-time-expanded field operations for instance methods and constructors:

```wurst
__wurst_forFields((fieldName, value) -> writer.write(fieldName, value))
__wurst_mapFields((fieldName, value) -> reader.read(fieldName, value))
```

`__wurst_forFields` emits one direct callback expression per instance field. `__wurst_mapFields` emits one direct assignment per field using the callback result. Static fields are excluded and declaration order is preserved. The `__wurst_` spelling makes the compiler intrinsic explicit and leaves ordinary user-defined `forFields`/`mapFields` functions untouched.

## Why

Wurst save/load libraries currently require handwritten serialization and deserialization code for every field. Runtime reflection would add metadata and lookup overhead on Warcraft III targets. Expanding field operations before type checking gives reflection-like ergonomics while preserving overload resolution and producing the same direct field accesses as handwritten code.

This is intentionally a narrow draft/prototype so the API and limitations can be discussed before broadening it (for example inheritance, module fields, opt-out annotations, or schema/version behavior).

## Impact

- Format-agnostic: stdlib or user code chooses the writer/reader and encoding.
- Type-safe: generated calls go through normal overload resolution.
- Backend-neutral: expansion occurs before Jass/Lua lowering.
- Zero runtime reflection tables, iteration, closures, or dynamic lookup.

## Validation

- Added focused execution and diagnostic tests.
- Verified Jass and real Lua execution.
- Verified generated Lua contains direct typed calls and assignments and no field intrinsics.
- Added regression coverage for ordinary helper-name compatibility and nested closure shadowing.
- Full Gradle test suite passes (`./gradlew test`, 8m40s).
- `git diff --check` passes.