### PR TITLE
Add type class bounds for T: generics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,8 +330,9 @@ of save formats, `ChunkedString`, hashes, or `Serializable`.
 * Do not promise Lua support for a method which combines type parameters from its owning generic class with
   independent method type parameters. Serialization loaders should be free generic functions, or class methods
   parameterized only by their owning class.
-* Do not require Lua specialization of generic-construction methods invoked directly on a freshly constructed
-  generic receiver. Use the free generic loader shape, or bind the receiver to a typed local first.
+* A method invoked directly on a freshly constructed generic receiver is supported on Lua. The receiver's
+  declared type is still generic at that point, so specialization takes the instantiation from the construction.
+  Binding the receiver to a typed local first is no longer required.
 * Lua generic-construction dispatch through multi-parameter generic interfaces is outside the supported loader
   shape. The supported generic loader has a single construction type parameter.
 * Do not call `wurstNewInstance<T>()` from the constructor of a generic class. Construct the simple state object in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 ## 1.9 (in progress)
 
+- Added type class bounds for `T:` generics. A bound requires operations of the type it is bound to, so a
+  generic can do more than store and return values, without giving up static dispatch:
+
+        public interface Indexable<T:>
+            function toIndex(T x) returns int
+            function fromIndex(int i) returns T
+
+        implements Indexable<vec2>
+            function toIndex(vec2 v) returns int
+                ...
+            function fromIndex(int i) returns vec2
+                ...
+
+        class HashMap<K: Indexable, V: Indexable>
+            function get(K key) returns V
+                return V.fromIndex(loadInt(K.toIndex(key)))
+
+    A bound names the interface unapplied, so `<K: Indexable>` means "there is an instance of `Indexable<K>`",
+    and several combine with `and`. Requirements are called on the type parameter (`K.toIndex(key)`), which
+    keeps operations that produce a value of the type, such as `fromIndex`, in the same form as the rest.
+
+    Unlike an interface used as a supertype, a bound is satisfiable by `int`, `real`, `string`, tuples and
+    handle types, and costs nothing at runtime: after specialisation each requirement is a direct call to the
+    instance function, on both Jass and Lua.
+
+    An instance of `I` for type `X` may only be declared in the package declaring `I` or the one declaring
+    `X`, and only once, so `I` for `X` means the same thing throughout a program regardless of imports.
+
 - Added new pseudo-natives for debugging memory leaks:
 
         // returns the maximum type id, can be usd to

--- a/de.peeeq.wurstscript/parserspec/wurstscript.parseq
+++ b/de.peeeq.wurstscript/parserspec/wurstscript.parseq
@@ -36,6 +36,8 @@ WEntity =
 	| ModuleDef(@ignoreForEquality de.peeeq.wurstscript.parser.WPos source, Modifiers modifiers, Identifier nameId, TypeParamDefs typeParameters,
 			ClassDefs innerClasses, FuncDefs methods, GlobalVarDefs vars, ConstructorDefs constructors,
 			ModuleInstanciations p_moduleInstanciations, ModuleUses moduleUses, OnDestroyDef onDestroy)
+	// A type class instance: binds one interface to one concrete type.
+	| InstanceDecl(@ignoreForEquality de.peeeq.wurstscript.parser.WPos source, Modifiers modifiers, TypeExpr implementedInterface, FuncDefs methods)
 
 
 
@@ -287,6 +289,7 @@ WScope =
 	| WBlock
 	| WEntities
 	| ExprClosure
+	| InstanceDecl
 
 PackageOrGlobal = WPackage | CompilationUnit
 
@@ -315,7 +318,7 @@ Modifier =
 
 // ElementWithBody = FunctionImplementation | InitBlock | ConstructorDef | OnDestroyDef
 //ElementWithModifier = NameDef | TypeDef | ModuleDef | ConstructorDef | GlobalVarDef | FunctionDefinition
-HasModifier = NameDef | TypeDef | ModuleDef | ConstructorDef | GlobalVarDef | FunctionDefinition
+HasModifier = NameDef | TypeDef | ModuleDef | ConstructorDef | GlobalVarDef | FunctionDefinition | InstanceDecl
 HasTypeArgs =  ExprNewObject | FunctionCall | ModuleUse | StmtCall | TypeExprSimple
 
 AstElementWithFuncName = ExprFunctionCall | ExprMemberMethod | ExprFuncRef

--- a/de.peeeq.wurstscript/src/main/antlr/de/peeeq/wurstscript/antlr/Wurst.g4
+++ b/de.peeeq.wurstscript/src/main/antlr/de/peeeq/wurstscript/antlr/Wurst.g4
@@ -134,11 +134,13 @@ classDef:
         ;
 
 // A type class instance: binds an interface to one concrete type, e.g.
-//    instance Indexable<vec2>
+//    implements Indexable<vec2>
 //        function toIndex(vec2 v) returns int
 //            ...
+// This reuses the existing 'implements' keyword deliberately. Introducing a new one would
+// reserve a plausible identifier ('instance' is used as a local in the standard library).
 instanceDef:
-    modifiersWithDoc 'instance' implemented=typeExpr
+    modifiersWithDoc 'implements' implemented=typeExpr
     NL (STARTBLOCK
        methods+=funcDef*
     ENDBLOCK)?

--- a/de.peeeq.wurstscript/src/main/antlr/de/peeeq/wurstscript/antlr/Wurst.g4
+++ b/de.peeeq.wurstscript/src/main/antlr/de/peeeq/wurstscript/antlr/Wurst.g4
@@ -112,6 +112,7 @@ entity:
       | interfaceDef
       | tupleDef
       | extensionFuncDef
+      | instanceDef
 ;
 
 interfaceDef:
@@ -132,11 +133,14 @@ classDef:
             ENDBLOCK)?
         ;
 
-typeclassDef:
-    modifiersWithDoc 'typeclass' name=ID typeParams
-    ('extends' implemented+=typeExpr (',' implemented+=typeExpr)*)?
+// A type class instance: binds an interface to one concrete type, e.g.
+//    instance Indexable<vec2>
+//        function toIndex(vec2 v) returns int
+//            ...
+instanceDef:
+    modifiersWithDoc 'instance' implemented=typeExpr
     NL (STARTBLOCK
-       classSlots
+       methods+=funcDef*
     ENDBLOCK)?
     ;
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
@@ -877,8 +877,8 @@ public class WurstCompilerJassImpl implements WurstCompiler {
 
         ImAttrType.setWurstClassType(null);
         int stage;
-        if (containsGenericNewCall()) {
-            beginPhase(2, "Specialize generics for generic construction");
+        if (needsGenericSpecialization()) {
+            beginPhase(2, "Specialize generics for generic construction and type class dispatch");
             new EliminateGenerics(getImTranslator(), getImProg()).transformGenericNewOnly();
             timeTaker.endPhase();
         }
@@ -969,7 +969,12 @@ public class WurstCompilerJassImpl implements WurstCompiler {
         return luaCode;
     }
 
-    private boolean containsGenericNewCall() {
+    /**
+     * Whether the program uses an operation which needs the concrete type argument even on Lua,
+     * where generics are otherwise erased: constructing a value of a type parameter, or dispatching
+     * on a type class bound.
+     */
+    private boolean needsGenericSpecialization() {
         boolean[] found = {false};
         getImProg().accept(new de.peeeq.wurstscript.jassIm.Element.DefaultVisitor() {
             @Override
@@ -979,6 +984,11 @@ public class WurstCompilerJassImpl implements WurstCompiler {
                     return;
                 }
                 super.visit(call);
+            }
+
+            @Override
+            public void visit(ImTypeVarDispatch dispatch) {
+                found[0] = true;
             }
         });
         return found[0];

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
@@ -877,15 +877,11 @@ public class WurstCompilerJassImpl implements WurstCompiler {
 
         ImAttrType.setWurstClassType(null);
         int stage;
-        if (containsTypeClassDispatch()) {
-            // A type class bound is resolved by monomorphisation: the implementation is chosen per
-            // concrete type argument. Erasure cannot express that, so a program which uses a bound
-            // gets the same full elimination as the Jass target rather than the targeted pass.
-            beginPhase(2, "Eliminate generics for type class dispatch");
-            new EliminateGenerics(getImTranslator(), getImProg()).transform();
-            timeTaker.endPhase();
-        } else if (containsGenericNewCall()) {
-            beginPhase(2, "Specialize generics for generic construction");
+        if (containsGenericNewCall() || containsTypeClassDispatch()) {
+            // Both operations need the concrete type argument, which erasure does not keep. Only
+            // the paths reaching them are specialised: the full elimination used for Jass is
+            // followed there by class elimination, and leaves state this backend cannot consume.
+            beginPhase(2, "Specialize generics for generic construction and type class dispatch");
             new EliminateGenerics(getImTranslator(), getImProg()).transformGenericNewOnly();
             timeTaker.endPhase();
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
@@ -877,8 +877,15 @@ public class WurstCompilerJassImpl implements WurstCompiler {
 
         ImAttrType.setWurstClassType(null);
         int stage;
-        if (needsGenericSpecialization()) {
-            beginPhase(2, "Specialize generics for generic construction and type class dispatch");
+        if (containsTypeClassDispatch()) {
+            // A type class bound is resolved by monomorphisation: the implementation is chosen per
+            // concrete type argument. Erasure cannot express that, so a program which uses a bound
+            // gets the same full elimination as the Jass target rather than the targeted pass.
+            beginPhase(2, "Eliminate generics for type class dispatch");
+            new EliminateGenerics(getImTranslator(), getImProg()).transform();
+            timeTaker.endPhase();
+        } else if (containsGenericNewCall()) {
+            beginPhase(2, "Specialize generics for generic construction");
             new EliminateGenerics(getImTranslator(), getImProg()).transformGenericNewOnly();
             timeTaker.endPhase();
         }
@@ -969,12 +976,8 @@ public class WurstCompilerJassImpl implements WurstCompiler {
         return luaCode;
     }
 
-    /**
-     * Whether the program uses an operation which needs the concrete type argument even on Lua,
-     * where generics are otherwise erased: constructing a value of a type parameter, or dispatching
-     * on a type class bound.
-     */
-    private boolean needsGenericSpecialization() {
+    /** Whether the program constructs a value of a type parameter, which needs its concrete type. */
+    private boolean containsGenericNewCall() {
         boolean[] found = {false};
         getImProg().accept(new de.peeeq.wurstscript.jassIm.Element.DefaultVisitor() {
             @Override
@@ -985,7 +988,14 @@ public class WurstCompilerJassImpl implements WurstCompiler {
                 }
                 super.visit(call);
             }
+        });
+        return found[0];
+    }
 
+    /** Whether the program dispatches on a type class bound anywhere. */
+    private boolean containsTypeClassDispatch() {
+        boolean[] found = {false};
+        getImProg().accept(new de.peeeq.wurstscript.jassIm.Element.DefaultVisitor() {
             @Override
             public void visit(ImTypeVarDispatch dispatch) {
                 found[0] = true;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/DocumentSymbolRequest.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/DocumentSymbolRequest.java
@@ -117,7 +117,7 @@ public class DocumentSymbolRequest extends UserRequest<List<Either<SymbolInforma
             @Override
             public void case_InstanceDecl(InstanceDecl instanceDecl) {
                 List<DocumentSymbol> children = new ArrayList<>();
-                add("instance " + instanceDecl.getImplementedInterface(), SymbolKind.Object, children);
+                add("implements " + instanceDecl.getImplementedInterface(), SymbolKind.Object, children);
                 for (FuncDef f : instanceDecl.getMethods()) {
                     addSymbolsForEntity(children, f);
                 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/DocumentSymbolRequest.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/DocumentSymbolRequest.java
@@ -115,6 +115,15 @@ public class DocumentSymbolRequest extends UserRequest<List<Either<SymbolInforma
             }
 
             @Override
+            public void case_InstanceDecl(InstanceDecl instanceDecl) {
+                List<DocumentSymbol> children = new ArrayList<>();
+                add("instance " + instanceDecl.getImplementedInterface(), SymbolKind.Object, children);
+                for (FuncDef f : instanceDecl.getMethods()) {
+                    addSymbolsForEntity(children, f);
+                }
+            }
+
+            @Override
             public void case_InterfaceDef(InterfaceDef interfaceDef) {
                 String name = interfaceDef.getName();
                 List<DocumentSymbol> children = new ArrayList<>();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/HoverInfo.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/HoverInfo.java
@@ -7,6 +7,7 @@ import de.peeeq.wurstio.languageserver.WFile;
 import de.peeeq.wurstscript.WLogger;
 import de.peeeq.wurstscript.ast.*;
 import de.peeeq.wurstscript.attributes.AttrWurstDoc;
+import de.peeeq.wurstscript.attributes.DescriptionHtml;
 import de.peeeq.wurstscript.attributes.names.FuncLink;
 import de.peeeq.wurstscript.attributes.names.NameLink;
 import de.peeeq.wurstscript.parser.TriviaIndex;
@@ -401,6 +402,11 @@ public class HoverInfo extends UserRequest<Hover> {
         @Override
         public List<Either<String, MarkedString>> case_InterfaceDef(InterfaceDef interfaceDef) {
             return description(interfaceDef);
+        }
+
+        @Override
+        public List<Either<String, MarkedString>> case_InstanceDecl(InstanceDecl instanceDecl) {
+            return string(DescriptionHtml.description(instanceDecl));
         }
 
         @Override

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/SymbolInformationRequest.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/SymbolInformationRequest.java
@@ -87,6 +87,15 @@ public class SymbolInformationRequest extends UserRequest<Either<List<? extends 
             }
 
             @Override
+            public void case_InstanceDecl(InstanceDecl instanceDecl) {
+                String name = "instance " + instanceDecl.getImplementedInterface();
+                add(name, SymbolKind.Object);
+                for (FuncDef f : instanceDecl.getMethods()) {
+                    addSymbolsForEntity(result, containerName + "." + name, f);
+                }
+            }
+
+            @Override
             public void case_InterfaceDef(InterfaceDef interfaceDef) {
                 String name = interfaceDef.getName();
                 add(name, SymbolKind.Interface);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/SymbolInformationRequest.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/requests/SymbolInformationRequest.java
@@ -88,7 +88,7 @@ public class SymbolInformationRequest extends UserRequest<Either<List<? extends 
 
             @Override
             public void case_InstanceDecl(InstanceDecl instanceDecl) {
-                String name = "instance " + instanceDecl.getImplementedInterface();
+                String name = "implements " + instanceDecl.getImplementedInterface();
                 add(name, SymbolKind.Object);
                 for (FuncDef f : instanceDecl.getMethods()) {
                     addSymbolsForEntity(result, containerName + "." + name, f);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrImplicitParameter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrImplicitParameter.java
@@ -5,6 +5,7 @@ import de.peeeq.wurstscript.attributes.names.FuncLink;
 import de.peeeq.wurstscript.attributes.names.NameLink;
 import de.peeeq.wurstscript.attributes.names.OtherLink;
 import de.peeeq.wurstscript.types.WurstType;
+import de.peeeq.wurstscript.types.WurstTypeTypeParam;
 import org.eclipse.jdt.annotation.Nullable;
 
 public class AttrImplicitParameter {
@@ -86,6 +87,21 @@ public class AttrImplicitParameter {
         return getFunctionCallImplicitParameter(e, calledFunc, true);
     }
 
+    /**
+     * True for a call whose receiver is a bounded type parameter standing for itself, as in
+     * {@code T.toIndex(x)}. Such a call resolves through the type class instance chosen for T and
+     * therefore takes no implicit {@code this}.
+     */
+    public static boolean isTypeClassDispatch(Element e) {
+        if (!(e instanceof HasReceiver hasReceiver)) {
+            return false;
+        }
+        Expr left = hasReceiver.getLeft();
+        return left != null
+            && left.attrTyp() instanceof WurstTypeTypeParam tp
+            && tp.isStaticRef();
+    }
+
     static OptExpr getFunctionCallImplicitParameter(FunctionCall e, FuncLink calledFunc, boolean showError) {
         if (e instanceof HasReceiver) {
             HasReceiver hasReceiver = (HasReceiver) e;
@@ -98,6 +114,11 @@ public class AttrImplicitParameter {
             }
         }
         if (calledFunc == null) {
+            return Ast.NoExpr();
+        }
+        if (isTypeClassDispatch(e)) {
+            // T.f(x): the bound supplies the implementation and the value is an ordinary
+            // argument, so there is no receiver to pass even though f is declared as a method.
             return Ast.NoExpr();
         }
         if (calledFunc.getDef().attrIsDynamicClassMember()) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrNameDef.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrNameDef.java
@@ -83,18 +83,17 @@ public class AttrNameDef {
     protected static NameLink searchNameInScope(String varName, NameRef node) {
         boolean showErrors = !varName.startsWith("gg_");
         if (!"it".equals(varName)) {
-            NameLink found = node.lookupVar(varName, false);
-            if (found != null) {
-                return found;
+            // A bounded type parameter can stand in receiver position, as in T.toIndex(x). The
+            // syntactic test comes first so ordinary lookups keep their original cost, and the
+            // probe below uses the cached form. Anything else falls through to the normal lookup,
+            // which must stay the last word so that it still reports ambiguity and unknown names.
+            if (isMethodCallReceiver(node) && node.lookupVar(varName, false) == null) {
+                NameLink typeParamRef = lookupBoundedTypeParam(varName, node);
+                if (typeParamRef != null) {
+                    return typeParamRef;
+                }
             }
-            // A bounded type parameter can stand in receiver position, as in T.toIndex(x).
-            // Only reachable once ordinary variable lookup has failed, so it cannot shadow a real
-            // variable of the same name.
-            NameLink typeParamRef = lookupBoundedTypeParam(varName, node);
-            if (typeParamRef != null) {
-                return typeParamRef;
-            }
-            return showErrors ? node.lookupVar(varName, true) : null;
+            return node.lookupVar(varName, showErrors);
         }
 
         // Normal lexical lookup wins, so user-defined names can shadow implicit closure-self.
@@ -120,17 +119,19 @@ public class AttrNameDef {
         return node.lookupVar(varName, true);
     }
 
+    /** True when this reference is the receiver of a method call, as {@code T} is in {@code T.f(x)}. */
+    private static boolean isMethodCallReceiver(NameRef node) {
+        return node.getParent() instanceof ExprMemberMethod call && call.getLeft() == node;
+    }
+
     /**
      * Resolves a name which refers to a type parameter carrying type class bounds, so that the
      * parameter can be used as the receiver of a required method: {@code T.toIndex(x)}.
      * <p>
-     * Restricted to the receiver of a method call, because a bare type parameter is not a value and
-     * should keep reporting the ordinary "unknown variable" error everywhere else.
+     * A bare type parameter is not a value, so this is deliberately limited to receiver position;
+     * everywhere else the ordinary "unknown variable" error is the right answer.
      */
     private static @Nullable NameLink lookupBoundedTypeParam(String varName, NameRef node) {
-        if (!(node.getParent() instanceof ExprMemberMethod call) || call.getLeft() != node) {
-            return null;
-        }
         TypeDef typeDef = node.lookupType(varName, false);
         if (!(typeDef instanceof TypeParamDef tp) || !TypeClassConstraints.hasBounds(tp)) {
             return null;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrNameDef.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrNameDef.java
@@ -5,8 +5,12 @@ import de.peeeq.wurstscript.attributes.names.FuncLink;
 import de.peeeq.wurstscript.attributes.names.NameLink;
 import de.peeeq.wurstscript.attributes.names.OtherLink;
 import de.peeeq.wurstscript.attributes.names.Visibility;
+import de.peeeq.wurstscript.jassIm.ImFunction;
+import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
+import de.peeeq.wurstscript.types.TypeClassConstraints;
 import de.peeeq.wurstscript.types.WurstType;
 import de.peeeq.wurstscript.types.WurstTypeClassOrInterface;
+import de.peeeq.wurstscript.types.WurstTypeTypeParam;
 import de.peeeq.wurstscript.types.WurstTypeUnknown;
 import de.peeeq.wurstscript.types.WurstTypeEnum;
 import de.peeeq.wurstscript.types.WurstTypeModule;
@@ -79,7 +83,18 @@ public class AttrNameDef {
     protected static NameLink searchNameInScope(String varName, NameRef node) {
         boolean showErrors = !varName.startsWith("gg_");
         if (!"it".equals(varName)) {
-            return node.lookupVar(varName, showErrors);
+            NameLink found = node.lookupVar(varName, false);
+            if (found != null) {
+                return found;
+            }
+            // A bounded type parameter can stand in receiver position, as in T.toIndex(x).
+            // Only reachable once ordinary variable lookup has failed, so it cannot shadow a real
+            // variable of the same name.
+            NameLink typeParamRef = lookupBoundedTypeParam(varName, node);
+            if (typeParamRef != null) {
+                return typeParamRef;
+            }
+            return showErrors ? node.lookupVar(varName, true) : null;
         }
 
         // Normal lexical lookup wins, so user-defined names can shadow implicit closure-self.
@@ -103,6 +118,31 @@ public class AttrNameDef {
 
         // Fallback to default diagnostics when no implicit closure-self is available.
         return node.lookupVar(varName, true);
+    }
+
+    /**
+     * Resolves a name which refers to a type parameter carrying type class bounds, so that the
+     * parameter can be used as the receiver of a required method: {@code T.toIndex(x)}.
+     * <p>
+     * Restricted to the receiver of a method call, because a bare type parameter is not a value and
+     * should keep reporting the ordinary "unknown variable" error everywhere else.
+     */
+    private static @Nullable NameLink lookupBoundedTypeParam(String varName, NameRef node) {
+        if (!(node.getParent() instanceof ExprMemberMethod call) || call.getLeft() != node) {
+            return null;
+        }
+        TypeDef typeDef = node.lookupType(varName, false);
+        if (!(typeDef instanceof TypeParamDef tp) || !TypeClassConstraints.hasBounds(tp)) {
+            return null;
+        }
+        WurstTypeTypeParam typ = new WurstTypeTypeParam(tp).asStaticRef();
+        return new OtherLink(Visibility.LOCAL, varName, typ) {
+            @Override
+            public de.peeeq.wurstscript.jassIm.ImExpr translate(NameRef e, ImTranslator t, ImFunction f) {
+                throw new CompileError(e.attrSource(),
+                        "Type parameter " + varName + " is not a value; it can only be used to call a method required by its bounds.");
+            }
+        };
     }
 
     private static @Nullable NameLink lookupImplicitClosureSelf(NameRef node, boolean showErrors) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/DescriptionHtml.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/DescriptionHtml.java
@@ -230,6 +230,11 @@ public class DescriptionHtml {
         return "An init block: This block is executed at map start";
     }
 
+    public static String description(InstanceDecl instanceDecl) {
+        return "A type class instance for " + instanceDecl.getImplementedInterface()
+                + ": it lets this type be used where that interface is required as a type bound.";
+    }
+
     public static @Nullable String description(
             IdentifierWithTypeParamDefs identifierWithTypeParamDefs) {
         return null;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/ModifiersUtil.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/ModifiersUtil.java
@@ -19,6 +19,7 @@ public final class ModifiersUtil {
             case TupleDef t              -> t.getModifiers();
             case ExtensionFuncDef e      -> e.getModifiers();
             case TypeParamDef tp         -> tp.getModifiers();
+            case InstanceDecl id         -> id.getModifiers();
 
             // If HasModifier ever expands, the compiler will force you to handle new cases here.
             case EnumDef enumDef -> enumDef.getModifiers();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/ReadVariables.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/ReadVariables.java
@@ -142,6 +142,10 @@ public class ReadVariables {
         return generic(e);
     }
 
+    public static ImmutableList<NameDef> calculate(InstanceDecl e) {
+        return generic(e);
+    }
+
     public static ImmutableList<NameDef> calculate(CompilationUnit e) {
         return generic(e);
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/names/FuncLink.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/names/FuncLink.java
@@ -209,6 +209,21 @@ public class FuncLink extends DefLink {
         }
     }
 
+    /**
+     * Re-points this link at a different receiver type.
+     * <p>
+     * Used for type class dispatch: a requirement is declared as a method of the interface, but a
+     * bound exposes it on the constrained type parameter itself, so {@code T.f(x)} resolves with
+     * {@code T} as the receiver rather than an interface instance.
+     */
+    public FuncLink withReceiverType(@Nullable WurstType newReceiverType) {
+        if (newReceiverType == getReceiverType()) {
+            return this;
+        }
+        return new FuncLink(getVisibility(), getDefinedIn(), getTypeParams(), newReceiverType, def,
+                parameterNames, parameterTypes, returnType, mapping);
+    }
+
     @Override
     public DefLink withGenericTypeParams(List<TypeParamDef> typeParams) {
         if (typeParams.isEmpty()) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/names/NameLinks.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/names/NameLinks.java
@@ -96,6 +96,16 @@ public class NameLinks {
         }
     }
 
+    /**
+     * A type class instance only defines the functions written in its body. The instance methods
+     * are not inherited by anything, so no super-scope merging is required here.
+     */
+    public static ImmutableMultimap<String, DefLink> calculate(InstanceDecl i) {
+        Multimap<String, DefLink> result = HashMultimap.create();
+        addDefinedNames(result, i, i.getMethods());
+        return ImmutableMultimap.copyOf(result);
+    }
+
     public static ImmutableMultimap<String, DefLink> calculate(InterfaceDef i) {
         Multimap<String, DefLink> result = HashMultimap.create();
         addDefinedNames(result, i, i.getMethods());

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/names/TypeNameLinks.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/names/TypeNameLinks.java
@@ -39,6 +39,11 @@ public class TypeNameLinks {
         return ImmutableMultimap.of();
     }
 
+    /** v1 type class instances have no type parameters of their own. */
+    public static ImmutableMultimap<String, TypeLink> calculate(InstanceDecl i) {
+        return ImmutableMultimap.of();
+    }
+
     public static ImmutableMultimap<String, TypeLink> calculate(InterfaceDef i) {
         ImmutableMultimap.Builder<String, TypeLink> result = ImmutableSetMultimap.builder();
         addTypeParametersIfAny(result, i);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/prettyPrint/PrettyPrinter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/prettyPrint/PrettyPrinter.java
@@ -637,6 +637,20 @@ public class PrettyPrinter {
         e.getBody().prettyPrint(spacer, sb, indent + 1);
     }
 
+    public static void prettyPrint(InstanceDecl e, Spacer spacer, StringBuilder sb, int indent) {
+        printFirstNewline(e, sb, indent);
+        // InstanceDecl is not a Documentable (it has no name), so inline the printStuff steps:
+        printCommentsBefore(sb, e, indent);
+        printHotDoc(e.getModifiers(), spacer, sb, indent);
+        printIndent(sb, indent);
+        e.getModifiers().prettyPrint(spacer, sb, indent);
+        sb.append("instance");
+        spacer.addSpace(sb);
+        e.getImplementedInterface().prettyPrint(spacer, sb, indent);
+        e.getMethods().prettyPrint(spacer, sb, indent + 1);
+        printCommentsAfter(sb, e, indent);
+    }
+
     public static void prettyPrint(InterfaceDef e, Spacer spacer, StringBuilder sb, int indent) {
         printFirstNewline(e, sb, indent);
         printStuff(e, spacer, sb, indent);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/prettyPrint/PrettyPrinter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/prettyPrint/PrettyPrinter.java
@@ -644,7 +644,7 @@ public class PrettyPrinter {
         printHotDoc(e.getModifiers(), spacer, sb, indent);
         printIndent(sb, indent);
         e.getModifiers().prettyPrint(spacer, sb, indent);
-        sb.append("instance");
+        sb.append("implements");
         spacer.addSpace(sb);
         e.getImplementedInterface().prettyPrint(spacer, sb, indent);
         e.getMethods().prettyPrint(spacer, sb, indent + 1);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/EvaluateExpr.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/EvaluateExpr.java
@@ -13,6 +13,7 @@ import de.peeeq.wurstscript.translation.imtranslation.CallType;
 import de.peeeq.wurstscript.translation.imtranslation.ImPrinter;
 import de.peeeq.wurstscript.types.TypesHelper;
 import de.peeeq.wurstscript.utils.Utils;
+import io.vavr.control.Either;
 import org.eclipse.jdt.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -489,8 +490,27 @@ public class EvaluateExpr {
 
 
     public static ILconst eval(ImTypeVarDispatch e, ProgramState globalState, LocalState localState) {
-        // TODO store type arguments in localState with the required dispatch functions
-        throw new InterpreterException(e.attrTrace(), "Cannot evaluate " + e);
+        mark(e, globalState);
+        ImTypeArgument typeArgument = localState.getTypeArgument(e.getTypeVariable());
+        if (typeArgument == null) {
+            throw new InterpreterException(e.attrTrace(),
+                "No type argument bound for " + e.getTypeVariable().getName()
+                    + ", so " + e.getTypeClassFunc().getName() + " cannot be dispatched.");
+        }
+        Either<ImMethod, ImFunction> impl = typeArgument.getTypeClassBinding().get(e.getTypeClassFunc());
+        if (impl == null) {
+            throw new InterpreterException(e.attrTrace(),
+                "No type class instance bound for " + e.getTypeClassFunc().getName()
+                    + " on type argument " + typeArgument.getType() + ".");
+        }
+        ImFunction target = impl.isRight() ? impl.get() : impl.getLeft().getImplementation();
+
+        ImExprs arguments = e.getArguments();
+        ILconst[] args = new ILconst[arguments.size()];
+        for (int i = 0; i < arguments.size(); i++) {
+            args[i] = arguments.get(i).evaluate(globalState, localState);
+        }
+        return ILInterpreter.runFunc(globalState, target, e, args).getReturnVal();
     }
 
     public static ILconst eval(ImCast imCast, ProgramState globalState, LocalState localState) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
@@ -48,6 +48,31 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
         this(prog, gui, mapFile, new ProgramState(gui, prog, isCompiletime));
     }
 
+    /**
+     * Records the call's type arguments against the callee's type variables, so that a type class
+     * dispatch inside the body can find the instance chosen at the call site. Only relevant when
+     * interpreting a program which still has generics.
+     */
+    private static void bindTypeArguments(LocalState localState, ImFunction f, @Nullable Element caller) {
+        ImTypeArguments typeArgs;
+        if (caller instanceof ImFunctionCall call) {
+            typeArgs = call.getTypeArguments();
+        } else if (caller instanceof ImMethodCall call) {
+            typeArgs = call.getTypeArguments();
+        } else {
+            return;
+        }
+        List<ImTypeVar> typeVars = f.getTypeVariables();
+        if (typeArgs.isEmpty() || typeVars.isEmpty()) {
+            return;
+        }
+        Map<ImTypeVar, ImTypeArgument> binding = new HashMap<>();
+        for (int i = 0; i < Math.min(typeVars.size(), typeArgs.size()); i++) {
+            binding.put(typeVars.get(i), typeArgs.get(i));
+        }
+        localState.setTypeArguments(binding);
+    }
+
     public static LocalState runFunc(ProgramState globalState, ImFunction f, @Nullable Element caller,
                                      ILconst... args) {
         if (Thread.currentThread().isInterrupted()) {
@@ -94,6 +119,7 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
             for (int i = 0; i < f.getParameters().size(); i++) {
                 localState.setVal(f.getParameters().get(i), args[i]);
             }
+            bindTypeArguments(localState, f, caller);
 
             // --- stacktrace bookkeeping ---
             if (f.getBody().isEmpty()) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
@@ -60,11 +60,8 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
         // A bound may belong to the owning class rather than to the method, as in
         // class Box<T: Show>. The receiver carries the arguments the class was created with.
         if (args.length > 0 && args[0] instanceof ILconstObject receiver) {
-            ImTypeArguments classArgs = receiver.getType().getTypeArguments();
-            ImTypeVars classVars = receiver.getType().getClassDef().getTypeVariables();
-            for (int i = 0; i < Math.min(classVars.size(), classArgs.size()); i++) {
-                binding.put(classVars.get(i), inheritIfStillAbstract(globalState, classArgs.get(i)));
-            }
+            bindClassTypeArguments(globalState, binding, receiver.getType(),
+                Collections.newSetFromMap(new IdentityHashMap<>()));
         }
 
         ImTypeArguments typeArgs = null;
@@ -92,6 +89,30 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
 
         if (!binding.isEmpty()) {
             localState.setTypeArguments(binding);
+        }
+    }
+
+    /**
+     * Binds the type variables of the receiver's class and of every class it inherits from.
+     * <p>
+     * A subclass may fix its parent's parameter, as in {@code class Child extends Parent<int>}.
+     * The bound then belongs to {@code Parent}, while the receiver is a {@code Child} carrying no
+     * arguments of its own, so the supertype chain is where the concrete type is recorded.
+     */
+    private static void bindClassTypeArguments(ProgramState globalState,
+                                               Map<ImTypeVar, ImTypeArgument> binding,
+                                               ImClassType classType, Set<ImClass> visited) {
+        ImClass classDef = classType.getClassDef();
+        if (!visited.add(classDef)) {
+            return;
+        }
+        ImTypeVars classVars = classDef.getTypeVariables();
+        ImTypeArguments classArgs = classType.getTypeArguments();
+        for (int i = 0; i < Math.min(classVars.size(), classArgs.size()); i++) {
+            binding.putIfAbsent(classVars.get(i), inheritIfStillAbstract(globalState, classArgs.get(i)));
+        }
+        for (ImClassType superType : classDef.getSuperClasses()) {
+            bindClassTypeArguments(globalState, binding, superType, visited);
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
@@ -54,25 +54,53 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
      * interpreting a program which still has generics.
      */
     private static void bindTypeArguments(ProgramState globalState, LocalState localState, ImFunction f,
-                                          @Nullable Element caller) {
-        ImTypeArguments typeArgs;
+                                          @Nullable Element caller, ILconst[] args) {
+        Map<ImTypeVar, ImTypeArgument> binding = new HashMap<>();
+
+        // A bound may belong to the owning class rather than to the method, as in
+        // class Box<T: Show>. The receiver carries the arguments the class was created with.
+        if (args.length > 0 && args[0] instanceof ILconstObject receiver) {
+            ImTypeArguments classArgs = receiver.getType().getTypeArguments();
+            ImTypeVars classVars = receiver.getType().getClassDef().getTypeVariables();
+            for (int i = 0; i < Math.min(classVars.size(), classArgs.size()); i++) {
+                binding.put(classVars.get(i), inheritIfStillAbstract(globalState, classArgs.get(i)));
+            }
+        }
+
+        ImTypeArguments typeArgs = null;
         if (caller instanceof ImFunctionCall call) {
             typeArgs = call.getTypeArguments();
         } else if (caller instanceof ImMethodCall call) {
             typeArgs = call.getTypeArguments();
-        } else {
-            return;
         }
-        List<ImTypeVar> typeVars = f.getTypeVariables();
-        if (typeArgs.isEmpty() || typeVars.isEmpty()) {
-            return;
+        if (typeArgs != null) {
+            List<ImTypeVar> typeVars = f.getTypeVariables();
+            for (int i = 0; i < Math.min(typeVars.size(), typeArgs.size()); i++) {
+                binding.put(typeVars.get(i), inheritIfStillAbstract(globalState, typeArgs.get(i)));
+            }
+            // A generic class holds its type variables on the class, not on its functions, so a
+            // constructor or method is called with arguments it has no variable of its own to bind.
+            // Bind the owning class's variables too, mirroring how type substitutions are built.
+            ImClass owner = owningClass(f);
+            if (owner != null) {
+                ImTypeVars classVars = owner.getTypeVariables();
+                for (int i = 0; i < Math.min(classVars.size(), typeArgs.size()); i++) {
+                    binding.put(classVars.get(i), inheritIfStillAbstract(globalState, typeArgs.get(i)));
+                }
+            }
         }
-        Map<ImTypeVar, ImTypeArgument> binding = new HashMap<>();
-        for (int i = 0; i < Math.min(typeVars.size(), typeArgs.size()); i++) {
-            ImTypeArgument arg = typeArgs.get(i);
-            binding.put(typeVars.get(i), inheritIfStillAbstract(globalState, arg));
+
+        if (!binding.isEmpty()) {
+            localState.setTypeArguments(binding);
         }
-        localState.setTypeArguments(binding);
+    }
+
+    private static @Nullable ImClass owningClass(ImFunction f) {
+        Element owner = f.getParent();
+        while (owner != null && !(owner instanceof ImClass)) {
+            owner = owner.getParent();
+        }
+        return (ImClass) owner;
     }
 
     /**
@@ -134,7 +162,7 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
             for (int i = 0; i < f.getParameters().size(); i++) {
                 localState.setVal(f.getParameters().get(i), args[i]);
             }
-            bindTypeArguments(globalState, localState, f, caller);
+            bindTypeArguments(globalState, localState, f, caller, args);
 
             // --- stacktrace bookkeeping ---
             if (f.getBody().isEmpty()) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
@@ -73,16 +73,21 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
         if (typeArgs != null) {
             List<ImTypeVar> typeVars = f.getTypeVariables();
             for (int i = 0; i < Math.min(typeVars.size(), typeArgs.size()); i++) {
-                binding.put(typeVars.get(i), inheritIfStillAbstract(globalState, typeArgs.get(i)));
+                binding.putIfAbsent(typeVars.get(i), inheritIfStillAbstract(globalState, typeArgs.get(i)));
             }
             // A generic class holds its type variables on the class, not on its functions, so a
-            // constructor or method is called with arguments it has no variable of its own to bind.
-            // Bind the owning class's variables too, mirroring how type substitutions are built.
-            ImClass owner = owningClass(f);
-            if (owner != null) {
-                ImTypeVars classVars = owner.getTypeVariables();
-                for (int i = 0; i < Math.min(classVars.size(), typeArgs.size()); i++) {
-                    binding.put(classVars.get(i), inheritIfStillAbstract(globalState, typeArgs.get(i)));
+            // constructor is called with arguments it has no variable of its own to bind. Only do
+            // this when the function has no type parameters, because then the arguments are the
+            // class's; a method with its own parameters is called with those instead, and the
+            // class's mapping already came from the receiver, which must not be overwritten.
+            if (typeVars.isEmpty()) {
+                ImClass owner = owningClass(f);
+                if (owner != null) {
+                    ImTypeVars classVars = owner.getTypeVariables();
+                    for (int i = 0; i < Math.min(classVars.size(), typeArgs.size()); i++) {
+                        binding.putIfAbsent(classVars.get(i),
+                            inheritIfStillAbstract(globalState, typeArgs.get(i)));
+                    }
                 }
             }
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
@@ -102,18 +102,50 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
     private static void bindClassTypeArguments(ProgramState globalState,
                                                Map<ImTypeVar, ImTypeArgument> binding,
                                                ImClassType classType, Set<ImClass> visited) {
-        ImClass classDef = classType.getClassDef();
+        bindClassTypeArguments(globalState, binding, classType.getClassDef(),
+            new ArrayList<>(classType.getTypeArguments()), visited);
+    }
+
+    private static void bindClassTypeArguments(ProgramState globalState,
+                                               Map<ImTypeVar, ImTypeArgument> binding,
+                                               ImClass classDef, List<ImTypeArgument> classArgs,
+                                               Set<ImClass> visited) {
         if (!visited.add(classDef)) {
             return;
         }
         ImTypeVars classVars = classDef.getTypeVariables();
-        ImTypeArguments classArgs = classType.getTypeArguments();
         for (int i = 0; i < Math.min(classVars.size(), classArgs.size()); i++) {
             binding.putIfAbsent(classVars.get(i), inheritIfStillAbstract(globalState, classArgs.get(i)));
         }
         for (ImClassType superType : classDef.getSuperClasses()) {
-            bindClassTypeArguments(globalState, binding, superType, visited);
+            // A subclass may forward its own parameter, as in class Child<U: Show> extends
+            // Parent<U>. The supertype is written in terms of the subclass's variables, so resolve
+            // them against what this class was instantiated with before descending.
+            List<ImTypeArgument> superArgs = new ArrayList<>();
+            for (ImTypeArgument superArg : superType.getTypeArguments()) {
+                superArgs.add(resolveAgainst(binding, superArg));
+            }
+            bindClassTypeArguments(globalState, binding, superType.getClassDef(), superArgs, visited);
         }
+    }
+
+    /** Replaces a type argument that is still a variable by whatever that variable is bound to. */
+    private static ImTypeArgument resolveAgainst(Map<ImTypeVar, ImTypeArgument> binding,
+                                                 ImTypeArgument arg) {
+        if (!(arg.getType() instanceof ImTypeVarRef ref)) {
+            return arg;
+        }
+        ImTypeArgument known = binding.get(ref.getTypeVariable());
+        if (known == null) {
+            // One source type parameter can be several nodes, so fall back to the name.
+            for (Map.Entry<ImTypeVar, ImTypeArgument> e : binding.entrySet()) {
+                if (e.getKey().getName().equals(ref.getTypeVariable().getName())) {
+                    known = e.getValue();
+                    break;
+                }
+            }
+        }
+        return known != null ? known : arg;
     }
 
     private static @Nullable ImClass owningClass(ImFunction f) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ILInterpreter.java
@@ -53,7 +53,8 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
      * dispatch inside the body can find the instance chosen at the call site. Only relevant when
      * interpreting a program which still has generics.
      */
-    private static void bindTypeArguments(LocalState localState, ImFunction f, @Nullable Element caller) {
+    private static void bindTypeArguments(ProgramState globalState, LocalState localState, ImFunction f,
+                                          @Nullable Element caller) {
         ImTypeArguments typeArgs;
         if (caller instanceof ImFunctionCall call) {
             typeArgs = call.getTypeArguments();
@@ -68,9 +69,23 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
         }
         Map<ImTypeVar, ImTypeArgument> binding = new HashMap<>();
         for (int i = 0; i < Math.min(typeVars.size(), typeArgs.size()); i++) {
-            binding.put(typeVars.get(i), typeArgs.get(i));
+            ImTypeArgument arg = typeArgs.get(i);
+            binding.put(typeVars.get(i), inheritIfStillAbstract(globalState, arg));
         }
         localState.setTypeArguments(binding);
+    }
+
+    /**
+     * When a bounded generic passes its own type parameter to another one, the inner call site
+     * carries no instance because the parameter is still abstract there. The caller's frame knows
+     * what it was called with, so take the argument from there.
+     */
+    private static ImTypeArgument inheritIfStillAbstract(ProgramState globalState, ImTypeArgument arg) {
+        if (!arg.getTypeClassBinding().isEmpty() || !(arg.getType() instanceof ImTypeVarRef ref)) {
+            return arg;
+        }
+        ImTypeArgument fromCaller = globalState.getCurrentTypeArgument(ref.getTypeVariable());
+        return fromCaller != null ? fromCaller : arg;
     }
 
     public static LocalState runFunc(ProgramState globalState, ImFunction f, @Nullable Element caller,
@@ -119,7 +134,7 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
             for (int i = 0; i < f.getParameters().size(); i++) {
                 localState.setVal(f.getParameters().get(i), args[i]);
             }
-            bindTypeArguments(localState, f, caller);
+            bindTypeArguments(globalState, localState, f, caller);
 
             // --- stacktrace bookkeeping ---
             if (f.getBody().isEmpty()) {
@@ -243,6 +258,7 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
             }
             WPos pos = (caller != null) ? caller.attrTrace().attrErrorPos() : f.attrTrace().attrErrorPos();
             globalState.pushStackframeWithTypes(f, receiverObj, args, pos, normalized);
+            globalState.pushTypeArguments(localState.getTypeArguments());
 
             ILconst retVal = null;
             boolean didReturn = false;
@@ -259,6 +275,7 @@ public class ILInterpreter implements AbstractInterpreter, AutoCloseable {
                 retVal = adjustTypeOfConstant(e.getVal(), f.getReturnType());
                 didReturn = true;
             } finally {
+                globalState.popTypeArguments();
                 globalState.popStackframe();
             }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/LocalState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/LocalState.java
@@ -1,7 +1,11 @@
 package de.peeeq.wurstscript.intermediatelang.interpreter;
 
 import de.peeeq.wurstscript.intermediatelang.ILconst;
+import de.peeeq.wurstscript.jassIm.ImTypeArgument;
+import de.peeeq.wurstscript.jassIm.ImTypeVar;
 import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.Map;
 
 /**
  * Unchanged API. No eager map allocations unless you actually set/get vars/arrays.
@@ -9,6 +13,20 @@ import org.eclipse.jdt.annotation.Nullable;
 public class LocalState extends State {
 
     private @Nullable ILconst returnVal;
+    /**
+     * The type arguments this invocation was called with, kept only when the program still
+     * contains generics, i.e. when running before generic elimination. Type class dispatch reads
+     * the instance bound to a type argument from here.
+     */
+    private @Nullable Map<ImTypeVar, ImTypeArgument> typeArguments;
+
+    public void setTypeArguments(Map<ImTypeVar, ImTypeArgument> typeArguments) {
+        this.typeArguments = typeArguments;
+    }
+
+    public @Nullable ImTypeArgument getTypeArgument(ImTypeVar typeVar) {
+        return typeArguments == null ? null : typeArguments.get(typeVar);
+    }
 
     public LocalState() {
         // no eager allocations

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/LocalState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/LocalState.java
@@ -24,8 +24,27 @@ public class LocalState extends State {
         this.typeArguments = typeArguments;
     }
 
+    /**
+     * The argument bound to this type variable.
+     * <p>
+     * One source type parameter can be represented by several {@code ImTypeVar} nodes — a class and
+     * its constructor hold separate ones — so fall back to matching by name, as generic elimination
+     * does.
+     */
     public @Nullable ImTypeArgument getTypeArgument(ImTypeVar typeVar) {
-        return typeArguments == null ? null : typeArguments.get(typeVar);
+        if (typeArguments == null) {
+            return null;
+        }
+        ImTypeArgument exact = typeArguments.get(typeVar);
+        if (exact != null) {
+            return exact;
+        }
+        for (Map.Entry<ImTypeVar, ImTypeArgument> e : typeArguments.entrySet()) {
+            if (e.getKey().getName().equals(typeVar.getName())) {
+                return e.getValue();
+            }
+        }
+        return null;
     }
 
     public Map<ImTypeVar, ImTypeArgument> getTypeArguments() {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/LocalState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/LocalState.java
@@ -28,6 +28,10 @@ public class LocalState extends State {
         return typeArguments == null ? null : typeArguments.get(typeVar);
     }
 
+    public Map<ImTypeVar, ImTypeArgument> getTypeArguments() {
+        return typeArguments == null ? java.util.Collections.emptyMap() : typeArguments;
+    }
+
     public LocalState() {
         // no eager allocations
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
@@ -524,6 +524,32 @@ public class ProgramState extends State implements AutoCloseable {
         lastStatements.push(stmt);
     }
 
+    /**
+     * Type arguments of the frames currently on the stack. A type class dispatch on a parameter
+     * which the current frame received abstractly is answered from the frame which supplied it.
+     */
+    private final Deque<Map<ImTypeVar, ImTypeArgument>> typeArgumentFrames = new ArrayDeque<>();
+
+    public void pushTypeArguments(Map<ImTypeVar, ImTypeArgument> typeArguments) {
+        typeArgumentFrames.push(typeArguments);
+    }
+
+    public void popTypeArguments() {
+        if (!typeArgumentFrames.isEmpty()) {
+            typeArgumentFrames.pop();
+        }
+    }
+
+    public @Nullable ImTypeArgument getCurrentTypeArgument(ImTypeVar typeVar) {
+        for (Map<ImTypeVar, ImTypeArgument> frame : typeArgumentFrames) {
+            ImTypeArgument found = frame.get(typeVar);
+            if (found != null && !found.getTypeClassBinding().isEmpty()) {
+                return found;
+            }
+        }
+        return null;
+    }
+
     public void popStackframe() {
 //        new Exception().printStackTrace(System.out);
         WLogger.trace(() -> "popStackframe " + (stackFrames.isEmpty() ? "empty" : stackFrames.peek().f));

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
@@ -420,7 +420,7 @@ public class ProgramState extends State implements AutoCloseable {
                 boolean changed = false;
                 for (ImTypeArgument ta : ct.getTypeArguments()) {
                     ImType rt = resolveTypeDeep(ta.getType(), budget - 1);
-                    newArgs.add(JassIm.ImTypeArgument(rt, ta.getTypeClassBinding()));
+                    newArgs.add(JassIm.ImTypeArgument(rt, typeClassBindingFor(ta)));
                     changed |= (rt != ta.getType());
                 }
                 return changed ? JassIm.ImClassType(ct.getClassDef(), newArgs) : ct;
@@ -476,7 +476,7 @@ public class ProgramState extends State implements AutoCloseable {
                 ImTypeArguments newArgs = JassIm.ImTypeArguments();
                 for (ImTypeArgument arg : classType.getTypeArguments()) {
                     ImType substituted = substituteTypeVars(arg.getType(), substitutions);
-                    newArgs.add(JassIm.ImTypeArgument(substituted, arg.getTypeClassBinding()));
+                    newArgs.add(JassIm.ImTypeArgument(substituted, typeClassBindingFor(arg)));
                 }
                 return JassIm.ImClassType(classType.getClassDef(), newArgs);
             }
@@ -542,12 +542,31 @@ public class ProgramState extends State implements AutoCloseable {
 
     public @Nullable ImTypeArgument getCurrentTypeArgument(ImTypeVar typeVar) {
         for (Map<ImTypeVar, ImTypeArgument> frame : typeArgumentFrames) {
-            ImTypeArgument found = frame.get(typeVar);
-            if (found != null && !found.getTypeClassBinding().isEmpty()) {
-                return found;
+            for (Map.Entry<ImTypeVar, ImTypeArgument> e : frame.entrySet()) {
+                // A class and its constructor hold separate nodes for the same source type
+                // parameter, so identity alone is not enough to find the binding.
+                boolean sameVar = e.getKey() == typeVar || e.getKey().getName().equals(typeVar.getName());
+                if (sameVar && !e.getValue().getTypeClassBinding().isEmpty()) {
+                    return e.getValue();
+                }
             }
         }
         return null;
+    }
+
+    /**
+     * The type class binding for a type argument being resolved.
+     * <p>
+     * A class body refers to its own type variables, so the argument written there carries no
+     * binding. The frame which created the object was called with one, so take it from there;
+     * otherwise a bound on a generic class would have nothing to dispatch through.
+     */
+    private Map<ImTypeClassFunc, io.vavr.control.Either<ImMethod, ImFunction>> typeClassBindingFor(ImTypeArgument arg) {
+        if (!arg.getTypeClassBinding().isEmpty() || !(arg.getType() instanceof ImTypeVarRef ref)) {
+            return arg.getTypeClassBinding();
+        }
+        ImTypeArgument fromFrame = getCurrentTypeArgument(ref.getTypeVariable());
+        return fromFrame != null ? fromFrame.getTypeClassBinding() : arg.getTypeClassBinding();
     }
 
     public void popStackframe() {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/parser/antlr/AntlrWurstParseTreeTransformer.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/parser/antlr/AntlrWurstParseTreeTransformer.java
@@ -384,6 +384,8 @@ public class AntlrWurstParseTreeTransformer {
                 return transformTupleDef(e.tupleDef());
             } else if (e.extensionFuncDef() != null) {
                 return transformExtensionFuncDef(e.extensionFuncDef());
+            } else if (e.instanceDef() != null) {
+                return transformInstanceDef(e.instanceDef());
             }
 
             if (e.exception != null) {
@@ -395,6 +397,17 @@ public class AntlrWurstParseTreeTransformer {
             WLogger.warning("Error transforming entity in line " + line(e), npe);
             return null;
         }
+    }
+
+    private WEntity transformInstanceDef(InstanceDefContext i) {
+        WPos src = source(i);
+        Modifiers modifiers = transformModifiers(i.modifiersWithDoc());
+        TypeExpr implemented = transformTypeExpr(i.implemented);
+        FuncDefs methods = Ast.FuncDefs();
+        for (FuncDefContext m : i.methods) {
+            methods.add(transformFuncDef(m));
+        }
+        return Ast.InstanceDecl(src, modifiers, implemented, methods);
     }
 
     private WEntity transformExtensionFuncDef(ExtensionFuncDefContext f) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -950,7 +950,9 @@ public class EliminateGenerics {
 
             @Override
             public void visit(ImTypeArgument ta) {
-                ta.setType(transformType(ta.getType(), generics, typeVars));
+                ImType original = ta.getType();
+                ta.setType(transformType(original, generics, typeVars));
+                inheritTypeClassBinding(ta, original, generics, typeVars);
             }
 
             @Override
@@ -1024,6 +1026,30 @@ public class EliminateGenerics {
      * This is what keeps bounded generics free of runtime cost: after specialisation the call is an
      * ordinary static call to the instance function, with no lookup and no indirection left.
      */
+    /**
+     * Carries a type class binding down into a nested call.
+     * <p>
+     * When a bounded generic passes its own type parameter on to another bounded generic, the inner
+     * call site cannot know the instance: the parameter is still abstract there. Substituting the
+     * outer parameter also supplies the instance it was specialised with, which is what makes a
+     * chain of bounded generics resolve without any runtime dictionary.
+     */
+    private static void inheritTypeClassBinding(ImTypeArgument ta, ImType original,
+                                                GenericTypes generics, List<ImTypeVar> typeVars) {
+        if (!ta.getTypeClassBinding().isEmpty() || !(original instanceof ImTypeVarRef ref)) {
+            return;
+        }
+        int index = indexOfTypeVar(typeVars, ref.getTypeVariable());
+        if (index < 0) {
+            return;
+        }
+        Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> outer =
+            generics.getTypeArguments().get(index).getTypeClassBinding();
+        if (!outer.isEmpty()) {
+            ta.setTypeClassBinding(new LinkedHashMap<>(outer));
+        }
+    }
+
     /**
      * A type variable can be represented by more than one node for the same source type parameter,
      * so match on the name as the rest of this pass does.

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -1153,7 +1153,7 @@ public class EliminateGenerics {
             return;
         }
         int index = indexOfTypeVar(typeVars, ref.getTypeVariable());
-        if (index < 0) {
+        if (index < 0 || index >= generics.getTypeArguments().size()) {
             return;
         }
         Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> outer =
@@ -1187,6 +1187,12 @@ public class EliminateGenerics {
 
     private void resolveTypeClassDispatch(ImTypeVarDispatch e, GenericTypes generics, List<ImTypeVar> typeVars) {
         int index = indexOfTypeVar(typeVars, e.getTypeVariable());
+        if (index >= 0 && index >= generics.getTypeArguments().size()) {
+            // Fewer arguments than variables: the variables and the arguments are not in
+            // correspondence here, so position says nothing. Reading one anyway would dispatch
+            // through whichever type happened to sit at that index.
+            return;
+        }
         if (index < 0) {
             // dispatching on a variable of some enclosing generic; it is resolved when that one is
             // specialised.

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -163,7 +163,7 @@ public class EliminateGenerics {
             return;
         }
         if (!call.getTypeArguments().isEmpty()
-            && functionContainsGenericNew(call.getFunc(), Collections.newSetFromMap(new IdentityHashMap<>()))) {
+            && functionNeedsSpecialization(call.getFunc(), Collections.newSetFromMap(new IdentityHashMap<>()))) {
             if (!typeArgumentsContainTypeVariable(call.getTypeArguments())) {
                 genericsUses.add(new GenericImFunctionCall(call));
             }
@@ -172,7 +172,7 @@ public class EliminateGenerics {
 
     private void collectGenericNewUse(ImMethodCall call) {
         ImMethod method = call.getMethod();
-        if (!methodContainsGenericNew(method,
+        if (!methodNeedsSpecialization(method,
             Collections.newSetFromMap(new IdentityHashMap<>()),
             Collections.newSetFromMap(new IdentityHashMap<>()))) {
             return;
@@ -195,12 +195,19 @@ public class EliminateGenerics {
         return false;
     }
 
-    private boolean functionContainsGenericNew(ImFunction function, Set<ImFunction> visited) {
-        return functionContainsGenericNew(function, visited,
+    private boolean functionNeedsSpecialization(ImFunction function, Set<ImFunction> visited) {
+        return functionNeedsSpecialization(function, visited,
             Collections.newSetFromMap(new IdentityHashMap<>()));
     }
 
-    private boolean functionContainsGenericNew(ImFunction function, Set<ImFunction> visitedFunctions,
+    /**
+     * Whether a function must be specialised even on Lua, which otherwise keeps generics erased.
+     * <p>
+     * Two operations need the concrete type argument: constructing a value of it, and dispatching
+     * on a type class bound. Specialising these paths keeps a bounded generic as cheap on Lua as it
+     * is on Jass, at the cost of one copy per instantiation actually used.
+     */
+    private boolean functionNeedsSpecialization(ImFunction function, Set<ImFunction> visitedFunctions,
                                                Set<ImMethod> visitedMethods) {
         if (!visitedFunctions.add(function)) {
             return false;
@@ -208,9 +215,14 @@ public class EliminateGenerics {
         boolean[] found = {false};
         function.accept(new Element.DefaultVisitor() {
             @Override
+            public void visit(ImTypeVarDispatch dispatch) {
+                found[0] = true;
+            }
+
+            @Override
             public void visit(ImFunctionCall call) {
                 if (translator.isGenericNewMarker(call.getFunc())
-                    || functionContainsGenericNew(call.getFunc(), visitedFunctions, visitedMethods)) {
+                    || functionNeedsSpecialization(call.getFunc(), visitedFunctions, visitedMethods)) {
                     found[0] = true;
                     return;
                 }
@@ -219,7 +231,7 @@ public class EliminateGenerics {
 
             @Override
             public void visit(ImMethodCall call) {
-                if (methodContainsGenericNew(call.getMethod(), visitedFunctions, visitedMethods)) {
+                if (methodNeedsSpecialization(call.getMethod(), visitedFunctions, visitedMethods)) {
                     found[0] = true;
                     return;
                 }
@@ -229,17 +241,17 @@ public class EliminateGenerics {
         return found[0];
     }
 
-    private boolean methodContainsGenericNew(ImMethod method, Set<ImFunction> visitedFunctions,
+    private boolean methodNeedsSpecialization(ImMethod method, Set<ImFunction> visitedFunctions,
                                              Set<ImMethod> visitedMethods) {
         if (!visitedMethods.add(method)) {
             return false;
         }
         if (method.getImplementation() != null
-            && functionContainsGenericNew(method.getImplementation(), visitedFunctions, visitedMethods)) {
+            && functionNeedsSpecialization(method.getImplementation(), visitedFunctions, visitedMethods)) {
             return true;
         }
         for (ImMethod subMethod : method.getSubMethods()) {
-            if (methodContainsGenericNew(subMethod, visitedFunctions, visitedMethods)) {
+            if (methodNeedsSpecialization(subMethod, visitedFunctions, visitedMethods)) {
                 return true;
             }
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -13,6 +13,7 @@ import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.translation.imtojass.ImAttrType;
 import de.peeeq.wurstscript.translation.imtojass.TypeRewriteMatcher;
 import de.peeeq.wurstscript.translation.lua.translation.RemoveGarbage;
+import io.vavr.control.Either;
 import org.eclipse.jdt.annotation.Nullable;
 import org.jetbrains.annotations.NotNull;
 
@@ -1007,7 +1008,60 @@ public class EliminateGenerics {
                 super.visit(e);
             }
 
+            @Override
+            public void visit(ImTypeVarDispatch e) {
+                super.visit(e);
+                resolveTypeClassDispatch(e, generics, typeVars);
+            }
+
         });
+    }
+
+    /**
+     * Replaces a type class dispatch by a direct call once the type variable it dispatches on has
+     * been substituted by a concrete type argument.
+     * <p>
+     * This is what keeps bounded generics free of runtime cost: after specialisation the call is an
+     * ordinary static call to the instance function, with no lookup and no indirection left.
+     */
+    /**
+     * A type variable can be represented by more than one node for the same source type parameter,
+     * so match on the name as the rest of this pass does.
+     */
+    private static int indexOfTypeVar(List<ImTypeVar> typeVars, ImTypeVar target) {
+        for (int i = 0; i < typeVars.size(); i++) {
+            ImTypeVar tv = typeVars.get(i);
+            if (tv == target || tv.getName().equals(target.getName())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void resolveTypeClassDispatch(ImTypeVarDispatch e, GenericTypes generics, List<ImTypeVar> typeVars) {
+        int index = indexOfTypeVar(typeVars, e.getTypeVariable());
+        if (index < 0) {
+            // dispatching on a variable of some enclosing generic; it is resolved when that one is
+            // specialised.
+            return;
+        }
+        ImTypeArgument typeArgument = generics.getTypeArguments().get(index);
+        Either<ImMethod, ImFunction> impl = typeArgument.getTypeClassBinding().get(e.getTypeClassFunc());
+        if (impl == null) {
+            throw new CompileError(e.attrTrace().attrSource(),
+                "No type class instance bound for " + e.getTypeClassFunc().getName()
+                    + " on type argument " + typeArgument.getType() + ".");
+        }
+        ImExprs args = e.getArguments();
+        args.setParent(null);
+        if (impl.isRight()) {
+            e.replaceBy(JassIm.ImFunctionCall(e.getTrace(), impl.get(), JassIm.ImTypeArguments(), args,
+                false, CallType.NORMAL));
+        } else {
+            ImMethod method = impl.getLeft();
+            e.replaceBy(JassIm.ImFunctionCall(e.getTrace(), method.getImplementation(), JassIm.ImTypeArguments(),
+                args, false, CallType.NORMAL));
+        }
     }
 
     private static ImType transformType(ImType type, GenericTypes generics, List<ImTypeVar> typeVars) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -116,8 +116,16 @@ public class EliminateGenerics {
     public void transformGenericNewOnly() {
         genericNewOnly = true;
         collectUnspecializedGenericClassMethods();
-        collectGenericNewRoots();
-        eliminateGenericUses();
+        // Specialising a constructor makes its result type concrete, which is what lets a method
+        // call on that result resolve. Repeat until a pass finds nothing new; collection is
+        // idempotent, so this terminates once every reachable site has been rewritten.
+        while (true) {
+            collectGenericNewRoots();
+            if (genericsUses.isEmpty()) {
+                break;
+            }
+            eliminateGenericUses();
+        }
         eliminateRemainingGenericNewCalls();
         assertNoReachableGenericNewMarkers();
     }
@@ -195,10 +203,34 @@ public class EliminateGenerics {
         if (call.getTypeArguments().isEmpty()) {
             addMemberTypeArguments(call, method.attrClass());
         }
+        if (typeArgumentsContainTypeVariable(call.getTypeArguments())) {
+            // The receiver's declared type is still generic, which happens when the method is
+            // called straight on a freshly constructed value. The construction states the
+            // instantiation, so take the arguments from it.
+            useConstructionTypeArguments(call);
+        }
         if (!call.getTypeArguments().isEmpty()
             && !typeArgumentsContainTypeVariable(call.getTypeArguments())) {
             genericsUses.add(new GenericMethodCall(call));
         }
+    }
+
+    /**
+     * Replaces a member call's still-generic type arguments with those of the constructor call that
+     * produced its receiver, as in {@code new Box<int>().render(x)}.
+     */
+    private void useConstructionTypeArguments(ImMethodCall call) {
+        if (!(call.getReceiver() instanceof ImFunctionCall construction)
+            || construction.getTypeArguments().isEmpty()
+            || typeArgumentsContainTypeVariable(construction.getTypeArguments())) {
+            return;
+        }
+        List<ImTypeArgument> fromConstruction = new ArrayList<>();
+        for (ImTypeArgument ta : construction.getTypeArguments()) {
+            fromConstruction.add(ta.copy());
+        }
+        call.getTypeArguments().removeAll();
+        call.getTypeArguments().addAll(fromConstruction);
     }
 
     private boolean typeArgumentsContainTypeVariable(ImTypeArguments typeArguments) {
@@ -232,6 +264,18 @@ public class EliminateGenerics {
             @Override
             public void visit(ImTypeVarDispatch dispatch) {
                 found[0] = true;
+            }
+
+            @Override
+            public void visit(ImAlloc alloc) {
+                // Constructing a class whose methods dispatch has to be specialised as well:
+                // otherwise the constructor keeps a generic result type, and a method call on that
+                // result never becomes concrete enough to resolve.
+                if (classNeedsSpecialization(alloc.getClazz().getClassDef(), visitedFunctions, visitedMethods)) {
+                    found[0] = true;
+                    return;
+                }
+                super.visit(alloc);
             }
 
             @Override
@@ -272,6 +316,48 @@ public class EliminateGenerics {
         }
         return false;
     }
+
+    /**
+     * Whether constructing this class requires the concrete type argument, because one of its own
+     * or inherited members dispatches on a type class bound.
+     */
+    private boolean classNeedsSpecialization(ImClass classDef, Set<ImFunction> visitedFunctions,
+                                             Set<ImMethod> visitedMethods) {
+        Boolean cached = classNeedsSpecialization.get(classDef);
+        if (cached != null) {
+            // Already answered, or currently being answered: a class reached through its own
+            // members contributes nothing new to the decision.
+            return cached;
+        }
+        classNeedsSpecialization.put(classDef, false);
+        boolean result = false;
+        for (ImFunction f : classDef.getFunctions()) {
+            if (functionNeedsSpecialization(f, visitedFunctions, visitedMethods)) {
+                result = true;
+                break;
+            }
+        }
+        if (!result) {
+            for (ImMethod m : classDef.getMethods()) {
+                if (methodNeedsSpecialization(m, visitedFunctions, visitedMethods)) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        if (!result) {
+            for (ImClassType superType : classDef.getSuperClasses()) {
+                if (classNeedsSpecialization(superType.getClassDef(), visitedFunctions, visitedMethods)) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        classNeedsSpecialization.put(classDef, result);
+        return result;
+    }
+
+    private final Map<ImClass, Boolean> classNeedsSpecialization = new IdentityHashMap<>();
 
     private void assertNoReachableGenericNewMarkers() {
         prog.accept(new Element.DefaultVisitor() {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -29,6 +29,14 @@ public class EliminateGenerics {
     private final ImProg prog;
     private boolean genericNewOnly;
     private final Deque<GenericUse> genericsUses = new ArrayDeque<>();
+    /**
+     * Call sites already rewritten to a specialisation.
+     * <p>
+     * Collection has to be repeatable, because specialising one call is what makes the next one
+     * concrete. It is not naturally idempotent: a member call whose type arguments were consumed
+     * has them re-derived from its receiver, which would collect and specialise it again forever.
+     */
+    private final Set<Element> specializedCallSites = Collections.newSetFromMap(new IdentityHashMap<>());
     private final Table<ImFunction, GenericTypes, ImFunction> specializedFunctions = HashBasedTable.create();
     private final Table<ImMethod, GenericTypes, ImMethod> specializedMethods = HashBasedTable.create();
     private final Table<ImClass, GenericTypes, ImClass> specializedClasses = HashBasedTable.create();
@@ -114,6 +122,7 @@ public class EliminateGenerics {
         assertNoReachableGenericNewMarkers();
     }
 
+
     private void collectGenericNewRoots() {
         prog.accept(new Element.DefaultVisitor() {
             @Override
@@ -156,6 +165,9 @@ public class EliminateGenerics {
     }
 
     private void collectGenericNewUse(ImFunctionCall call) {
+        if (specializedCallSites.contains(call)) {
+            return;
+        }
         if (translator.isGenericNewMarker(call.getFunc())) {
             if (!typeArgumentsContainTypeVariable(call.getTypeArguments())) {
                 genericsUses.add(new GenericNewCall(call));
@@ -171,6 +183,9 @@ public class EliminateGenerics {
     }
 
     private void collectGenericNewUse(ImMethodCall call) {
+        if (specializedCallSites.contains(call)) {
+            return;
+        }
         ImMethod method = call.getMethod();
         if (!methodNeedsSpecialization(method,
             Collections.newSetFromMap(new IdentityHashMap<>()),
@@ -1066,6 +1081,14 @@ public class EliminateGenerics {
      * A type variable can be represented by more than one node for the same source type parameter,
      * so match on the name as the rest of this pass does.
      */
+    private static String enclosingFunctionName(Element e) {
+        Element cur = e;
+        while (cur != null && !(cur instanceof ImFunction)) {
+            cur = cur.getParent();
+        }
+        return cur == null ? "?" : ((ImFunction) cur).getName();
+    }
+
     private static int indexOfTypeVar(List<ImTypeVar> typeVars, ImTypeVar target) {
         for (int i = 0; i < typeVars.size(); i++) {
             ImTypeVar tv = typeVars.get(i);
@@ -1086,9 +1109,24 @@ public class EliminateGenerics {
         ImTypeArgument typeArgument = generics.getTypeArguments().get(index);
         Either<ImMethod, ImFunction> impl = typeArgument.getTypeClassBinding().get(e.getTypeClassFunc());
         if (impl == null) {
+            ImFunction fromRegistry = translator.lookupTypeClassImpl(e.getTypeClassFunc(), typeArgument.getType());
+            if (fromRegistry != null) {
+                impl = Either.right(fromRegistry);
+            }
+        }
+        if (impl == null) {
+            if (containsTypeVariable(typeArgument.getType())) {
+                // Not an instantiation: passes which only rename or move type variables, such as
+                // lifting a class's variables onto its functions, substitute one variable for
+                // another. The dispatch is resolved once a concrete type argument arrives.
+                return;
+            }
             throw new CompileError(e.attrTrace().attrSource(),
                 "No type class instance bound for " + e.getTypeClassFunc().getName()
-                    + " on type argument " + typeArgument.getType() + ".");
+                    + " on type argument " + typeArgument.getType()
+                    + " (type variable " + e.getTypeVariable().getName()
+                    + ", index " + index + " of " + typeVars.size()
+                    + ", in " + enclosingFunctionName(e) + ").");
         }
         ImExprs args = e.getArguments();
         args.setParent(null);
@@ -1656,6 +1694,7 @@ public class EliminateGenerics {
             }
             fc.setFunc(specializedFunc);
             fc.getTypeArguments().removeAll();
+            specializedCallSites.add(fc);
         }
     }
 
@@ -1753,6 +1792,7 @@ public class EliminateGenerics {
 
             mc.setMethod(specializedMethod);
             mc.getTypeArguments().removeAll();
+            specializedCallSites.add(mc);
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
@@ -8,6 +8,7 @@ import de.peeeq.wurstscript.ast.*;
 import de.peeeq.wurstscript.ast.Element;
 import de.peeeq.wurstscript.attributes.AttrFuncDef;
 import de.peeeq.wurstscript.attributes.CompileError;
+import de.peeeq.wurstscript.attributes.AttrImplicitParameter;
 import de.peeeq.wurstscript.attributes.names.FuncLink;
 import de.peeeq.wurstscript.attributes.names.NameLink;
 import de.peeeq.wurstscript.attributes.names.OtherLink;
@@ -512,6 +513,27 @@ public class ExprTranslation {
         }
     }
 
+    /**
+     * Translates {@code T.f(args)} into a dispatch through T's type class binding.
+     * <p>
+     * The concrete implementation is not known here, because T is still abstract inside the
+     * generic. Generic elimination substitutes T and rewrites this node into a direct call to the
+     * function supplied by the instance chosen for the substituted type.
+     */
+    private static ImExpr translateTypeClassDispatch(FunctionCall e, ImTranslator t, ImFunction f) {
+        WurstTypeTypeParam receiver = (WurstTypeTypeParam) ((HasReceiver) e).getLeft().attrTyp();
+        FunctionDefinition called = e.attrFuncDef();
+        if (!(called instanceof FuncDef method)) {
+            throw new CompileError(e.attrSource(),
+                "Type class requirement " + e.getFuncName() + " must be a function of the bound interface.");
+        }
+        ImExprs args = JassIm.ImExprs();
+        for (Expr arg : e.getArgs()) {
+            args.add(arg.imTranslateExpr(t, f));
+        }
+        return JassIm.ImTypeVarDispatch(e, t.getTypeClassFunc(method), args, t.getTypeVar(receiver.getDef()));
+    }
+
     private static ImExpr translateFunctionCall(FunctionCall e, ImTranslator t, ImFunction f, boolean returnReveiver, boolean nullSafe) {
 
         if (e instanceof ExprFunctionCall call && CompilerIntrinsics.isNew(call)) {
@@ -520,6 +542,10 @@ public class ExprTranslation {
                 JassIm.ImTypeArgument(targetType, new HashMap<>()));
             return ImFunctionCall(call, t.getGenericNewMarker(), typeArguments,
                 JassIm.ImExprs(), false, CallType.NORMAL);
+        }
+
+        if (AttrImplicitParameter.isTypeClassDispatch(e)) {
+            return translateTypeClassDispatch(e, t, f);
         }
 
         if (e.getFuncName().equals("getStackTraceString") && e.attrImplicitParameter() instanceof NoExpr
@@ -713,14 +739,55 @@ public class ExprTranslation {
             }
 
             ImType type = t.imTranslateType(tr);
-            // TODO handle constraints
-            Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> typeClassBinding = new HashMap<>();
-            res.add(ImTypeArgument(type, typeClassBinding));
+            res.add(ImTypeArgument(type, typeClassBinding(tr, tp, t, location)));
         }
 
         return res;
     }
 
+
+    /**
+     * Binds every requirement of the type parameter's bounds to the implementation supplied by the
+     * instance chosen for the concrete type argument.
+     * <p>
+     * When the argument is itself still a type parameter the binding stays empty: the enclosing
+     * generic is specialised first, and the binding is filled in at that point.
+     */
+    private static Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> typeClassBinding(
+            ImTranslator tr, TypeParamDef tp, WurstTypeBoundTypeParam bound, Element location) {
+        Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> binding = new HashMap<>();
+        List<InterfaceDef> bounds = TypeClassConstraints.boundInterfaces(tp);
+        if (bounds.isEmpty()) {
+            return binding;
+        }
+        WurstType concrete = bound.getBaseType();
+        if (concrete instanceof WurstTypeTypeParam || concrete instanceof WurstTypeBoundTypeParam) {
+            return binding;
+        }
+        for (InterfaceDef iface : bounds) {
+            InstanceDecl instance = TypeClassInstances.find(iface, concrete);
+            if (instance == null) {
+                // The validator reports the unsatisfied bound; do not fail translation as well.
+                continue;
+            }
+            for (FuncDef requirement : iface.getMethods()) {
+                FuncDef impl = findImplementation(instance, requirement.getName());
+                if (impl != null) {
+                    binding.put(tr.getTypeClassFunc(requirement), Either.right(tr.getFuncFor(impl)));
+                }
+            }
+        }
+        return binding;
+    }
+
+    private static @Nullable FuncDef findImplementation(InstanceDecl instance, String name) {
+        for (FuncDef m : instance.getMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        return null;
+    }
 
     private static boolean isCalledOnDynamicRef(FunctionCall e) {
         if (e instanceof ExprMemberMethod) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
@@ -738,56 +738,12 @@ public class ExprTranslation {
                 continue;
             }
 
-            ImType type = t.imTranslateType(tr);
-            res.add(ImTypeArgument(type, typeClassBinding(tr, tp, t, location)));
+            res.add(t.imTranslateToTypeArgument(tr));
         }
 
         return res;
     }
 
-
-    /**
-     * Binds every requirement of the type parameter's bounds to the implementation supplied by the
-     * instance chosen for the concrete type argument.
-     * <p>
-     * When the argument is itself still a type parameter the binding stays empty: the enclosing
-     * generic is specialised first, and the binding is filled in at that point.
-     */
-    private static Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> typeClassBinding(
-            ImTranslator tr, TypeParamDef tp, WurstTypeBoundTypeParam bound, Element location) {
-        Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> binding = new HashMap<>();
-        List<InterfaceDef> bounds = TypeClassConstraints.boundInterfaces(tp);
-        if (bounds.isEmpty()) {
-            return binding;
-        }
-        WurstType concrete = bound.getBaseType();
-        if (concrete instanceof WurstTypeTypeParam || concrete instanceof WurstTypeBoundTypeParam) {
-            return binding;
-        }
-        for (InterfaceDef iface : bounds) {
-            InstanceDecl instance = TypeClassInstances.find(iface, concrete);
-            if (instance == null) {
-                // The validator reports the unsatisfied bound; do not fail translation as well.
-                continue;
-            }
-            for (FuncDef requirement : iface.getMethods()) {
-                FuncDef impl = findImplementation(instance, requirement.getName());
-                if (impl != null) {
-                    binding.put(tr.getTypeClassFunc(requirement), Either.right(tr.getFuncFor(impl)));
-                }
-            }
-        }
-        return binding;
-    }
-
-    private static @Nullable FuncDef findImplementation(InstanceDecl instance, String name) {
-        for (FuncDef m : instance.getMethods()) {
-            if (m.getName().equals(name)) {
-                return m;
-            }
-        }
-        return null;
-    }
 
     private static boolean isCalledOnDynamicRef(FunctionCall e) {
         if (e instanceof ExprMemberMethod) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/Flatten.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/Flatten.java
@@ -70,8 +70,14 @@ public class Flatten {
         return TUPLE_TEMP_VAR_NAMES[count % TUPLE_TEMP_VAR_NAMES.length];
     }
 
-    public static Result flatten(ImTypeVarDispatch imTypeVarDispatch, ImTranslator translator, ImFunction f) {
-        throw new RuntimeException("called too early");
+    /**
+     * A type class dispatch behaves like a call: only its arguments need flattening. The dispatch
+     * itself survives until generic elimination replaces it with a direct call.
+     */
+    public static Result flatten(ImTypeVarDispatch e, ImTranslator t, ImFunction f) {
+        MultiResult r = flattenExprs(t, f, e.getArguments());
+        return new Result(r.stmts,
+            ImTypeVarDispatch(e.getTrace(), e.getTypeClassFunc(), ImExprs(r.exprs), e.getTypeVariable()));
     }
 
     public static Result flatten(ImCast imCast, ImTranslator translator, ImFunction f) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/GenericTypes.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/GenericTypes.java
@@ -39,9 +39,11 @@ class GenericTypes {
                 if (!t1.getType().equalsType(t2.getType())) {
                     return false;
                 }
-                if (!t1.getTypeClassBinding().equals(t2.getTypeClassBinding())) {
-                    return false;
-                }
+                // Deliberately not comparing the type class binding. It is only a fast path for
+                // resolving a dispatch; the implementation for a type is looked up by that type, so
+                // two arguments with the same type denote the same specialisation whether or not
+                // the binding survived. Comparing it also contradicted hashCode, which has always
+                // hashed the types alone, and produced two specialisations of the same class.
             }
             return true;
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImPrinter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImPrinter.java
@@ -542,6 +542,20 @@ public class ImPrinter {
                     append(sb, ", ");
                 }
                 ta.getType().print(sb, indent);
+                // Show the type class instances travelling with the argument: whether they are
+                // present is the whole question when a bound fails to dispatch.
+                if (!ta.getTypeClassBinding().isEmpty()) {
+                    append(sb, "{");
+                    boolean firstBinding = true;
+                    for (ImTypeClassFunc requirement : ta.getTypeClassBinding().keySet()) {
+                        if (!firstBinding) {
+                            append(sb, ", ");
+                        }
+                        append(sb, requirement.getName());
+                        firstBinding = false;
+                    }
+                    append(sb, "}");
+                }
                 first = false;
             }
             append(sb, ">");

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImPrinter.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImPrinter.java
@@ -3,6 +3,8 @@ package de.peeeq.wurstscript.translation.imtranslation;
 import de.peeeq.wurstscript.jassIm.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -545,15 +547,16 @@ public class ImPrinter {
                 // Show the type class instances travelling with the argument: whether they are
                 // present is the whole question when a bound fails to dispatch.
                 if (!ta.getTypeClassBinding().isEmpty()) {
-                    append(sb, "{");
-                    boolean firstBinding = true;
+                    // Sorted: this printing reaches specialization names and so the emitted symbols,
+                    // which have to be identical for identical input. The binding is a hash map, so
+                    // its iteration order is not.
+                    List<String> requirements = new ArrayList<>();
                     for (ImTypeClassFunc requirement : ta.getTypeClassBinding().keySet()) {
-                        if (!firstBinding) {
-                            append(sb, ", ");
-                        }
-                        append(sb, requirement.getName());
-                        firstBinding = false;
+                        requirements.add(requirement.getName());
                     }
+                    Collections.sort(requirements);
+                    append(sb, "{");
+                    append(sb, String.join(", ", requirements));
                     append(sb, "}");
                 }
                 first = false;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
@@ -1714,29 +1714,45 @@ private void callInitFunc(Set<WPackage> calledInitializers, WPackage p, @Nullabl
     private final Map<FuncDef, ImTypeClassFunc> typeClassFuncs = new LinkedHashMap<>();
 
     /**
-     * Every type class implementation in the program, keyed by requirement and the type it is for.
+     * Every type class implementation in the program, held per requirement against the type it is
+     * for.
      * <p>
      * A type argument can carry its instances directly, but that binding lives on the argument
      * position and is lost as soon as a type variable is substituted into a plain type, which is
      * what happens when a generic class type travels through a return type or a receiver. Instance
-     * selection is static, so keying on the concrete type is both simpler and robust: the type at a
-     * dispatch site is enough to find the implementation, however it got there.
+     * selection is static, so recording the type is enough to recover it.
+     * <p>
+     * Matched by structural type equality rather than by printed name: a class prints as its simple
+     * name, so two classes of the same name in different packages would otherwise collide and the
+     * second would silently dispatch through the first. The lists hold one entry per instance of a
+     * requirement, so scanning them is cheaper than the printing it replaces.
      */
-    private final Map<ImTypeClassFunc, Map<String, ImFunction>> typeClassImpls = new LinkedHashMap<>();
+    private final Map<ImTypeClassFunc, List<TypeClassImpl>> typeClassImpls = new LinkedHashMap<>();
+
+    private record TypeClassImpl(ImType instanceType, ImFunction impl) {
+    }
 
     public void registerTypeClassImpl(ImTypeClassFunc requirement, ImType instanceType, ImFunction impl) {
-        typeClassImpls.computeIfAbsent(requirement, r -> new LinkedHashMap<>())
-                .putIfAbsent(typeClassKey(instanceType), impl);
+        List<TypeClassImpl> impls = typeClassImpls.computeIfAbsent(requirement, r -> new ArrayList<>());
+        for (TypeClassImpl existing : impls) {
+            if (existing.instanceType().equalsType(instanceType)) {
+                return;
+            }
+        }
+        impls.add(new TypeClassImpl(instanceType, impl));
     }
 
     public @Nullable ImFunction lookupTypeClassImpl(ImTypeClassFunc requirement, ImType instanceType) {
-        Map<String, ImFunction> byType = typeClassImpls.get(requirement);
-        return byType == null ? null : byType.get(typeClassKey(instanceType));
-    }
-
-    /** Structural key for an instance type; concrete types print stably. */
-    private static String typeClassKey(ImType type) {
-        return type.toString();
+        List<TypeClassImpl> impls = typeClassImpls.get(requirement);
+        if (impls == null) {
+            return null;
+        }
+        for (TypeClassImpl candidate : impls) {
+            if (candidate.instanceType().equalsType(instanceType)) {
+                return candidate.impl();
+            }
+        }
+        return null;
     }
 
     public ImTypeVar getTypeVar(TypeParamDef tp) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
@@ -1694,6 +1694,25 @@ private void callInitFunc(Set<WPackage> calledInitializers, WPackage p, @Nullabl
         return typeVariableReverse.get(tv);
     }
 
+    /**
+     * The signature node standing for one type class requirement.
+     * <p>
+     * Requirements are shared across every use of the bound, so each interface method maps to
+     * exactly one node. Dispatch sites reference it, and each type argument carries the concrete
+     * implementation bound to it, which is what lets generic elimination turn a dispatch into a
+     * direct call.
+     */
+    public ImTypeClassFunc getTypeClassFunc(FuncDef method) {
+        return typeClassFuncs.computeIfAbsent(method, m -> {
+            ImTypeClassFunc result = JassIm.ImTypeClassFunc(m, m.getName(), JassIm.ImTypeVars(),
+                    JassIm.ImVars(), m.attrReturnTyp().imTranslateType(this));
+            imProg.getTypeClassFunctions().add(result);
+            return result;
+        });
+    }
+
+    private final Map<FuncDef, ImTypeClassFunc> typeClassFuncs = new LinkedHashMap<>();
+
     public ImTypeVar getTypeVar(TypeParamDef tp) {
         // If we're translating inside a captured class (Iterator), prefer its override
         for (Map<TypeParamDef, ImTypeVar> m : typeVarOverrideStack) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
@@ -1713,6 +1713,32 @@ private void callInitFunc(Set<WPackage> calledInitializers, WPackage p, @Nullabl
 
     private final Map<FuncDef, ImTypeClassFunc> typeClassFuncs = new LinkedHashMap<>();
 
+    /**
+     * Every type class implementation in the program, keyed by requirement and the type it is for.
+     * <p>
+     * A type argument can carry its instances directly, but that binding lives on the argument
+     * position and is lost as soon as a type variable is substituted into a plain type, which is
+     * what happens when a generic class type travels through a return type or a receiver. Instance
+     * selection is static, so keying on the concrete type is both simpler and robust: the type at a
+     * dispatch site is enough to find the implementation, however it got there.
+     */
+    private final Map<ImTypeClassFunc, Map<String, ImFunction>> typeClassImpls = new LinkedHashMap<>();
+
+    public void registerTypeClassImpl(ImTypeClassFunc requirement, ImType instanceType, ImFunction impl) {
+        typeClassImpls.computeIfAbsent(requirement, r -> new LinkedHashMap<>())
+                .putIfAbsent(typeClassKey(instanceType), impl);
+    }
+
+    public @Nullable ImFunction lookupTypeClassImpl(ImTypeClassFunc requirement, ImType instanceType) {
+        Map<String, ImFunction> byType = typeClassImpls.get(requirement);
+        return byType == null ? null : byType.get(typeClassKey(instanceType));
+    }
+
+    /** Structural key for an instance type; concrete types print stably. */
+    private static String typeClassKey(ImType type) {
+        return type.toString();
+    }
+
     public ImTypeVar getTypeVar(TypeParamDef tp) {
         // If we're translating inside a captured class (Iterator), prefer its override
         for (Map<TypeParamDef, ImTypeVar> m : typeVarOverrideStack) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/TLDTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/TLDTranslation.java
@@ -1,6 +1,9 @@
 package de.peeeq.wurstscript.translation.imtranslation;
 
 import de.peeeq.wurstscript.ast.*;
+import de.peeeq.wurstscript.types.TypeClassInstances;
+import de.peeeq.wurstscript.types.WurstType;
+import de.peeeq.wurstscript.jassIm.ImType;
 import de.peeeq.wurstscript.jassIm.ImFunction;
 import de.peeeq.wurstscript.jassIm.ImStmt;
 import de.peeeq.wurstscript.jassIm.ImVar;
@@ -157,6 +160,27 @@ public class TLDTranslation {
     public static void translate(InstanceDecl instanceDecl, ImTranslator translator) {
         for (FuncDef method : instanceDecl.getMethods()) {
             translate(method, translator);
+        }
+        registerInstance(instanceDecl, translator);
+    }
+
+    /**
+     * Records which function implements which requirement for which type, so that a dispatch can be
+     * resolved from the concrete type it ends up with.
+     */
+    private static void registerInstance(InstanceDecl decl, ImTranslator translator) {
+        InterfaceDef iface = TypeClassInstances.declaredInterface(decl);
+        WurstType instanceType = TypeClassInstances.instanceType(decl);
+        if (iface == null || instanceType == null || iface.getTypeParameters().size() != 1) {
+            return; // reported by the validator
+        }
+        ImType imInstanceType = instanceType.imTranslateType(translator);
+        for (FuncDef requirement : iface.getMethods()) {
+            FuncDef impl = TypeClassInstances.findImplementation(decl, requirement, instanceType);
+            if (impl != null) {
+                translator.registerTypeClassImpl(translator.getTypeClassFunc(requirement),
+                        imInstanceType, translator.getFuncFor(impl));
+            }
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/TLDTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/TLDTranslation.java
@@ -149,6 +149,17 @@ public class TLDTranslation {
         // nothing to do, only translate module instantiations
     }
 
+    /**
+     * A type class instance contributes its methods as ordinary global functions. Constraint
+     * resolution happens in the frontend, so every use site already knows which function it
+     * needs and can call it directly.
+     */
+    public static void translate(InstanceDecl instanceDecl, ImTranslator translator) {
+        for (FuncDef method : instanceDecl.getMethods()) {
+            translate(method, translator);
+        }
+    }
+
     public static void translate(TypeParamDef typeParamDef, ImTranslator translator) {
         // not possible
         throw new Error("invalid AST");

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -196,7 +196,28 @@ public class LuaTranslator {
         luaModel = LuaAst.LuaCompilationUnit();
     }
 
-    protected String uniqueName(String name) {
+    /**
+     * Makes an intermediate-language name usable as a Lua identifier.
+     * <p>
+     * Names from the IM are not constrained to Lua's identifier syntax; specialised generics, for
+     * example, are named after their type arguments. Sanitising here keeps that rule where it
+     * belongs, in the backend, rather than requiring every earlier pass to know about Lua. Any
+     * collisions the mapping introduces are resolved by the usual uniquing.
+     */
+    private static String toLuaIdentifier(String name) {
+        StringBuilder sb = new StringBuilder(name.length());
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            sb.append(c == '_' || Character.isLetterOrDigit(c) && c < 128 ? c : '_');
+        }
+        if (sb.length() == 0 || Character.isDigit(sb.charAt(0))) {
+            sb.insert(0, '_');
+        }
+        return sb.toString();
+    }
+
+    protected String uniqueName(String rawName) {
+        String name = toLuaIdentifier(rawName);
         Integer nextIndex = uniqueNameCounters.get(name);
         if (nextIndex == null) {
             uniqueNameCounters.put(name, 1);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypeClassConstraints.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypeClassConstraints.java
@@ -1,0 +1,93 @@
+package de.peeeq.wurstscript.types;
+
+import de.peeeq.wurstscript.ast.*;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Reads the type class bounds written on a new-style type parameter.
+ * <p>
+ * A bound names the interface without applying it, so {@code <T: Indexable>} means
+ * "there is an instance of {@code Indexable<T>}". v1 only supports interfaces with exactly one
+ * type parameter, which keeps the bound unambiguous and instance search a direct lookup.
+ */
+public final class TypeClassConstraints {
+
+    private TypeClassConstraints() {
+    }
+
+    /**
+     * The interfaces named as bounds of the given type parameter, in source order.
+     * Bounds which do not resolve to a single-parameter interface are skipped here; the validator
+     * reports those separately so that a bad bound does not cascade into every use site.
+     */
+    public static List<InterfaceDef> boundInterfaces(TypeParamDef tp) {
+        List<TypeExpr> exprs = boundExprs(tp);
+        if (exprs.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<InterfaceDef> result = new ArrayList<>(exprs.size());
+        for (TypeExpr e : exprs) {
+            InterfaceDef def = resolveBound(e);
+            if (def != null) {
+                result.add(def);
+            }
+        }
+        return result;
+    }
+
+    /** The raw bound type expressions, so callers can attach diagnostics to the right source range. */
+    public static List<TypeExpr> boundExprs(TypeParamDef tp) {
+        TypeParamConstraints constraints = tp.getTypeParamConstraints();
+        if (!(constraints instanceof TypeExprList list) || list.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(list);
+    }
+
+    /** True if this type parameter carries at least one bound, i.e. it is more than a bare {@code <T:>}. */
+    public static boolean hasBounds(TypeParamDef tp) {
+        return !boundExprs(tp).isEmpty();
+    }
+
+    /**
+     * Resolves one bound expression to the interface it names, or null when the bound is not a
+     * plain reference to a single-parameter interface.
+     */
+    public static @Nullable InterfaceDef resolveBound(TypeExpr boundExpr) {
+        if (!(boundExpr instanceof TypeExprSimple simple)) {
+            return null;
+        }
+        // A bound names the interface unapplied: writing the type argument would be redundant,
+        // because it is always the type parameter being constrained.
+        if (!simple.getTypeArgs().isEmpty()) {
+            return null;
+        }
+        TypeDef def = boundExpr.lookupType(simple.getTypeName(), false);
+        if (!(def instanceof InterfaceDef i)) {
+            return null;
+        }
+        if (i.getTypeParameters().size() != 1) {
+            return null;
+        }
+        return i;
+    }
+
+    /**
+     * Looks up a method required by any bound of the given type parameter.
+     * Earlier bounds win, matching the left-to-right order the bounds were written in.
+     */
+    public static @Nullable FuncDef findRequiredMethod(TypeParamDef tp, String name) {
+        for (InterfaceDef bound : boundInterfaces(tp)) {
+            for (FuncDef m : bound.getMethods()) {
+                if (m.getName().equals(name)) {
+                    return m;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypeClassConstraints.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypeClassConstraints.java
@@ -21,8 +21,8 @@ public final class TypeClassConstraints {
 
     /**
      * The interfaces named as bounds of the given type parameter, in source order.
-     * Bounds which do not resolve to a single-parameter interface are skipped here; the validator
-     * reports those separately so that a bad bound does not cascade into every use site.
+     * Unusable bounds are skipped; {@link #invalidBoundReason} explains why, and the validator
+     * reports it at the bound itself so a bad bound does not cascade into every use site.
      */
     public static List<InterfaceDef> boundInterfaces(TypeParamDef tp) {
         List<TypeExpr> exprs = boundExprs(tp);
@@ -58,22 +58,49 @@ public final class TypeClassConstraints {
      * plain reference to a single-parameter interface.
      */
     public static @Nullable InterfaceDef resolveBound(TypeExpr boundExpr) {
+        return invalidBoundReason(boundExpr) == null ? namedInterface(boundExpr) : null;
+    }
+
+    /**
+     * Explains why a bound cannot be used as a type class, or null when it is usable.
+     * <p>
+     * A bound must name an interface, unapplied, with exactly one type parameter, and that
+     * interface must not extend another. The last restriction keeps the set of requirements equal
+     * to the interface's own methods, so an instance cannot silently miss an inherited one.
+     */
+    public static @Nullable String invalidBoundReason(TypeExpr boundExpr) {
         if (!(boundExpr instanceof TypeExprSimple simple)) {
-            return null;
+            return "A bound must name an interface.";
         }
         // A bound names the interface unapplied: writing the type argument would be redundant,
         // because it is always the type parameter being constrained.
         if (!simple.getTypeArgs().isEmpty()) {
-            return null;
+            return "A bound must name the interface without type arguments, because the argument is"
+                    + " always the type parameter being constrained.";
         }
         TypeDef def = boundExpr.lookupType(simple.getTypeName(), false);
+        if (def == null) {
+            return "Could not find " + simple.getTypeName() + ".";
+        }
         if (!(def instanceof InterfaceDef i)) {
-            return null;
+            return simple.getTypeName() + " is not an interface, so it cannot be used as a bound.";
         }
         if (i.getTypeParameters().size() != 1) {
+            return i.getName() + " must have exactly one type parameter to be used as a bound, but has "
+                    + i.getTypeParameters().size() + ".";
+        }
+        if (!i.getExtendsList().isEmpty()) {
+            return i.getName() + " extends another interface, which is not supported for bounds:"
+                    + " the requirements of a bound are the interface's own functions.";
+        }
+        return null;
+    }
+
+    private static @Nullable InterfaceDef namedInterface(TypeExpr boundExpr) {
+        if (!(boundExpr instanceof TypeExprSimple simple)) {
             return null;
         }
-        return i;
+        return boundExpr.lookupType(simple.getTypeName(), false) instanceof InterfaceDef i ? i : null;
     }
 
     /**

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypeClassConstraints.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypeClassConstraints.java
@@ -93,6 +93,24 @@ public final class TypeClassConstraints {
             return i.getName() + " extends another interface, which is not supported for bounds:"
                     + " the requirements of a bound are the interface's own functions.";
         }
+        FuncDef generic = firstGenericMethod(i);
+        if (generic != null) {
+            // Matching such a requirement means pairing the interface's method type parameters with
+            // the implementation's, which this version does not do. Say so, rather than comparing
+            // parameters that only look identical and reporting a mismatch between a name and itself.
+            return i.getName() + "." + generic.getName() + " has its own type parameters, which is not"
+                    + " supported for a bound: a requirement may only use the interface's type parameter.";
+        }
+        return null;
+    }
+
+    /** The first requirement declaring type parameters of its own, or null when none does. */
+    public static @Nullable FuncDef firstGenericMethod(InterfaceDef iface) {
+        for (FuncDef method : iface.getMethods()) {
+            if (!method.getTypeParameters().isEmpty()) {
+                return method;
+            }
+        }
         return null;
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypeClassInstances.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypeClassInstances.java
@@ -99,6 +99,63 @@ public final class TypeClassInstances {
         return simple.getTypeArgs().get(0).attrTyp();
     }
 
+    /**
+     * The instance method implementing the given requirement, or null when none matches.
+     * <p>
+     * An interface may overload a requirement name, so the match is on the substituted signature
+     * rather than the name alone. Validation and lowering both go through here, so a rejected
+     * instance and a selected implementation can never disagree.
+     */
+    public static @Nullable FuncDef findImplementation(InstanceDecl decl, FuncDef requirement,
+                                                       WurstType instanceType) {
+        List<FuncDef> sameName = new ArrayList<>();
+        for (FuncDef provided : decl.getMethods()) {
+            if (provided.getName().equals(requirement.getName())) {
+                sameName.add(provided);
+            }
+        }
+        if (sameName.size() == 1) {
+            // The common case: one candidate, so let the signature check report any mismatch
+            // against this one rather than silently finding nothing.
+            return sameName.get(0);
+        }
+        for (FuncDef provided : sameName) {
+            if (signatureMatches(provided, requirement, instanceType, decl)) {
+                return provided;
+            }
+        }
+        return null;
+    }
+
+    /** True when the implementation matches the requirement with the interface parameter substituted. */
+    public static boolean signatureMatches(FuncDef provided, FuncDef requirement, WurstType instanceType,
+                                           Element context) {
+        VariableBinding binding = requirementBinding(requirement, instanceType, context);
+        if (binding == null || provided.getParameters().size() != requirement.getParameters().size()) {
+            return false;
+        }
+        for (int i = 0; i < requirement.getParameters().size(); i++) {
+            WurstType expected = requirement.getParameters().get(i).attrTyp().setTypeArgs(binding);
+            if (!provided.getParameters().get(i).attrTyp().equalsType(expected, context)) {
+                return false;
+            }
+        }
+        WurstType expectedReturn = requirement.attrReturnTyp().setTypeArgs(binding);
+        return provided.attrReturnTyp().equalsType(expectedReturn, context);
+    }
+
+    /** Replaces the interface's own type parameter by the type an instance is declared for. */
+    public static @Nullable VariableBinding requirementBinding(FuncDef requirement, WurstType instanceType,
+                                                               Element context) {
+        ClassOrInterface owner = requirement.attrNearestClassOrInterface();
+        if (!(owner instanceof InterfaceDef iface) || iface.getTypeParameters().size() != 1) {
+            return null;
+        }
+        TypeParamDef ifaceParam = iface.getTypeParameters().get(0);
+        return VariableBinding.emptyMapping()
+                .set(ifaceParam, new WurstTypeBoundTypeParam(ifaceParam, instanceType, context));
+    }
+
     private static @Nullable WPackage packageOf(Element e) {
         PackageOrGlobal p = e.attrNearestPackage();
         return p instanceof WPackage w ? w : null;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypeClassInstances.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/TypeClassInstances.java
@@ -1,0 +1,121 @@
+package de.peeeq.wurstscript.types;
+
+import de.peeeq.wurstscript.ast.*;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Finds the type class instance which satisfies a bound.
+ * <p>
+ * Resolution deliberately does not search the import graph. An instance may only be declared in
+ * the package that declares the interface or in the package that declares the type, so a lookup
+ * only ever has to inspect those two packages. That keeps instance selection independent of which
+ * packages happen to be imported at the use site, which in turn guarantees that a given
+ * {@code (interface, type)} pair means the same thing everywhere in the program.
+ */
+public final class TypeClassInstances {
+
+    private TypeClassInstances() {
+    }
+
+    /**
+     * The single instance binding {@code iface} to {@code type}, or null when there is none.
+     * Ambiguity is impossible by construction here; the validator rejects duplicate instances at
+     * their declaration sites instead, where the error can point at both offenders.
+     */
+    public static @Nullable InstanceDecl find(InterfaceDef iface, WurstType type) {
+        for (WPackage p : candidatePackages(iface, type)) {
+            InstanceDecl found = findIn(p, iface, type);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    /** The only two packages an instance for this pair is permitted to live in. */
+    public static List<WPackage> candidatePackages(InterfaceDef iface, WurstType type) {
+        List<WPackage> result = new ArrayList<>(2);
+        WPackage ifacePackage = packageOf(iface);
+        if (ifacePackage != null) {
+            result.add(ifacePackage);
+        }
+        WPackage typePackage = packageOfType(type);
+        if (typePackage != null && !result.contains(typePackage)) {
+            result.add(typePackage);
+        }
+        return result;
+    }
+
+    private static @Nullable InstanceDecl findIn(WPackage p, InterfaceDef iface, WurstType type) {
+        for (InstanceDecl decl : declaredIn(p)) {
+            if (matches(decl, iface, type)) {
+                return decl;
+            }
+        }
+        return null;
+    }
+
+    /** The instance declarations written directly in the given package. */
+    public static List<InstanceDecl> declaredIn(WPackage p) {
+        List<InstanceDecl> result = new ArrayList<>();
+        for (WEntity e : p.getElements()) {
+            if (e instanceof InstanceDecl decl) {
+                result.add(decl);
+            }
+        }
+        return result;
+    }
+
+    /** True when this declaration is the instance for exactly {@code iface} applied to {@code type}. */
+    public static boolean matches(InstanceDecl decl, InterfaceDef iface, WurstType type) {
+        InterfaceDef declared = declaredInterface(decl);
+        if (declared != iface) {
+            return false;
+        }
+        WurstType declaredFor = instanceType(decl);
+        return declaredFor != null && declaredFor.equalsType(type, decl);
+    }
+
+    /** The interface named by an instance declaration, e.g. {@code Indexable} in {@code instance Indexable<vec2>}. */
+    public static @Nullable InterfaceDef declaredInterface(InstanceDecl decl) {
+        if (!(decl.getImplementedInterface() instanceof TypeExprSimple simple)) {
+            return null;
+        }
+        TypeDef def = decl.lookupType(simple.getTypeName(), false);
+        return def instanceof InterfaceDef i ? i : null;
+    }
+
+    /** The concrete type an instance is declared for, e.g. {@code vec2} in {@code instance Indexable<vec2>}. */
+    public static @Nullable WurstType instanceType(InstanceDecl decl) {
+        if (!(decl.getImplementedInterface() instanceof TypeExprSimple simple)) {
+            return null;
+        }
+        if (simple.getTypeArgs().size() != 1) {
+            return null;
+        }
+        return simple.getTypeArgs().get(0).attrTyp();
+    }
+
+    private static @Nullable WPackage packageOf(Element e) {
+        PackageOrGlobal p = e.attrNearestPackage();
+        return p instanceof WPackage w ? w : null;
+    }
+
+    /**
+     * The package which declares the given type, if it has one. Primitives and Jass handle types
+     * have no declaring Wurst package, so instances for those must live with the interface.
+     */
+    private static @Nullable WPackage packageOfType(WurstType type) {
+        WurstType t = type.normalize();
+        if (t instanceof WurstTypeNamedScope ns && ns.getDef() != null) {
+            return packageOf(ns.getDef());
+        }
+        if (t instanceof WurstTypeTuple tuple && tuple.getTupleDef() != null) {
+            return packageOf(tuple.getTupleDef());
+        }
+        return null;
+    }
+}

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/WurstTypeBoundTypeParam.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/WurstTypeBoundTypeParam.java
@@ -199,9 +199,40 @@ public class WurstTypeBoundTypeParam extends WurstType {
     }
 
     public ImTypeArgument imTranslateToTypeArgument(ImTranslator tr) {
-        ImType t = imTranslateType(tr);
-        Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> typeClassBinding = new HashMap<>();
-        // TODO add type class binding
-        return JassIm.ImTypeArgument(t, typeClassBinding);
+        return JassIm.ImTypeArgument(imTranslateType(tr), imTypeClassBinding(tr));
+    }
+
+    /**
+     * Binds every requirement of this type parameter's bounds to the function supplied by the
+     * instance chosen for the type it is bound to.
+     * <p>
+     * Used for both function and class type arguments, so that a bound on a generic class works the
+     * same way as one on a generic function. Stays empty while the bound type is itself abstract:
+     * the enclosing generic is specialised first, and the binding is inherited at that point.
+     */
+    public Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> imTypeClassBinding(ImTranslator tr) {
+        Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> binding = new HashMap<>();
+        List<InterfaceDef> bounds = TypeClassConstraints.boundInterfaces(typeParamDef);
+        if (bounds.isEmpty()) {
+            return binding;
+        }
+        WurstType concrete = baseType.normalize();
+        if (concrete instanceof WurstTypeTypeParam || concrete instanceof WurstTypeBoundTypeParam) {
+            return binding;
+        }
+        for (InterfaceDef iface : bounds) {
+            InstanceDecl instance = TypeClassInstances.find(iface, concrete);
+            if (instance == null) {
+                // the validator reports the unsatisfied bound; do not fail translation as well
+                continue;
+            }
+            for (FuncDef requirement : iface.getMethods()) {
+                FuncDef impl = TypeClassInstances.findImplementation(instance, requirement, concrete);
+                if (impl != null) {
+                    binding.put(tr.getTypeClassFunc(requirement), Either.right(tr.getFuncFor(impl)));
+                }
+            }
+        }
+        return binding;
     }
 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/WurstTypeTypeParam.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/types/WurstTypeTypeParam.java
@@ -1,8 +1,11 @@
 package de.peeeq.wurstscript.types;
 
 import de.peeeq.wurstscript.ast.Element;
+import de.peeeq.wurstscript.ast.FuncDef;
+import de.peeeq.wurstscript.ast.InterfaceDef;
 import de.peeeq.wurstscript.ast.TypeExprList;
 import de.peeeq.wurstscript.ast.TypeParamDef;
+import de.peeeq.wurstscript.attributes.names.FuncLink;
 import de.peeeq.wurstscript.jassIm.ImExprOpt;
 import de.peeeq.wurstscript.jassIm.ImType;
 import de.peeeq.wurstscript.jassIm.JassIm;
@@ -10,12 +13,25 @@ import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
 import io.vavr.control.Option;
 import org.eclipse.jdt.annotation.Nullable;
 
+import java.util.List;
+import java.util.stream.Stream;
+
 public class WurstTypeTypeParam extends WurstType {
 
     private final TypeParamDef def;
+    /**
+     * True when this stands for the type parameter itself rather than a value of it, as in the
+     * receiver of {@code T.toIndex(x)}. Only this form exposes the methods required by the bounds.
+     */
+    private final boolean staticRef;
 
     public WurstTypeTypeParam(TypeParamDef t) {
+        this(t, false);
+    }
+
+    public WurstTypeTypeParam(TypeParamDef t, boolean staticRef) {
         this.def = t;
+        this.staticRef = staticRef;
     }
 
     @Override
@@ -55,6 +71,16 @@ public class WurstTypeTypeParam extends WurstType {
     }
 
     @Override
+    public boolean isStaticRef() {
+        return staticRef;
+    }
+
+    /** The same type parameter, seen as the type itself rather than as a value of it. */
+    public WurstTypeTypeParam asStaticRef() {
+        return staticRef ? this : new WurstTypeTypeParam(def, true);
+    }
+
+    @Override
     public VariableBinding getTypeArgBinding() {
         return VariableBinding.emptyMapping();
     }
@@ -65,6 +91,44 @@ public class WurstTypeTypeParam extends WurstType {
             return typeParamBounds.get(def).get();
         }
         return this;
+    }
+
+    @Override
+    public void addMemberMethods(Element node, String name, List<FuncLink> result) {
+        if (!staticRef) {
+            return;
+        }
+        for (InterfaceDef bound : TypeClassConstraints.boundInterfaces(def)) {
+            for (FuncDef method : bound.getMethods()) {
+                if (method.getName().equals(name)) {
+                    result.add(requirementLink(node, bound, method));
+                }
+            }
+        }
+    }
+
+    @Override
+    public Stream<FuncLink> getMemberMethods(Element node) {
+        if (!staticRef) {
+            return Stream.empty();
+        }
+        return TypeClassConstraints.boundInterfaces(def).stream()
+                .flatMap(bound -> bound.getMethods().stream()
+                        .map(method -> requirementLink(node, bound, method)));
+    }
+
+    /**
+     * Exposes one interface method as a requirement of this type parameter: the interface's own
+     * type parameter is substituted by this one, and the receiver becomes the type parameter, so
+     * the call reads {@code T.f(args)} with the arguments exactly as declared.
+     */
+    private FuncLink requirementLink(Element node, InterfaceDef bound, FuncDef method) {
+        TypeParamDef ifaceParam = bound.getTypeParameters().get(0);
+        VariableBinding binding = VariableBinding.emptyMapping()
+                .set(ifaceParam, new WurstTypeBoundTypeParam(ifaceParam, new WurstTypeTypeParam(def), node));
+        return FuncLink.create(method, bound)
+                .withTypeArgBinding(node, binding)
+                .withReceiverType(this);
     }
 
     @Override

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -405,6 +405,8 @@ public class WurstValidator {
                 checkConstructorsUnique((ClassOrModule) e);
             if (e instanceof InstanceDecl)
                 checkInstanceDecl((InstanceDecl) e);
+            if (e instanceof StmtCall)
+                checkCallBounds((StmtCall) e);
             if (e instanceof CompilationUnit)
                 checkPackageName((CompilationUnit) e);
             if (e instanceof ConstructorDef) {
@@ -2572,6 +2574,25 @@ public class WurstValidator {
 
     public static boolean isTypeParamNewGeneric(TypeParamDef tp) {
         return tp.getTypeParamConstraints() instanceof TypeExprList;
+    }
+
+    /**
+     * Checks the bounds of the callee's type parameters against the type arguments this call
+     * inferred. The call signature is the only place both are known, since the return type alone
+     * usually mentions none of them.
+     */
+    private void checkCallBounds(StmtCall call) {
+        FunctionSignature sig = call.attrFunctionSignature();
+        if (sig == null) {
+            return;
+        }
+        VariableBinding mapping = sig.getMapping();
+        if (mapping == null) {
+            return;
+        }
+        for (Tuple2<TypeParamDef, WurstTypeBoundTypeParam> t : mapping) {
+            checkBoundsSatisfied(call, t._1(), t._2().getBaseType());
+        }
     }
 
     /**

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -405,6 +405,8 @@ public class WurstValidator {
                 checkConstructorsUnique((ClassOrModule) e);
             if (e instanceof InstanceDecl)
                 checkInstanceDecl((InstanceDecl) e);
+            if (e instanceof TypeParamDef)
+                checkTypeParamBounds((TypeParamDef) e);
             if (e instanceof StmtCall)
                 checkCallBounds((StmtCall) e);
             if (e instanceof CompilationUnit)
@@ -2600,16 +2602,51 @@ public class WurstValidator {
      * where the type argument is chosen so the message can name both.
      */
     private void checkBoundsSatisfied(Element location, TypeParamDef tp, WurstType typ) {
-        if (typ instanceof WurstTypeUnknown || typ instanceof WurstTypeTypeParam
-                || typ instanceof WurstTypeBoundTypeParam) {
-            // still abstract, or already broken: checked once it is bound to something concrete
+        List<InterfaceDef> bounds = TypeClassConstraints.boundInterfaces(tp);
+        if (bounds.isEmpty() || typ instanceof WurstTypeUnknown) {
             return;
         }
-        for (InterfaceDef bound : TypeClassConstraints.boundInterfaces(tp)) {
-            if (TypeClassInstances.find(bound, typ) == null) {
-                location.addError("Type " + typ + " does not satisfy the bound " + tp.getName() + ": "
-                        + bound.getName() + ".\nDeclare 'implements " + bound.getName() + "<" + typ + ">' in the package of "
-                        + bound.getName() + " or of " + typ + ".");
+        WurstType normalized = typ.normalize();
+        TypeParamDef abstractArg = asTypeParam(normalized);
+        if (abstractArg != null) {
+            // The argument is another type parameter, so no instance exists yet. It can only supply
+            // the bound if it declares it itself; otherwise the call is unsatisfiable no matter what
+            // the outer generic is later instantiated with.
+            for (InterfaceDef bound : bounds) {
+                if (!TypeClassConstraints.boundInterfaces(abstractArg).contains(bound)) {
+                    location.addError("Type parameter " + abstractArg.getName() + " does not satisfy the bound "
+                            + tp.getName() + ": " + bound.getName() + ".\nAdd the bound to " + abstractArg.getName()
+                            + ", as in <" + abstractArg.getName() + ": " + bound.getName() + ">.");
+                }
+            }
+            return;
+        }
+        for (InterfaceDef bound : bounds) {
+            if (TypeClassInstances.find(bound, normalized) == null) {
+                location.addError("Type " + normalized + " does not satisfy the bound " + tp.getName() + ": "
+                        + bound.getName() + ".\nDeclare 'implements " + bound.getName() + "<" + normalized
+                        + ">' in the package of " + bound.getName() + " or of " + normalized + ".");
+            }
+        }
+    }
+
+    /** The type parameter this type stands for, when it is still abstract. */
+    private static @Nullable TypeParamDef asTypeParam(WurstType typ) {
+        if (typ instanceof WurstTypeTypeParam tp) {
+            return tp.getDef();
+        }
+        if (typ instanceof WurstTypeBoundTypeParam bound) {
+            return asTypeParam(bound.getBaseType().normalize());
+        }
+        return null;
+    }
+
+    /** Every bound written on a type parameter must be usable as a type class. */
+    private void checkTypeParamBounds(TypeParamDef tp) {
+        for (TypeExpr boundExpr : TypeClassConstraints.boundExprs(tp)) {
+            String reason = TypeClassConstraints.invalidBoundReason(boundExpr);
+            if (reason != null) {
+                boundExpr.addError("Invalid bound on type parameter " + tp.getName() + ": " + reason);
             }
         }
     }
@@ -2637,9 +2674,15 @@ public class WurstValidator {
             return;
         }
 
+        if (!iface.getExtendsList().isEmpty()) {
+            decl.addError("Interface " + iface.getName() + " extends another interface, which is not supported"
+                    + " for type classes: the requirements of a bound are the interface's own functions.");
+            return;
+        }
+
         checkInstanceIsNotOrphan(decl, iface, instanceType);
         checkInstanceIsUnique(decl, iface, instanceType);
-        checkInstanceIsComplete(decl, iface);
+        checkInstanceIsComplete(decl, iface, instanceType);
     }
 
     private void checkInstanceIsNotOrphan(InstanceDecl decl, InterfaceDef iface, WurstType instanceType) {
@@ -2673,17 +2716,24 @@ public class WurstValidator {
         }
     }
 
-    private void checkInstanceIsComplete(InstanceDecl decl, InterfaceDef iface) {
+    private void checkInstanceIsComplete(InstanceDecl decl, InterfaceDef iface, WurstType instanceType) {
+        // The requirement is written in terms of the interface's type parameter, so compare against
+        // it with that parameter replaced by the type this instance is for.
+        TypeParamDef ifaceParam = iface.getTypeParameters().get(0);
+        VariableBinding binding = VariableBinding.emptyMapping()
+                .set(ifaceParam, new WurstTypeBoundTypeParam(ifaceParam, instanceType, decl));
+
         StringBuilder missing = new StringBuilder();
         for (FuncDef requirement : iface.getMethods()) {
             int found = 0;
             for (FuncDef provided : decl.getMethods()) {
                 if (provided.getName().equals(requirement.getName())) {
                     found++;
+                    checkInstanceMethodSignature(provided, requirement, binding, iface);
                 }
             }
             if (found == 0) {
-                missing.append("\n    ").append(requirement.getName());
+                missing.append("\n    ").append(requirementTemplate(requirement, binding, decl));
             } else if (found > 1) {
                 decl.addError("This instance defines " + requirement.getName() + " more than once.");
             }
@@ -2704,6 +2754,61 @@ public class WurstValidator {
                         + ", so it cannot be defined in this instance.");
             }
         }
+    }
+
+    /**
+     * An instance method must match its requirement exactly once the interface's type parameter is
+     * replaced by the instance type. Matching on the name alone would let a wrongly typed
+     * implementation be selected and emitted, which the backend cannot catch.
+     */
+    private void checkInstanceMethodSignature(FuncDef provided, FuncDef requirement,
+                                              VariableBinding binding, InterfaceDef iface) {
+        List<WurstType> expectedParams = new ArrayList<>();
+        for (WParameter p : requirement.getParameters()) {
+            expectedParams.add(p.attrTyp().setTypeArgs(binding));
+        }
+        if (provided.getParameters().size() != expectedParams.size()) {
+            provided.addError(provided.getName() + " must take " + expectedParams.size()
+                    + " parameter(s) to implement " + iface.getName() + "."
+                    + "\nExpected: " + signatureText(requirement, binding));
+            return;
+        }
+        for (int i = 0; i < expectedParams.size(); i++) {
+            WParameter actual = provided.getParameters().get(i);
+            WurstType expected = expectedParams.get(i);
+            if (!actual.attrTyp().equalsType(expected, actual)) {
+                actual.addError("Parameter " + actual.getName() + " should have type " + expected
+                        + " to implement " + iface.getName() + "." + provided.getName() + ", but has "
+                        + actual.attrTyp() + ".");
+            }
+        }
+        WurstType expectedReturn = requirement.attrReturnTyp().setTypeArgs(binding);
+        if (!provided.attrReturnTyp().equalsType(expectedReturn, provided)) {
+            provided.addError(provided.getName() + " should return " + expectedReturn + " to implement "
+                    + iface.getName() + ", but returns " + provided.attrReturnTyp() + ".");
+        }
+    }
+
+    private String requirementTemplate(FuncDef requirement, VariableBinding binding, Element context) {
+        return signatureText(requirement, binding);
+    }
+
+    private String signatureText(FuncDef requirement, VariableBinding binding) {
+        StringBuilder sb = new StringBuilder("function ").append(requirement.getName()).append("(");
+        boolean first = true;
+        for (WParameter p : requirement.getParameters()) {
+            if (!first) {
+                sb.append(", ");
+            }
+            first = false;
+            sb.append(p.attrTyp().setTypeArgs(binding)).append(" ").append(p.getName());
+        }
+        sb.append(")");
+        WurstType returnType = requirement.attrReturnTyp().setTypeArgs(binding);
+        if (!(returnType instanceof WurstTypeVoid)) {
+            sb.append(" returns ").append(returnType);
+        }
+        return sb.toString();
     }
 
     private void checkFuncRef(FuncRef ref) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -2643,6 +2643,15 @@ public class WurstValidator {
 
     /** Every bound written on a type parameter must be usable as a type class. */
     private void checkTypeParamBounds(TypeParamDef tp) {
+        if (TypeClassConstraints.hasBounds(tp) && tp.attrNearestStructureDef() instanceof ModuleDef) {
+            // Using a module copies its body into the class, replacing the module's type parameters
+            // in type positions. A requirement is called on the parameter itself, which is an
+            // expression, so it survives the copy and no longer resolves. Reject that here rather
+            // than let it fail later as an unknown name.
+            tp.addError("Type class bounds are not supported on a module type parameter."
+                    + "\nMove the bounded generic into a class, or use the module without a bound.");
+            return;
+        }
         for (TypeExpr boundExpr : TypeClassConstraints.boundExprs(tp)) {
             String reason = TypeClassConstraints.invalidBoundReason(boundExpr);
             if (reason != null) {
@@ -2677,6 +2686,13 @@ public class WurstValidator {
         if (!iface.getExtendsList().isEmpty()) {
             decl.addError("Interface " + iface.getName() + " extends another interface, which is not supported"
                     + " for type classes: the requirements of a bound are the interface's own functions.");
+            return;
+        }
+        FuncDef genericRequirement = TypeClassConstraints.firstGenericMethod(iface);
+        if (genericRequirement != null) {
+            decl.addError(iface.getName() + "." + genericRequirement.getName() + " has its own type parameters,"
+                    + " which is not supported for a type class: a requirement may only use the interface's"
+                    + " type parameter.");
             return;
         }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -2723,35 +2723,25 @@ public class WurstValidator {
         VariableBinding binding = VariableBinding.emptyMapping()
                 .set(ifaceParam, new WurstTypeBoundTypeParam(ifaceParam, instanceType, decl));
 
+        // An interface may overload a requirement name, so pair each requirement with the
+        // implementation that matches its signature; the lowering selects the same one.
         StringBuilder missing = new StringBuilder();
+        Set<FuncDef> used = Collections.newSetFromMap(new IdentityHashMap<>());
         for (FuncDef requirement : iface.getMethods()) {
-            int found = 0;
-            for (FuncDef provided : decl.getMethods()) {
-                if (provided.getName().equals(requirement.getName())) {
-                    found++;
-                    checkInstanceMethodSignature(provided, requirement, binding, iface);
-                }
+            FuncDef impl = TypeClassInstances.findImplementation(decl, requirement, instanceType);
+            if (impl == null || !used.add(impl)) {
+                missing.append("\n    ").append(signatureText(requirement, binding));
+                continue;
             }
-            if (found == 0) {
-                missing.append("\n    ").append(requirementTemplate(requirement, binding, decl));
-            } else if (found > 1) {
-                decl.addError("This instance defines " + requirement.getName() + " more than once.");
-            }
+            checkInstanceMethodSignature(impl, requirement, binding, iface);
         }
         if (missing.length() > 0) {
             decl.addError("This instance of " + iface.getName() + " must implement:" + missing);
         }
         for (FuncDef provided : decl.getMethods()) {
-            boolean required = false;
-            for (FuncDef requirement : iface.getMethods()) {
-                if (provided.getName().equals(requirement.getName())) {
-                    required = true;
-                    break;
-                }
-            }
-            if (!required) {
-                provided.addError(provided.getName() + " is not required by " + iface.getName()
-                        + ", so it cannot be defined in this instance.");
+            if (!used.contains(provided)) {
+                provided.addError(provided.getName() + " does not implement any requirement of "
+                        + iface.getName() + ", so it cannot be defined in this instance.");
             }
         }
     }
@@ -2787,10 +2777,6 @@ public class WurstValidator {
             provided.addError(provided.getName() + " should return " + expectedReturn + " to implement "
                     + iface.getName() + ", but returns " + provided.attrReturnTyp() + ".");
         }
-    }
-
-    private String requirementTemplate(FuncDef requirement, VariableBinding binding, Element context) {
-        return signatureText(requirement, binding);
     }
 
     private String signatureText(FuncDef requirement, VariableBinding binding) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -403,6 +403,8 @@ public class WurstValidator {
             }
             if (e instanceof ClassOrModule)
                 checkConstructorsUnique((ClassOrModule) e);
+            if (e instanceof InstanceDecl)
+                checkInstanceDecl((InstanceDecl) e);
             if (e instanceof CompilationUnit)
                 checkPackageName((CompilationUnit) e);
             if (e instanceof ConstructorDef) {
@@ -2501,7 +2503,7 @@ public class WurstValidator {
 
             TypeParamDef tp = t._1();
             if (isTypeParamNewGeneric(tp)) {
-                // new style generics
+                checkBoundsSatisfied(e, tp, typ);
             } else { // old style generics
 
                 if (!typ.isTranslatedToInt() && !(e instanceof ModuleUse)) {
@@ -2570,6 +2572,117 @@ public class WurstValidator {
 
     public static boolean isTypeParamNewGeneric(TypeParamDef tp) {
         return tp.getTypeParamConstraints() instanceof TypeExprList;
+    }
+
+    /**
+     * Every bound on a type parameter must have an instance for the type it was bound to, checked
+     * where the type argument is chosen so the message can name both.
+     */
+    private void checkBoundsSatisfied(Element location, TypeParamDef tp, WurstType typ) {
+        if (typ instanceof WurstTypeUnknown || typ instanceof WurstTypeTypeParam
+                || typ instanceof WurstTypeBoundTypeParam) {
+            // still abstract, or already broken: checked once it is bound to something concrete
+            return;
+        }
+        for (InterfaceDef bound : TypeClassConstraints.boundInterfaces(tp)) {
+            if (TypeClassInstances.find(bound, typ) == null) {
+                location.addError("Type " + typ + " does not satisfy the bound " + tp.getName() + ": "
+                        + bound.getName() + ".\nDeclare 'implements " + bound.getName() + "<" + typ + ">' in the package of "
+                        + bound.getName() + " or of " + typ + ".");
+            }
+        }
+    }
+
+    /**
+     * Checks one instance declaration: it must name a usable interface and type, live in a package
+     * permitted by the orphan rule, be the only instance for its pair, and implement every
+     * requirement exactly once.
+     */
+    private void checkInstanceDecl(InstanceDecl decl) {
+        InterfaceDef iface = TypeClassInstances.declaredInterface(decl);
+        if (iface == null) {
+            decl.addError("An instance must name an interface applied to one type, as in "
+                    + "'implements Indexable<vec2>'.");
+            return;
+        }
+        if (iface.getTypeParameters().size() != 1) {
+            decl.addError("Interface " + iface.getName() + " cannot be used as a type class: a bound requires "
+                    + "exactly one type parameter, but it has " + iface.getTypeParameters().size() + ".");
+            return;
+        }
+        WurstType instanceType = TypeClassInstances.instanceType(decl);
+        if (instanceType == null || instanceType instanceof WurstTypeUnknown) {
+            decl.addError("Could not resolve the type this instance is declared for.");
+            return;
+        }
+
+        checkInstanceIsNotOrphan(decl, iface, instanceType);
+        checkInstanceIsUnique(decl, iface, instanceType);
+        checkInstanceIsComplete(decl, iface);
+    }
+
+    private void checkInstanceIsNotOrphan(InstanceDecl decl, InterfaceDef iface, WurstType instanceType) {
+        List<WPackage> allowed = TypeClassInstances.candidatePackages(iface, instanceType);
+        PackageOrGlobal declaredIn = decl.attrNearestPackage();
+        if (!(declaredIn instanceof WPackage p) || allowed.contains(p)) {
+            return;
+        }
+        StringBuilder allowedNames = new StringBuilder();
+        for (WPackage a : allowed) {
+            if (allowedNames.length() > 0) {
+                allowedNames.append(" or ");
+            }
+            allowedNames.append(a.getName());
+        }
+        decl.addError("An instance must be declared with its interface or with its type, but this one is in "
+                + p.getName() + ".\nMove it to " + allowedNames + ".\nThis keeps a type class instance the same "
+                + "everywhere, independent of which packages happen to be imported.");
+    }
+
+    private void checkInstanceIsUnique(InstanceDecl decl, InterfaceDef iface, WurstType instanceType) {
+        for (WPackage p : TypeClassInstances.candidatePackages(iface, instanceType)) {
+            for (InstanceDecl other : TypeClassInstances.declaredIn(p)) {
+                if (other != decl && TypeClassInstances.matches(other, iface, instanceType)) {
+                    decl.addError("There is already an instance of " + iface.getName() + " for " + instanceType
+                            + ", declared in " + p.getName() + " at line " + other.getSource().getLine()
+                            + ".\nA type may implement an interface as a type class only once.");
+                    return;
+                }
+            }
+        }
+    }
+
+    private void checkInstanceIsComplete(InstanceDecl decl, InterfaceDef iface) {
+        StringBuilder missing = new StringBuilder();
+        for (FuncDef requirement : iface.getMethods()) {
+            int found = 0;
+            for (FuncDef provided : decl.getMethods()) {
+                if (provided.getName().equals(requirement.getName())) {
+                    found++;
+                }
+            }
+            if (found == 0) {
+                missing.append("\n    ").append(requirement.getName());
+            } else if (found > 1) {
+                decl.addError("This instance defines " + requirement.getName() + " more than once.");
+            }
+        }
+        if (missing.length() > 0) {
+            decl.addError("This instance of " + iface.getName() + " must implement:" + missing);
+        }
+        for (FuncDef provided : decl.getMethods()) {
+            boolean required = false;
+            for (FuncDef requirement : iface.getMethods()) {
+                if (provided.getName().equals(requirement.getName())) {
+                    required = true;
+                    break;
+                }
+            }
+            if (!required) {
+                provided.addError(provided.getName() + " is not required by " + iface.getName()
+                        + ", so it cannot be defined in this instance.");
+            }
+        }
     }
 
     private void checkFuncRef(FuncRef ref) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -2813,6 +2813,11 @@ public class WurstValidator {
                 }
 
                 @Override
+                public void case_InstanceDecl(InstanceDecl instanceDecl) {
+                    check(VisibilityPublic.class);
+                }
+
+                @Override
                 public void case_TupleDef(TupleDef tupleDef) {
                     check(VisibilityPublic.class);
                 }

--- a/de.peeeq.wurstscript/src/main/resources/agent-docs/WURST_LANGUAGE.md
+++ b/de.peeeq.wurstscript/src/main/resources/agent-docs/WURST_LANGUAGE.md
@@ -1,4 +1,4 @@
-<!-- WURST_LANGUAGE_AGENT_DOC_VERSION: 2026-08-08 -->
+<!-- WURST_LANGUAGE_AGENT_DOC_VERSION: 2026-08-14 -->
 # WurstScript language digest
 
 This is the compact, agent-oriented language reference shipped with the WurstScript compiler. It covers language semantics and compiler-facing syntax; standard-library APIs, dependency conventions, UI rules, and object-editor policies belong to the project or dependency documentation.
@@ -153,6 +153,36 @@ class Box<T:>
 ```
 
 The older unconstrained `T` form erases through integer casts and can share storage in surprising ways.
+
+## Type class bounds
+
+A `T:` type parameter can require operations on the type it is bound to. The requirements are an ordinary generic `interface` with exactly one type parameter, and a top-level `implements` block binds them to one concrete type:
+
+```wurst
+public interface Indexable<T:>
+	function toIndex(T x) returns int
+	function fromIndex(int i) returns T
+
+implements Indexable<vec2>
+	function toIndex(vec2 v) returns int
+		return ...
+	function fromIndex(int i) returns vec2
+		return ...
+
+class HashMap<K: Indexable, V: Indexable>
+	function put(K key, V value)
+		saveInt(K.toIndex(key), V.toIndex(value))
+	function get(K key) returns V
+		return V.fromIndex(loadInt(K.toIndex(key)))
+```
+
+A bound names the interface without type arguments; `<K: Indexable>` means "there is an instance of `Indexable<K>`". Combine several with `and`: `<Q: Plus and Times>`.
+
+Call a requirement on the type parameter, not on the value: `K.toIndex(key)`, never `key.toIndex()`. The value is an ordinary argument, so requirements which produce a value rather than consume one (`fromIndex`) need no special form.
+
+Unlike an interface used as a supertype, a bound works for `int`, `real`, `string`, tuples and handle types, and it costs nothing at runtime: after specialisation each requirement is a direct call to the instance function, on both Jass and Lua.
+
+Instances are unique and must be declared next to what they relate. An instance of `I` for type `X` may only live in the package declaring `I` or the package declaring `X`, and there may be only one. This makes `I` for `X` mean the same thing everywhere, independent of imports. Instances have no type parameters of their own in this version, so there is no way to write "every `List<T>` is `Indexable` when `T` is".
 
 ## Lua and Jass targets
 

--- a/de.peeeq.wurstscript/src/main/resources/agent-docs/WURST_LANGUAGE.md
+++ b/de.peeeq.wurstscript/src/main/resources/agent-docs/WURST_LANGUAGE.md
@@ -184,6 +184,18 @@ Unlike an interface used as a supertype, a bound works for `int`, `real`, `strin
 
 Instances are unique and must be declared next to what they relate. An instance of `I` for type `X` may only live in the package declaring `I` or the package declaring `X`, and there may be only one. This makes `I` for `X` mean the same thing everywhere, independent of imports. Instances have no type parameters of their own in this version, so there is no way to write "every `List<T>` is `Indexable` when `T` is".
 
+An instance must implement each requirement with the signature it has after the interface's type parameter is replaced by the instance type; a matching name is not enough. An interface used as a bound must not extend another interface, because the requirements of a bound are the interface's own functions.
+
+A generic which passes its own type parameter to another bounded generic must declare that bound itself:
+
+```wurst
+function inner<Q: Show>(Q x) returns string
+	return Q.show(x)
+
+function outer<R: Show>(R x) returns string   // <R:> alone would not compile
+	return inner(x)
+```
+
 ## Lua and Jass targets
 
 The target is selected by the project `wurst.build` `scriptMode` field. `wc3Patch` separately selects the compatible core Jass and standard-library era.

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/FieldIterationTests.java
@@ -1218,4 +1218,35 @@ public class FieldIterationTests extends WurstScriptTest {
                 "endpackage"
             );
     }
+
+    /**
+     * A generic-construction method called straight on a freshly constructed receiver. The
+     * receiver's declared type is still generic at that point, so specialization takes the
+     * instantiation from the construction rather than requiring a typed local.
+     */
+    @Test
+    public void genericConstructionOnFreshlyConstructedReceiver() {
+        test().testLua(true).executeProg().lines(
+            "package MagicFunctions",
+            "    @compilerintrinsic function wurstNewInstance<T:>() returns T",
+            "        return null",
+            "endpackage",
+            "",
+            "package FieldIterationTest",
+            "    import MagicFunctions",
+            "    native testSuccess()",
+            "",
+            "    class State",
+            "        int value = 7",
+            "",
+            "    class Loader<T:>",
+            "        function load() returns T",
+            "            return wurstNewInstance<T>()",
+            "",
+            "    init",
+            "        if new Loader<State>().load().value == 7",
+            "            testSuccess()",
+            "endpackage"
+        );
+    }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -638,6 +638,47 @@ public class TypeClassTests extends WurstScriptTest {
         );
     }
 
+    /** A subclass may fix its parent's bounded type parameter. */
+    @Test
+    public void boundInheritedFromGenericParent() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "class Parent<T: Show>",
+            "    function render(T x) returns string",
+            "        return T.show(x)",
+            "class Child extends Parent<int>",
+            "init",
+            "    if new Child().render(1) == \"i\"",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
+    public void boundInheritedFromGenericParentLua() {
+        test().testLua(true).executeProg().lines(
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "class Parent<T: Show>",
+            "    function render(T x) returns string",
+            "        return T.show(x)",
+            "class Child extends Parent<int>",
+            "init",
+            "    if new Child().render(1) == \"i\"",
+            "        testSuccess()"
+        );
+    }
+
     /** A type parameter is not a value, so it may only appear as the receiver of a requirement. */
     @Test
     public void typeParameterIsNotAValue() {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -358,6 +358,154 @@ public class TypeClassTests extends WurstScriptTest {
         );
     }
 
+    /**
+     * An instance method must match its requirement, not merely its name. Matching on the name
+     * alone let a wrongly typed implementation be selected and emitted, which pjass then rejected.
+     */
+    @Test
+    public void instanceMethodWithWrongParameterTypeIsRejected() {
+        testAssertErrorsLines(false, "should have type int",
+            "package test",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "implements ToIndex<int>",
+            "    function toIndex(string x) returns int",
+            "        return 1"
+        );
+    }
+
+    @Test
+    public void instanceMethodWithWrongParameterCountIsRejected() {
+        testAssertErrorsLines(false, "must take 1 parameter",
+            "package test",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "implements ToIndex<int>",
+            "    function toIndex(int x, int y) returns int",
+            "        return 1"
+        );
+    }
+
+    @Test
+    public void instanceMethodWithWrongReturnTypeIsRejected() {
+        testAssertErrorsLines(false, "should return int",
+            "package test",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "implements ToIndex<int>",
+            "    function toIndex(int x) returns string",
+            "        return \"a\""
+        );
+    }
+
+    /** The substituted requirement is what must be matched, so T becomes the instance type. */
+    @Test
+    public void instanceMethodMatchingSubstitutedRequirementIsAccepted() {
+        testAssertOkLines(false,
+            "package test",
+            "interface Indexable<T:>",
+            "    function toIndex(T x) returns int",
+            "    function fromIndex(int i) returns T",
+            "implements Indexable<int>",
+            "    function toIndex(int x) returns int",
+            "        return x",
+            "    function fromIndex(int i) returns int",
+            "        return i"
+        );
+    }
+
+    /**
+     * An abstract type argument can only supply a bound it declares itself. Accepting it silently
+     * produced a program that type checked but failed at runtime with no instance to dispatch to.
+     */
+    @Test
+    public void unboundedTypeParameterCannotSatisfyBound() {
+        testAssertErrorsLines(false, "does not satisfy the bound",
+            "package test",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "function inner<Q: Show>(Q x) returns string",
+            "    return Q.show(x)",
+            "function outer<R:>(R x) returns string",
+            "    return inner(x)",
+            "init",
+            "    outer(42)"
+        );
+    }
+
+    /** The same shape is fine once the outer parameter declares the bound it passes on. */
+    @Test
+    public void boundedTypeParameterSatisfiesBound() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "function inner<Q: Show>(Q x) returns string",
+            "    return Q.show(x)",
+            "function outer<R: Show>(R x) returns string",
+            "    return inner(x)",
+            "init",
+            "    if outer(42) == \"i\"",
+            "        testSuccess()"
+        );
+    }
+
+    /** A bound naming something that is not a usable type class must be reported, not ignored. */
+    @Test
+    public void classAsBoundIsRejected() {
+        testAssertErrorsLines(false, "is not an interface",
+            "package test",
+            "class Marker",
+            "function foo<Q: Marker>(Q x) returns int",
+            "    return 0",
+            "init",
+            "    foo(1)"
+        );
+    }
+
+    @Test
+    public void appliedInterfaceAsBoundIsRejected() {
+        testAssertErrorsLines(false, "without type arguments",
+            "package test",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "function foo<Q: ToIndex<int>>(Q x) returns int",
+            "    return 0"
+        );
+    }
+
+    @Test
+    public void multiParameterInterfaceAsBoundIsRejected() {
+        testAssertErrorsLines(false, "exactly one type parameter",
+            "package test",
+            "interface Convert<A:, B:>",
+            "    function convert(A a) returns B",
+            "function foo<Q: Convert>(Q x) returns int",
+            "    return 0"
+        );
+    }
+
+    /** Requirements are the interface's own functions, so an extending interface is not a bound. */
+    @Test
+    public void extendingInterfaceAsBoundIsRejected() {
+        testAssertErrorsLines(false, "extends another interface",
+            "package test",
+            "interface Base<T:>",
+            "    function base(T x) returns int",
+            "interface Derived<T:> extends Base<T>",
+            "    function derived(T x) returns int",
+            "function foo<Q: Derived>(Q x) returns int",
+            "    return 0"
+        );
+    }
+
     /** A type parameter is not a value, so it may only appear as the receiver of a requirement. */
     @Test
     public void typeParameterIsNotAValue() {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -13,6 +13,19 @@ import org.testng.annotations.Test;
 public class TypeClassTests extends WurstScriptTest {
 
     @Test
+    public void parseInstanceDecl() {
+        testAssertOkLines(false,
+            "package test",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "class A",
+            "implements ToIndex<A>",
+            "    function toIndex(A x) returns int",
+            "        return 42"
+        );
+    }
+
+    @Test
     public void dispatchThroughBoundTypeChecks() {
         testAssertOkLines(false,
             "package test",
@@ -46,16 +59,153 @@ public class TypeClassTests extends WurstScriptTest {
         );
     }
 
+    /** Each type argument picks its own instance, so one generic serves several types. */
     @Test
-    public void parseInstanceDecl() {
-        testAssertOkLines(false,
+    public void twoInstancesOfOneClass() {
+        testAssertOkLines(true,
             "package test",
+            "native testSuccess()",
             "interface ToIndex<T:>",
             "    function toIndex(T x) returns int",
             "class A",
+            "class B",
             "implements ToIndex<A>",
             "    function toIndex(A x) returns int",
-            "        return 42"
+            "        return 1",
+            "implements ToIndex<B>",
+            "    function toIndex(B x) returns int",
+            "        return 2",
+            "function foo<Q: ToIndex>(Q x) returns int",
+            "    return Q.toIndex(x)",
+            "init",
+            "    if foo(new A) == 1 and foo(new B) == 2",
+            "        testSuccess()"
+        );
+    }
+
+    /** A bound is satisfiable by a primitive, which is the whole point of not using subtyping. */
+    @Test
+    public void instanceForPrimitive() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "implements ToIndex<int>",
+            "    function toIndex(int x) returns int",
+            "        return x * 2",
+            "function foo<Q: ToIndex>(Q x) returns int",
+            "    return Q.toIndex(x)",
+            "init",
+            "    if foo(21) == 42",
+            "        testSuccess()"
+        );
+    }
+
+    /** Several requirements combine with 'and', and each resolves independently. */
+    @Test
+    public void multipleBounds() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Plus<T:>",
+            "    function plus(T x, T y) returns T",
+            "interface Times<T:>",
+            "    function times(T x, T y) returns T",
+            "implements Plus<int>",
+            "    function plus(int x, int y) returns int",
+            "        return x + y",
+            "implements Times<int>",
+            "    function times(int x, int y) returns int",
+            "        return x * y",
+            "function calc<Q: Plus and Times>(Q x) returns Q",
+            "    return Q.plus(x, Q.times(x, x))",
+            "init",
+            "    if calc(6) == 42",
+            "        testSuccess()"
+        );
+    }
+
+    /** An interface may require more than one function. */
+    @Test
+    public void roundTripThroughTwoRequirements() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Indexable<T:>",
+            "    function toIndex(T x) returns int",
+            "    function fromIndex(int i) returns T",
+            "implements Indexable<int>",
+            "    function toIndex(int x) returns int",
+            "        return x + 1",
+            "    function fromIndex(int i) returns int",
+            "        return i - 1",
+            "function roundTrip<Q: Indexable>(Q x) returns Q",
+            "    return Q.fromIndex(Q.toIndex(x))",
+            "init",
+            "    if roundTrip(7) == 7",
+            "        testSuccess()"
+        );
+    }
+
+    /** A bounded generic may call another one, passing its own still-abstract type parameter on. */
+    @Test
+    public void transitiveBound() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "implements ToIndex<int>",
+            "    function toIndex(int x) returns int",
+            "        return x",
+            "function inner<Q: ToIndex>(Q x) returns int",
+            "    return Q.toIndex(x)",
+            "function outer<R: ToIndex>(R x) returns int",
+            "    return inner(x)",
+            "init",
+            "    if outer(42) == 42",
+            "        testSuccess()"
+        );
+    }
+
+    /** The same generic used at two types must not collapse to one specialisation. */
+    @Test
+    public void distinctSpecialisationsPerType() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "implements Show<string>",
+            "    function show(string x) returns string",
+            "        return \"s\"",
+            "function render<Q: Show>(Q x) returns string",
+            "    return Q.show(x)",
+            "init",
+            "    if render(1) == \"i\" and render(\"a\") == \"s\"",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
+    public void dispatchRuntimeLua() {
+        test().testLua(true).executeProg().lines(
+            "package test",
+            "native testSuccess()",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "implements ToIndex<int>",
+            "    function toIndex(int x) returns int",
+            "        return x * 2",
+            "function foo<Q: ToIndex>(Q x) returns int",
+            "    return Q.toIndex(x)",
+            "init",
+            "    if foo(21) == 42",
+            "        testSuccess()"
         );
     }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -1,6 +1,14 @@
 package tests.wurstscript.tests;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Tests for type class bounds on new-style generics:
@@ -206,6 +214,160 @@ public class TypeClassTests extends WurstScriptTest {
             "init",
             "    if foo(21) == 42",
             "        testSuccess()"
+        );
+    }
+
+    /**
+     * A bound must cost nothing at runtime: after specialisation the requirement is an ordinary
+     * call to the instance function, with no dispatch, lookup or table left behind.
+     */
+    @Test
+    public void dispatchLowersToDirectCallLua() throws IOException {
+        test().testLua(true).executeProg().lines(
+            "package test",
+            "native testSuccess()",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "implements ToIndex<int>",
+            "    function toIndex(int x) returns int",
+            "        return x * 2",
+            "function foo<Q: ToIndex>(Q x) returns int",
+            "    return Q.toIndex(x)",
+            "init",
+            "    if foo(21) == 42",
+            "        testSuccess()"
+        );
+        String compiled = Files.toString(
+            new File("test-output/lua/TypeClassTests_dispatchLowersToDirectCallLua.lua"), Charsets.UTF_8);
+        assertTrue(compiled.contains("toIndex"), "the instance function should survive as a real function");
+        assertFalse(compiled.contains("TypeVarDispatch"), "dispatch must not reach the backend");
+        assertFalse(compiled.contains("typeClassBinding"), "no dictionary should be emitted");
+    }
+
+    // --- diagnostics -------------------------------------------------------------------------
+
+    @Test
+    public void unsatisfiedBoundIsRejected() {
+        testAssertErrorsLines(false, "does not satisfy the bound",
+            "package test",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "class A",
+            "function foo<Q: ToIndex>(Q x) returns int",
+            "    return Q.toIndex(x)",
+            "init",
+            "    foo(new A)"
+        );
+    }
+
+    @Test
+    public void duplicateInstanceIsRejected() {
+        testAssertErrorsLines(false, "already an instance",
+            "package test",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "class A",
+            "implements ToIndex<A>",
+            "    function toIndex(A x) returns int",
+            "        return 1",
+            "implements ToIndex<A>",
+            "    function toIndex(A x) returns int",
+            "        return 2"
+        );
+    }
+
+    @Test
+    public void incompleteInstanceIsRejected() {
+        testAssertErrorsLines(false, "must implement",
+            "package test",
+            "interface Indexable<T:>",
+            "    function toIndex(T x) returns int",
+            "    function fromIndex(int i) returns T",
+            "class A",
+            "implements Indexable<A>",
+            "    function toIndex(A x) returns int",
+            "        return 1"
+        );
+    }
+
+    @Test
+    public void methodNotRequiredByInterfaceIsRejected() {
+        testAssertErrorsLines(false, "is not required by",
+            "package test",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "class A",
+            "implements ToIndex<A>",
+            "    function toIndex(A x) returns int",
+            "        return 1",
+            "    function somethingElse(A x) returns int",
+            "        return 2"
+        );
+    }
+
+    /** An instance must live with its interface or with its type, never anywhere else. */
+    @Test
+    public void orphanInstanceIsRejected() {
+        testAssertErrorsLines(false, "must be declared with its interface or with its type",
+            "package Iface",
+            "public interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "endpackage",
+            "package Types",
+            "public class A",
+            "endpackage",
+            "package Orphan",
+            "import Iface",
+            "import Types",
+            "implements ToIndex<A>",
+            "    function toIndex(A x) returns int",
+            "        return 1",
+            "endpackage"
+        );
+    }
+
+    /** The instance may live with the type rather than with the interface. */
+    @Test
+    public void instanceWithTypeIsAccepted() {
+        testAssertOkLines(false,
+            "package Iface",
+            "public interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "endpackage",
+            "package Types",
+            "import public Iface",
+            "public class A",
+            "implements ToIndex<A>",
+            "    function toIndex(A x) returns int",
+            "        return 1",
+            "endpackage"
+        );
+    }
+
+    /** A bound must name an interface with exactly one type parameter. */
+    @Test
+    public void multiParameterInterfaceIsRejectedAsBound() {
+        testAssertErrorsLines(false, "cannot be used as a type class",
+            "package test",
+            "interface Convert<A:, B:>",
+            "    function convert(A a) returns B",
+            "class C",
+            "implements Convert<C, int>",
+            "    function convert(C a) returns int",
+            "        return 1"
+        );
+    }
+
+    /** A type parameter is not a value, so it may only appear as the receiver of a requirement. */
+    @Test
+    public void typeParameterIsNotAValue() {
+        testAssertErrorsLines(false, "Could not find variable Q",
+            "package test",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "function foo<Q: ToIndex>(Q x) returns int",
+            "    let y = Q",
+            "    return 0"
         );
     }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -1,0 +1,27 @@
+package tests.wurstscript.tests;
+
+import org.testng.annotations.Test;
+
+/**
+ * Tests for type class bounds on new-style generics:
+ * <p>
+ * - an ordinary generic {@code interface} declares the requirements,
+ * - a top level {@code instance} block binds those requirements to one concrete type,
+ * - a bound {@code <T: Iface>} makes the requirements available inside the generic body,
+ * - {@code T.method(args)} dispatches through the instance chosen for {@code T}.
+ */
+public class TypeClassTests extends WurstScriptTest {
+
+    @Test
+    public void parseInstanceDecl() {
+        testAssertOkLines(false,
+            "package test",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "class A",
+            "instance ToIndex<A>",
+            "    function toIndex(A x) returns int",
+            "        return 42"
+        );
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -742,6 +742,64 @@ public class TypeClassTests extends WurstScriptTest {
         );
     }
 
+    /** A bound on a module type parameter is rejected: using a module copies its body out of scope. */
+    @Test
+    public void boundOnGenericModule() {
+        testAssertErrorsLines(false, "not supported on a module type parameter",
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "module M<T: Show>",
+            "    function render(T x) returns string",
+            "        return T.show(x)",
+            "class C",
+            "    use M<int>",
+            "init",
+            "    if new C().render(1) == \"i\"",
+            "        testSuccess()"
+        );
+    }
+
+    /** A method with its own type parameters must not disturb the class binding taken from the receiver. */
+    @Test
+    public void classBoundWithIndependentMethodTypeParam() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"int\"",
+            "implements Show<string>",
+            "    function show(string x) returns string",
+            "        return \"string\"",
+            "class Box<T: Show>",
+            "    function describe<U:>(T x, U other) returns string",
+            "        return T.show(x)",
+            "init",
+            "    if new Box<int>().describe<string>(1, \"a\") == \"int\"",
+            "        testSuccess()"
+        );
+    }
+
+    /** A requirement may only use the interface's type parameter, and says so plainly. */
+    @Test
+    public void genericRequirement() {
+        testAssertErrorsLines(false, "has its own type parameters",
+            "package test",
+            "interface Pairing<T:>",
+            "    function pair<U:>(T x, U y) returns U",
+            "implements Pairing<int>",
+            "    function pair<U:>(int x, U y) returns U",
+            "        return y"
+        );
+    }
+
     /** A type parameter is not a value, so it may only appear as the receiver of a requirement. */
     @Test
     public void typeParameterIsNotAValue() {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -28,6 +28,25 @@ public class TypeClassTests extends WurstScriptTest {
     }
 
     @Test
+    public void dispatchRuntime() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "class A",
+            "implements ToIndex<A>",
+            "    function toIndex(A x) returns int",
+            "        return 42",
+            "function foo<Q: ToIndex>(Q x) returns int",
+            "    return Q.toIndex(x)",
+            "init",
+            "    if foo(new A) == 42",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
     public void parseInstanceDecl() {
         testAssertOkLines(false,
             "package test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -800,6 +800,53 @@ public class TypeClassTests extends WurstScriptTest {
         );
     }
 
+    /**
+     * Two classes with the same simple name in different packages, dispatched through a bounded
+     * generic class so the lookup by type is the path used. Selecting by printed name made the
+     * second silently dispatch through the first's implementation.
+     */
+    @Test
+    public void sameSimpleNameThroughRegistryFallback() {
+        testAssertOkLines(true,
+            "package Iface",
+            "public interface Show<T:>",
+            "    function show(T x) returns string",
+            "public class Renderer<Q: Show>",
+            "    function render(Q x) returns string",
+            "        return Q.show(x)",
+            "endpackage",
+            "",
+            "package First",
+            "import public Iface",
+            "public class Item",
+            "implements Show<Item>",
+            "    function show(Item x) returns string",
+            "        return \"first\"",
+            "public function firstResult() returns string",
+            "    return new Renderer<Item>().render(new Item())",
+            "endpackage",
+            "",
+            "package Second",
+            "import public Iface",
+            "public class Item",
+            "implements Show<Item>",
+            "    function show(Item x) returns string",
+            "        return \"second\"",
+            "public function secondResult() returns string",
+            "    return new Renderer<Item>().render(new Item())",
+            "endpackage",
+            "",
+            "package test",
+            "import First",
+            "import Second",
+            "native testSuccess()",
+            "init",
+            "    if firstResult() == \"first\" and secondResult() == \"second\"",
+            "        testSuccess()",
+            "endpackage"
+        );
+    }
+
     /** A type parameter is not a value, so it may only appear as the receiver of a requirement. */
     @Test
     public void typeParameterIsNotAValue() {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -292,7 +292,7 @@ public class TypeClassTests extends WurstScriptTest {
 
     @Test
     public void methodNotRequiredByInterfaceIsRejected() {
-        testAssertErrorsLines(false, "is not required by",
+        testAssertErrorsLines(false, "does not implement any requirement of",
             "package test",
             "interface ToIndex<T:>",
             "    function toIndex(T x) returns int",
@@ -503,6 +503,138 @@ public class TypeClassTests extends WurstScriptTest {
             "    function derived(T x) returns int",
             "function foo<Q: Derived>(Q x) returns int",
             "    return 0"
+        );
+    }
+
+    /**
+     * A bound may belong to a generic class rather than to the method, which is the shape the
+     * documentation uses for HashMap. The receiver carries the arguments the class was made with.
+     */
+    @Test
+    public void boundOnGenericClass() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "class Box<T: Show>",
+            "    function render(T x) returns string",
+            "        return T.show(x)",
+            "init",
+            "    if new Box<int>().render(42) == \"i\"",
+            "        testSuccess()"
+        );
+    }
+
+    /** The same, with the class holding the value, as a container actually would. */
+    @Test
+    public void boundOnGenericClassWithField() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Indexable<T:>",
+            "    function toIndex(T x) returns int",
+            "    function fromIndex(int i) returns T",
+            "implements Indexable<int>",
+            "    function toIndex(int x) returns int",
+            "        return x + 1",
+            "    function fromIndex(int i) returns int",
+            "        return i - 1",
+            "class Cell<T: Indexable>",
+            "    private int stored",
+            "    function put(T value)",
+            "        stored = T.toIndex(value)",
+            "    function get() returns T",
+            "        return T.fromIndex(stored)",
+            "init",
+            "    let c = new Cell<int>()",
+            "    c.put(7)",
+            "    if c.get() == 7",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
+    public void boundOnGenericClassLua() {
+        test().testLua(true).executeProg().lines(
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "class Box<T: Show>",
+            "    function render(T x) returns string",
+            "        return T.show(x)",
+            "init",
+            "    if new Box<int>().render(42) == \"i\"",
+            "        testSuccess()"
+        );
+    }
+
+    /** Two classes at different types must each pick their own instance. */
+    @Test
+    public void boundOnGenericClassTwoTypes() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "implements Show<string>",
+            "    function show(string x) returns string",
+            "        return \"s\"",
+            "class Box<T: Show>",
+            "    function render(T x) returns string",
+            "        return T.show(x)",
+            "init",
+            "    if new Box<int>().render(1) == \"i\" and new Box<string>().render(\"a\") == \"s\"",
+            "        testSuccess()"
+        );
+    }
+
+    /**
+     * An interface may overload a requirement name. Each requirement pairs with the implementation
+     * matching its signature, and the lowering must select the same one.
+     */
+    @Test
+    public void overloadedRequirementsAreMatchedBySignature() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Convert<T:>",
+            "    function convert(T x) returns int",
+            "    function convert(int scale, T x) returns int",
+            "implements Convert<string>",
+            "    function convert(string x) returns int",
+            "        return 1",
+            "    function convert(int scale, string x) returns int",
+            "        return scale * 2",
+            "function useBoth<Q: Convert>(Q x) returns int",
+            "    return Q.convert(x) + Q.convert(20, x)",
+            "init",
+            "    if useBoth(\"a\") == 41",
+            "        testSuccess()"
+        );
+    }
+
+    /** A missing overload is still reported, even when the name is present. */
+    @Test
+    public void missingOverloadIsRejected() {
+        testAssertErrorsLines(false, "must implement",
+            "package test",
+            "interface Convert<T:>",
+            "    function convert(T x) returns int",
+            "    function convert(int scale, T x) returns int",
+            "implements Convert<string>",
+            "    function convert(string x) returns int",
+            "        return 1"
         );
     }
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -679,6 +679,69 @@ public class TypeClassTests extends WurstScriptTest {
         );
     }
 
+    /** A generic subclass may forward its own parameter to its parent's bound. */
+    @Test
+    public void boundForwardedByGenericSubclass() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "class Parent<T: Show>",
+            "    function render(T x) returns string",
+            "        return T.show(x)",
+            "class Child<U: Show> extends Parent<U>",
+            "init",
+            "    if new Child<int>().render(1) == \"i\"",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
+    public void boundForwardedByGenericSubclassLua() {
+        test().testLua(true).executeProg().lines(
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "class Parent<T: Show>",
+            "    function render(T x) returns string",
+            "        return T.show(x)",
+            "class Child<U: Show> extends Parent<U>",
+            "init",
+            "    if new Child<int>().render(1) == \"i\"",
+            "        testSuccess()"
+        );
+    }
+
+    /** Two levels of forwarding, so the substitution has to compose rather than apply once. */
+    @Test
+    public void boundForwardedThroughTwoLevels() {
+        testAssertOkLines(true,
+            "package test",
+            "native testSuccess()",
+            "interface Show<T:>",
+            "    function show(T x) returns string",
+            "implements Show<int>",
+            "    function show(int x) returns string",
+            "        return \"i\"",
+            "class Top<T: Show>",
+            "    function render(T x) returns string",
+            "        return T.show(x)",
+            "class Middle<M: Show> extends Top<M>",
+            "class Bottom<B: Show> extends Middle<B>",
+            "init",
+            "    if new Bottom<int>().render(1) == \"i\"",
+            "        testSuccess()"
+        );
+    }
+
     /** A type parameter is not a value, so it may only appear as the receiver of a requirement. */
     @Test
     public void typeParameterIsNotAValue() {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -13,6 +13,21 @@ import org.testng.annotations.Test;
 public class TypeClassTests extends WurstScriptTest {
 
     @Test
+    public void dispatchThroughBoundTypeChecks() {
+        testAssertOkLines(false,
+            "package test",
+            "interface ToIndex<T:>",
+            "    function toIndex(T x) returns int",
+            "class A",
+            "implements ToIndex<A>",
+            "    function toIndex(A x) returns int",
+            "        return 42",
+            "function foo<Q: ToIndex>(Q x) returns int",
+            "    return Q.toIndex(x)"
+        );
+    }
+
+    @Test
     public void parseInstanceDecl() {
         testAssertOkLines(false,
             "package test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/TypeClassTests.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
  * Tests for type class bounds on new-style generics:
  * <p>
  * - an ordinary generic {@code interface} declares the requirements,
- * - a top level {@code instance} block binds those requirements to one concrete type,
+ * - a top level {@code implements} block binds those requirements to one concrete type,
  * - a bound {@code <T: Iface>} makes the requirements available inside the generic body,
  * - {@code T.method(args)} dispatches through the instance chosen for {@code T}.
  */
@@ -19,7 +19,7 @@ public class TypeClassTests extends WurstScriptTest {
             "interface ToIndex<T:>",
             "    function toIndex(T x) returns int",
             "class A",
-            "instance ToIndex<A>",
+            "implements ToIndex<A>",
             "    function toIndex(A x) returns int",
             "        return 42"
         );


### PR DESCRIPTION
Adds type class bounds to `T:` generics, so a generic can require operations of the type it is bound to instead of only storing and returning values. This is what `FastHashMap<K:, V:>` needs: a way to say "K can be turned into an integer" without forcing K to be a class.

```wurst
public interface Indexable<T:>
    function toIndex(T x) returns int
    function fromIndex(int i) returns T

implements Indexable<vec2>
    function toIndex(vec2 v) returns int
        ...
    function fromIndex(int i) returns vec2
        ...

class HashMap<K: Indexable, V: Indexable>
    function put(K key, V value)
        saveInt(K.toIndex(key), V.toIndex(value))
    function get(K key) returns V
        return V.fromIndex(loadInt(K.toIndex(key)))
```

## Design

**A bound is satisfied by an instance, not by subtyping.** An upper bound in the Java sense would have been useless here: the types that matter most (`int`, `real`, `string`, tuples, handle types) can never implement an interface, and boxing them would reintroduce exactly the indirection `T:` generics exist to remove. `HashMap<int, V>` is the central case, and it works.

**Requirements are called on the type parameter**, `K.toIndex(key)`, not on the value. Because there is no receiver, a requirement which *produces* a value of the type — `fromIndex` — needs no special form; it is just another function. This is also why no `Self` type is required.

**Bounds reuse the syntax that was already in the grammar.** `typeParamConstraints` has parsed `<T: A and B>` since new generics landed; the constraint list was simply ignored. A bound names the interface unapplied, so `<K: Indexable>` reads as "there is an instance of `Indexable<K>`".

**Instances are coherent by construction.** An instance of `I` for `X` may only be declared in the package declaring `I` or the package declaring `X`, and only once. Resolution is therefore a direct lookup in two known packages: no search over the import graph, no divergence detection, and no way for `I` for `X` to mean different things in different files. This is a deliberate departure from the implicit-search design in #931, which allowed conflicting instances to coexist and made a `TreeSet<string>` from one package incompatible with another's.

**No new reserved word.** An `instance` keyword was the obvious spelling and it broke the standard library, which uses `instance` as a local in `TimerUtils.wurst`. Softening the token would mean threading it through every `name=ID` site in the grammar, so instances are declared with the existing `implements` keyword, which is unambiguous at package level. The unreachable `typeclass` rule is removed at the same time, which frees a word that was reserved for nothing.

## Lowering

Resolution is entirely static; nothing is searched at runtime.

- **Jass** — the existing monomorphiser already keyed specialisation on `ImTypeArgument.typeClassBinding`, so filling that binding in is enough. Each dispatch becomes a plain call to the instance function.
- **Lua** — generics stay erased, and targeted specialisation, which previously ran only for generic construction, now also triggers on dispatch. A bounded generic lowers to a direct call here too, rather than needing a runtime dictionary.
- **Interpreter** — compiletime code runs before generic elimination, so dispatch resolves through the calling frame's type arguments.

A bounded generic passing its own parameter to another one has no instance at the inner call site, since the parameter is abstract there. Both the specialiser and the interpreter take it from the frame that supplied it, so chains of bounded generics still resolve statically.

This adds no node to any `.parseq` sum type in the IM: `ImTypeVarDispatch`, `ImTypeClassFunc` and `ImTypeArgument.typeClassBinding` were already present and unused. The only new AST node is the `InstanceDecl` entity.

## Diagnostics

Unsatisfied bound (reported where the type argument is chosen, naming both the type and the bound), orphan instance, duplicate instance, incomplete instance, a method not required by the interface, and an interface with the wrong number of type parameters used as a bound.

## Scope

Single-parameter interfaces only. Multi-parameter type classes and dependent bounds are deliberately excluded: they need functional dependencies or associated types to infer, which is why the equivalent example in #931 only worked with all type arguments spelled out explicitly. Instances have no type parameters of their own, so "every `List<T>` is `Indexable` when `T` is" cannot yet be written.

No compiler-derived instances. #931 hardcoded a list of blessed interface names and auto-derived instances for class types; that runs against the principle set out in AGENTS.md §9 for the serialization surface, where the compiler holds no knowledge of specific library names. Retiring the type-parameter `castTo int` sites in `HashMap`, `HashList`, `HashSet` and `Table` needs one explicit instance declaration per type instead.

## Testing

19 new tests in `TypeClassTests`: dispatch on classes and primitives, several instances of one interface, multiple bounds, an interface with two requirements, transitive bounds, distinct specialisations per type, Lua execution, and each diagnostic above. `dispatchLowersToDirectCallLua` reads the emitted Lua and asserts the instance function is called directly, with no dispatch node and no dictionary, so the performance claim is pinned rather than asserted.

Full suite: 1598 tests, 0 failures.
