### PR TITLE
Bump the pinned standard library, and check its string handling

### DIFF
--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/StdLib.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/StdLib.java
@@ -24,7 +24,7 @@ public class StdLib {
     /**
      * version to use for the tests
      */
-    private final static String version = "16729fa07197bdc331dc5e30eb0f91d444eece85";
+    private final static String version = "98b1140803dcb99a4a48cf8f14fc099961ad55f7";
 
     /**
      * flag so that initialization in only done once

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/StdLibStringTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/StdLibStringTests.java
@@ -1,0 +1,60 @@
+package tests.wurstscript.tests;
+
+import org.testng.annotations.Test;
+
+/**
+ * The standard library's own string handling, run against the interpreter.
+ * <p>
+ * {@code String.wurst} enables multibyte support by default and works it out at runtime rather than
+ * being told: it slices a character in half to see how the engine represents a partial slice, and
+ * slices a literal byte by byte to enumerate every continuation byte. All of that rests on a string
+ * being a sequence of bytes, so these check the library reaches the answers it is meant to reach
+ * rather than quietly falling back to its ascii-only path.
+ * <p>
+ * Nothing else runs the library's own tests, so a bump of the pinned version is otherwise only
+ * checked for still compiling.
+ */
+public class StdLibStringTests extends WurstScriptTest {
+
+    /** Two bytes for the character, and the library counts what the game counts. */
+    @Test
+    public void lengthOfAMultibyteStringIsInBytes() {
+        test().withStdLib().executeProg().lines(
+            "package test",
+            "import String",
+            "init",
+            "    if \"ä\".length() == 2 and \"aä\".length() == 3",
+            "        testSuccess()"
+        );
+    }
+
+    /**
+     * The position between the two bytes of a character is not a boundary, and both ends are. This is
+     * the library's detection working end to end: it only answers this way if slicing produced the
+     * partial bytes it expected to find.
+     */
+    @Test
+    public void aPositionInsideACharacterIsNotABoundary() {
+        test().withStdLib().executeProg().lines(
+            "package test",
+            "import String",
+            "init",
+            "    let s = \"ä\"",
+            "    if s.isCharBoundary(0) and s.isCharBoundary(2) and not s.isCharBoundary(1)",
+            "        testSuccess()"
+        );
+    }
+
+    /** Ascii is unaffected: every position in it starts a character. */
+    @Test
+    public void everyPositionInAnAsciiStringIsABoundary() {
+        test().withStdLib().executeProg().lines(
+            "package test",
+            "import String",
+            "init",
+            "    let s = \"abc\"",
+            "    if s.isCharBoundary(0) and s.isCharBoundary(1) and s.isCharBoundary(2)",
+            "        testSuccess()"
+        );
+    }
+}


### PR DESCRIPTION
Moves the pinned standard library from `16729fa` to `98b1140`, twenty-one commits on.

This is the bump that was blocked until the interpreter agreed with the game on byte semantics. The library enables multibyte support by default over this range and works the engine's behaviour out at runtime rather than being told: `String.wurst` cuts a character in half to see how a partial slice is represented, and slices a 64 character literal byte by byte to enumerate every continuation byte. All of that rests on a string being a sequence of bytes.

## Why there are tests attached to a version bump

Nothing in this repository runs the standard library's own test functions, so a bump has only ever been checked for still compiling. That is a weak signal for a change whose whole point is behaviour: the library's multibyte detection is designed to degrade quietly to an ascii-only path when it cannot find what it probes for, so a version where it silently gave up would look exactly like a version where it worked.

`StdLibStringTests` checks the part this bump turns on:

- `lengthOfAMultibyteStringIsInBytes` — `"ä".length()` is 2 and `"aä".length()` is 3, so the library counts what the game counts.
- `aPositionInsideACharacterIsNotABoundary` — both ends of `"ä"` are boundaries and the position between its two bytes is not. This is the detection working end to end: it only answers this way if slicing actually produced the partial bytes the library expects, and it is the assertion that would fail on the silent fallback.
- `everyPositionInAnAsciiStringIsABoundary` — ascii is unaffected.

Worth noting the library reaches the right answer by a different route than it does in game. The engine collapses every half-character slice to one marker string with a constant hash; byte-accurate, a lead byte hashes as itself and misses `PARTIAL_CHAR_HASH`, then falls through to the continuation byte table, is not found there, and is correctly reported as a boundary. Both paths agree on the answer, so `isCharBoundary` is right either way, but `PARTIAL_CHAR_DETECTABLE` is true at compiletime while matching a narrower set of slices than in game.

Full suite green on the new pin.