### PR TITLE
Let the interpreter ask what a node was copied from, and who owns it

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -90,6 +90,9 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
         this.translator = tr;
         this.imProg = imProg;
         globalState = new ProgramStateIO(mapFile, mpqEditor, gui, imProg, true);
+        // The interpreter is handed a program; this hands over the one thing it cannot work out from
+        // the program alone, which is what a specialised node was copied from.
+        globalState.setSpecialisations(tr);
         initializeBackendConstants();
         this.interpreter = new ILInterpreter(imProg, gui, mapFile, globalState);
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/ProgramState.java
@@ -11,6 +11,7 @@ import de.peeeq.wurstscript.intermediatelang.*;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.parser.WPos;
 import de.peeeq.wurstscript.translation.imtojass.ImAttrType;
+import de.peeeq.wurstscript.translation.imtranslation.SpecialisationLookup;
 import de.peeeq.wurstscript.utils.LineOffsets;
 import de.peeeq.wurstscript.utils.Utils;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -49,6 +50,20 @@ public class ProgramState extends State implements AutoCloseable {
     private final IdentityHashMap<ImVar, Object2ObjectOpenHashMap<String, ILconst>> genericStaticVals = new IdentityHashMap<>();
     private final Object2ObjectOpenHashMap<String, ILconst> genericStaticScalarVals = new Object2ObjectOpenHashMap<>();
     private int untrackedWriteDepth;
+
+    /**
+     * What each specialised node was copied from, when the caller knows. A program handed over without
+     * it is treated as having no specialisation in it, which is what a hand-built program means.
+     */
+    private SpecialisationLookup specialisations = SpecialisationLookup.NONE;
+
+    public void setSpecialisations(SpecialisationLookup specialisations) {
+        this.specialisations = specialisations;
+        // The owners were worked out in the constructor, before this arrived, and the recorded answer
+        // is better than the one read out of a name - so ask again now that it can be asked.
+        genericStaticOwner.clear();
+        identifyGenericStaticGlobals();
+    }
 
     private static boolean containsTypeVariable(ImType type) {
         return type.match(new ImType.Matcher<Boolean>() {
@@ -122,9 +137,17 @@ public class ProgramState extends State implements AutoCloseable {
         }
 
         for (ImVar global : prog.getGlobals()) {
-            String n = global.getName();
+            // Recorded where the global was created, when the caller supplied the relation.
+            ImClass recorded = specialisations.genericStaticOwnerOf(global);
+            if (recorded != null) {
+                genericStaticOwner.put(global, recorded);
+                continue;
+            }
 
-            // longest prefix ending at an underscore that matches a class name
+            // Otherwise the name is all there is: the longest prefix ending at an underscore which
+            // names a generic class. Wrong for a class whose name contains an underscore, and wrong
+            // silently, which is why the recorded answer is preferred.
+            String n = global.getName();
             int pos = n.lastIndexOf('_');
             while (pos > 0) {
                 String className = n.substring(0, pos);
@@ -507,17 +530,13 @@ public class ProgramState extends State implements AutoCloseable {
     public @Nullable ImTypeArgument getCurrentTypeArgument(ImTypeVar typeVar) {
         for (Map<ImTypeVar, ImTypeArgument> frame : typeArgumentFrames) {
             for (Map.Entry<ImTypeVar, ImTypeArgument> e : frame.entrySet()) {
-                // A class and its constructor hold separate nodes for the same source type
-                // parameter, so identity alone is not enough to find the binding.
-                //
-                // EliminateGenerics no longer needs this: it records what each copy was made from and
-                // compares that. The record lives on the ImTranslator, which the interpreter is not
-                // given - it is handed a program, not the translation that produced it - so matching
-                // on the name is what is left here. It is wrong in the same way it was wrong there:
-                // two parameters which merely share a name look like one. Reaching the record from
-                // here means threading the translator through the interpreter, which is its own
-                // change; backlog item 10 carries it.
-                boolean sameVar = e.getKey() == typeVar || e.getKey().getName().equals(typeVar.getName());
+                // A class and its constructor hold separate nodes for the same source type parameter,
+                // so identity alone does not find the binding. This used to fall back to comparing
+                // names, which takes two parameters that merely share one for the same parameter - the
+                // same mistake EliminateGenerics made, where it dispatched a value through the wrong
+                // instance. Both now ask what the node was copied from.
+                boolean sameVar = e.getKey() == typeVar
+                    || specialisations.canonical(e.getKey()) == specialisations.canonical(typeVar);
                 if (sameVar && !e.getValue().getTypeClassBinding().isEmpty()) {
                     return e.getValue();
                 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -1629,6 +1629,11 @@ public class EliminateGenerics {
 
             // Create + register global
             translator.addGlobal(specializedGlobal);
+            // Both halves of what the interpreter used to read out of the name: what this was copied
+            // from, and which class it belongs to.
+            translator.recordSpecialisation(specializedGlobal, originalGlobal, generics.getTypeArguments());
+            translator.recordGenericStaticOwner(specializedGlobal, originalClass);
+            translator.recordGenericStaticOwner(originalGlobal, originalClass);
             specializedGlobals.put(originalGlobal, key, specializedGlobal);
             dbg("Created specialized global: " + specializedName + " type=" + specializedType);
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
@@ -37,7 +37,7 @@ import static de.peeeq.wurstscript.jassIm.JassIm.*;
 import static de.peeeq.wurstscript.translation.imtranslation.FunctionFlagEnum.*;
 import static de.peeeq.wurstscript.utils.Utils.elementNameWithPath;
 
-public class ImTranslator {
+public class ImTranslator implements SpecialisationLookup {
 
 
     public static final String $DEBUG_PRINT = "$debugPrint";
@@ -75,6 +75,25 @@ public class ImTranslator {
         recordSpecialisation(copy, original, List.of());
     }
 
+    /**
+     * The generic class a static field belongs to.
+     * <p>
+     * A static field of a generic class becomes a global named after the class, and the interpreter
+     * used to recover the owner by taking the longest prefix of that name ending at an underscore
+     * which matches a class name. A class whose name contains an underscore, or a field whose name
+     * begins like a class, answers that wrongly and silently. Recorded here instead, where it is
+     * known.
+     */
+    private final Map<ImVar, ImClass> genericStaticOwners = new IdentityHashMap<>();
+
+    public void recordGenericStaticOwner(ImVar global, ImClass owner) {
+        genericStaticOwners.put(global, owner);
+    }
+
+    public @Nullable ImClass genericStaticOwnerOf(ImVar global) {
+        return genericStaticOwners.get(global);
+    }
+
     /** What {@code copy} was made from and for, or null when it is not a copy. */
     public @Nullable Specialisation specialisationOf(Element copy) {
         return specialisations.get(copy);
@@ -87,6 +106,7 @@ public class ImTranslator {
      * construction because a copy is always newer than what it was made from; the bound is there so a
      * mistake elsewhere fails loudly rather than hanging.
      */
+    @Override
     @SuppressWarnings("unchecked")
     public <T extends Element> T canonical(T copy) {
         Element current = copy;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/SpecialisationLookup.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/SpecialisationLookup.java
@@ -1,0 +1,45 @@
+package de.peeeq.wurstscript.translation.imtranslation;
+
+import de.peeeq.wurstscript.jassIm.Element;
+import de.peeeq.wurstscript.jassIm.ImClass;
+import de.peeeq.wurstscript.jassIm.ImVar;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Answers what a specialised node was copied from.
+ * <p>
+ * The interpreter is handed a program rather than the translation which produced it, which is why it
+ * had no way to tell two type variables apart except by name - and two parameters which merely share
+ * a name are not the same parameter. This is the one question it needs answered, narrow enough to hand
+ * over without handing over the translator.
+ */
+public interface SpecialisationLookup {
+
+    /** The node {@code node} was ultimately copied from, or {@code node} itself. */
+    <T extends Element> T canonical(T node);
+
+    /**
+     * The generic class a static field belongs to, or null when it is not one.
+     * <p>
+     * The alternative was reading the owner out of the global's name, which a class name containing
+     * an underscore answers wrongly and without saying so.
+     */
+    @Nullable ImClass genericStaticOwnerOf(ImVar global);
+
+    /**
+     * For a program which did not come from a translation that recorded anything - a hand-built
+     * program in a test, say. Every node is its own original, which is what a program with no
+     * specialisation in it means.
+     */
+    SpecialisationLookup NONE = new SpecialisationLookup() {
+        @Override
+        public <T extends Element> T canonical(T node) {
+            return node;
+        }
+
+        @Override
+        public @Nullable ImClass genericStaticOwnerOf(ImVar global) {
+            return null;
+        }
+    };
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/SpecialisationOriginTest.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/SpecialisationOriginTest.java
@@ -1,13 +1,19 @@
 package tests.wurstscript.tests;
 
+import de.peeeq.wurstscript.intermediatelang.interpreter.ProgramState;
+import de.peeeq.wurstscript.jassIm.ImFunction;
 import de.peeeq.wurstscript.jassIm.ImTypeArgument;
+import de.peeeq.wurstscript.jassIm.ImTypeClassFunc;
+import de.peeeq.wurstscript.jassIm.ImTypeVar;
 import de.peeeq.wurstscript.jassIm.ImVar;
 import de.peeeq.wurstscript.jassIm.JassIm;
 import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
 import org.testng.annotations.Test;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -110,5 +116,60 @@ public class SpecialisationOriginTest {
         translator.recordSpecialisation(b, a);
 
         assertThrows(IllegalStateException.class, () -> translator.canonical(a));
+    }
+
+    private static ImTypeVar typeVar(String name) {
+        return JassIm.ImTypeVar(name);
+    }
+
+    /**
+     * A type argument carrying a binding, since the lookup only returns arguments which have one -
+     * an argument with an empty binding is one nothing was dispatched through.
+     */
+    private static ImTypeArgument boundArgument(String instanceName) {
+        ImFunction instance = JassIm.ImFunction(de.peeeq.wurstscript.ast.Ast.NoExpr(), instanceName,
+            JassIm.ImTypeVars(), JassIm.ImVars(), JassIm.ImVoid(), JassIm.ImVars(), JassIm.ImStmts(),
+            new java.util.ArrayList<>());
+        ImTypeClassFunc requirement = JassIm.ImTypeClassFunc(de.peeeq.wurstscript.ast.Ast.NoExpr(),
+            "show", JassIm.ImTypeVars(), JassIm.ImVars(), JassIm.ImVoid());
+        Map<ImTypeClassFunc, io.vavr.control.Either<de.peeeq.wurstscript.jassIm.ImMethod, ImFunction>> binding =
+            new LinkedHashMap<>();
+        binding.put(requirement, io.vavr.control.Either.right(instance));
+        return JassIm.ImTypeArgument(JassIm.ImSimpleType("integer"), binding);
+    }
+
+    /**
+     * The interpreter picks a binding for a type variable, and two unrelated parameters may share a
+     * name. Comparing names returns whichever the frame happens to hold, which is how a value gets
+     * dispatched through the wrong instance; asking what each was copied from does not.
+     * <p>
+     * Fails without the change: the frame below holds two parameters called T, and the copy being
+     * looked up belongs to only one of them.
+     */
+    @Test
+    public void aBindingIsFoundByOriginRatherThanByName() {
+        ImTranslator translator = translator();
+        ImTypeVar unrelated = typeVar("T");
+        ImTypeVar original = typeVar("T");
+        ImTypeVar copy = typeVar("T");
+        translator.recordSpecialisation(copy, original);
+
+        ImTypeArgument wrong = boundArgument("unrelated_show");
+        ImTypeArgument right = boundArgument("original_show");
+
+        ProgramState state = new ProgramState(new de.peeeq.wurstscript.gui.WurstGuiLogger(),
+            JassIm.ImProg(de.peeeq.wurstscript.ast.Ast.NoExpr(), JassIm.ImVars(), JassIm.ImFunctions(),
+                JassIm.ImMethods(), JassIm.ImClasses(), JassIm.ImTypeClassFuncs(), new LinkedHashMap<>()),
+            true);
+        state.setSpecialisations(translator);
+
+        // The unrelated parameter is first, so a name comparison reaches it before the right one.
+        Map<ImTypeVar, ImTypeArgument> frame = new LinkedHashMap<>();
+        frame.put(unrelated, wrong);
+        frame.put(original, right);
+        state.pushTypeArguments(frame);
+
+        assertSame(state.getCurrentTypeArgument(copy), right,
+            "the binding of the parameter this copy came from, not of one which shares its name");
     }
 }


### PR DESCRIPTION
Stage two, complete on this pull request. Consumes the relation from #1248, now merged, so this targets master directly.

Two name-based answers in `ProgramState`, both replaced by recorded ones. This closes the remaining half of backlog item 10.

## Type variables were compared by name

    boolean sameVar = e.getKey() == typeVar || e.getKey().getName().equals(typeVar.getName());

That takes two parameters which merely share a name for the same parameter — the mistake `EliminateGenerics` made, where it dispatched a string through an `int` instance and killed the interpreter (#1244). The same bug was waiting in the compiletime path, unpinned.

Its survival was legitimate rather than neglect: the interpreter is handed a program, not the translation which produced it, so it had nothing else to compare.

## A static field's owner was read out of its name

`identifyGenericStaticGlobals` took the **longest prefix of the global's name ending at an underscore which names a generic class**. A class whose name contains an underscore answers that wrongly, and silently — nothing downstream can tell a mis-attributed owner from a correct one.

The owner is now recorded where the specialised global is created, which is where it is known.

## How both reach the interpreter

`SpecialisationLookup` — two questions, `canonical(node)` and `genericStaticOwnerOf(global)` — handed over instead of the translator, keeping the interpreter's independence from the translation. `ImTranslator` implements it; `CompiletimeFunctionRunner` supplies the translator it already holds.

Without one, `SpecialisationLookup.NONE` makes every node its own original and the name search stands in. That is what a hand-built program in a test means, and it still answers those correctly.

One ordering detail worth naming: the owners are worked out in the `ProgramState` constructor, before the lookup is supplied, so supplying it re-derives them. I introduced that bug in this change and caught it before pushing — without the re-derivation the recorded path would never have fired, and the tests would still have passed, since the name search returns the same answer for every program in the suite.

## Behaviour

Unchanged where the two approaches agreed, which is everywhere the relation exists — that is why no test moves. What changes is that they can no longer agree by accident.

Green: `CompiletimeTests`, `TypeClassTests`, `FastHashMapTests`, `GenericsTests`, `GenericsWithTypeclassesTests`, `LuaTranslationTests`, `StdLibOwnTests` (all 460 library tests), `SpecialisationOriginTest`.

## What I did not fold in, and why

The naming half — `semanticNameFromMethodName` and the two slot composers. When I proposed stage two I said the relation would let names be composed from structure; #1247 showed that is wrong, and I would rather say so than quietly leave it out. An override chain's methods have **different** originals, so identity by origin splits a chain which must share one slot — which is exactly how the declared-name condition in #1247 was arrived at. The relation answers liveness and the identity of copies; it does not answer "is this method the same dispatchable thing as that one", and grouping a virtual method with its overrides needs that instead.

So the name parsing in the slot composers stays until there is an identity which handles override chains. Backlog item 15 records what such an identity has to do.