### PR TITLE
Fix module inlay hint source positions

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/InlayHintsRequest.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/InlayHintsRequest.java
@@ -20,6 +20,7 @@ import de.peeeq.wurstscript.ast.ExprNull;
 import de.peeeq.wurstscript.ast.ExprRealVal;
 import de.peeeq.wurstscript.ast.ExprStringVal;
 import de.peeeq.wurstscript.ast.FuncRef;
+import de.peeeq.wurstscript.ast.ModuleInstanciation;
 import de.peeeq.wurstscript.ast.NameRef;
 import de.peeeq.wurstscript.attributes.names.FuncLink;
 import org.eclipse.lsp4j.InlayHint;
@@ -68,6 +69,12 @@ public class InlayHintsRequest extends UserRequest<List<InlayHint>> {
         todo.push(cu);
         while (!todo.isEmpty()) {
             Element e = todo.pop();
+            // Module instantiations are compiler-generated copies of module bodies. Their children
+            // retain the source positions of the module definition, which are not positions in the
+            // document containing the `use` statement.
+            if (e instanceof ModuleInstanciation) {
+                continue;
+            }
             collectHints(hints, e);
             for (int i = e.size() - 1; i >= 0; i--) {
                 todo.push(e.get(i));
@@ -125,6 +132,9 @@ public class InlayHintsRequest extends UserRequest<List<InlayHint>> {
         Map<String, Integer> typeFrequencies = typeFrequencies(paramTypes);
         for (int i = 0; i < count; i++) {
             Expr arg = args.get(i);
+            if (!isConcreteSourceInRequestedFile(arg)) {
+                continue;
+            }
             String paramName = paramNames.get(i);
             if (paramName == null || paramName.isEmpty()) {
                 continue;
@@ -141,6 +151,11 @@ public class InlayHintsRequest extends UserRequest<List<InlayHint>> {
             hint.setPaddingRight(true);
             hints.add(hint);
         }
+    }
+
+    private boolean isConcreteSourceInRequestedFile(Expr arg) {
+        return !arg.attrSource().isArtificial()
+                && WFile.create(arg.attrSource().getFile()).equals(filename);
     }
 
     private int hintScore(Expr arg, String paramName, String paramType, Map<String, Integer> typeFrequencies) {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LspNativeFeaturesTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LspNativeFeaturesTests.java
@@ -47,6 +47,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -550,6 +551,37 @@ public class LspNativeFeaturesTests extends WurstLanguageServerTest {
     }
 
     @Test
+    public void inlayHintsIgnoreCopiedModuleBodyFromAnotherFile() throws IOException {
+        CompletionTestData data = input(
+                "package test",
+                "import HintModule",
+                "class Mover",
+                "    use HintModule",
+                "",
+                "",
+                "endpackage"
+        );
+        String module = String.join("\n",
+                "package HintModule",
+                "public module HintModule",
+                "    function target(int amount)",
+                "        skip",
+                "    function callTarget()",
+                "        target(1)",
+                "endpackage",
+                "");
+        TestContext ctx = createContext(data, data.buffer, Map.of("HintModule.wurst", module));
+
+        InlayHintParams params = new InlayHintParams(
+                new TextDocumentIdentifier(ctx.uri),
+                new Range(new Position(0, 0), new Position(100, 0))
+        );
+        List<InlayHint> hints = new InlayHintsRequest(params, ctx.bufferManager).execute(ctx.modelManager);
+
+        assertTrue(hints.isEmpty(), "Hints from a copied module body must not appear in the using file: " + hints);
+    }
+
+    @Test
     public void inlayHintsStayStableWhileTemporarilyUnparsable() throws IOException {
         CompletionTestData valid = input(
                 "package test",
@@ -870,6 +902,11 @@ public class LspNativeFeaturesTests extends WurstLanguageServerTest {
     }
 
     private TestContext createContext(CompletionTestData data, String diskContent) throws IOException {
+        return createContext(data, diskContent, Collections.emptyMap());
+    }
+
+    private TestContext createContext(CompletionTestData data, String diskContent,
+                                      Map<String, String> additionalFiles) throws IOException {
         File projectFolder = new File("./temp/lspNative/" + System.nanoTime());
         File wurstFolder = new File(projectFolder, "wurst");
         Files.createDirectories(wurstFolder.toPath());
@@ -878,6 +915,9 @@ public class LspNativeFeaturesTests extends WurstLanguageServerTest {
         File wurstFile = new File(wurstFolder, "Wurst.wurst");
         Files.writeString(testFile.toPath(), diskContent);
         Files.writeString(wurstFile.toPath(), "package Wurst\n");
+        for (Map.Entry<String, String> additionalFile : additionalFiles.entrySet()) {
+            Files.writeString(new File(wurstFolder, additionalFile.getKey()).toPath(), additionalFile.getValue());
+        }
 
         BufferManager bufferManager = new BufferManager();
         ModelManagerImpl modelManager = new ModelManagerImpl(projectFolder.getAbsoluteFile(), bufferManager);


### PR DESCRIPTION
## Summary

- skip compiler-generated module instantiation bodies when collecting inlay hints
- require hinted arguments to have concrete source positions in the requested document
- add a regression test for hints leaking from an imported module onto blank lines

## Root cause

Module expansion grafts copied module bodies beneath classes that use them. The copied expressions retain the module definition's line and column, while an LSP position carries no filename. Those coordinates were therefore interpreted as positions in the consuming document, producing hints on unrelated or empty lines.

## Impact

Classes using modules no longer display parameter hints originating from generated module copies. Normal source-level parameter hints remain unchanged.

## Validation

- `./gradlew.bat test --tests "tests.wurstscript.tests.LspNativeFeaturesTests.inlayHintsIgnoreCopiedModuleBodyFromAnotherFile"`
- `./gradlew.bat test --tests "tests.wurstscript.tests.LspNativeFeaturesTests"`
- `git diff --check`
