### PR TITLE
Fix the macOS-only library failure, and say which test it was

### DIFF
--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/StdLib.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/StdLib.java
@@ -24,7 +24,7 @@ public class StdLib {
     /**
      * version to use for the tests
      */
-    private final static String version = "98b1140803dcb99a4a48cf8f14fc099961ad55f7";
+    private final static String version = "a85001e8e93a1271ccfc8edb0810c07041f24661";
 
     /**
      * flag so that initialization in only done once

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/StdLibOwnTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/StdLibOwnTests.java
@@ -69,4 +69,36 @@ public class StdLibOwnTests extends WurstScriptTest {
         // count: it is there to catch the program holding none, not to be updated on every bump.
         test().withStdLib().expectAtLeastTests(100).lines(program.toArray(new String[0]));
     }
+
+    /**
+     * A failing library test says which one it was.
+     * <p>
+     * The name is printed to stdout, which a CI run does not keep, so the thrown message was all that
+     * was left of it - and it carried the counts followed by every warning the library compiles with.
+     * A failure on a runner one does not have therefore said that one test of four hundred and sixty
+     * failed and nothing more, which is how a slow-runner timeout cost an afternoon to place.
+     * <p>
+     * The name has to arrive before the warnings, because a report which truncates a long message
+     * keeps the front of it.
+     */
+    @Test
+    public void aFailingLibraryTestIsNamed() {
+        try {
+            test().withStdLib().executeTests().lines(
+                "package test",
+                "import Wurstunit",
+                "@Test function deliberatelyFails()",
+                "    let one = 1",
+                "    one.assertEquals(2)",
+                "init",
+                "    skip"
+            );
+        } catch (Error e) {
+            String message = e.getMessage();
+            assertTrue(message.contains("deliberatelyFails"),
+                "the failure should name the test, but said:\n" + message);
+            return;
+        }
+        throw new AssertionError("a failing library test should have failed the suite");
+    }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstScriptTest.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstScriptTest.java
@@ -1160,9 +1160,37 @@ public class WurstScriptTest {
         RunTests.TestResult res = runTests.runTests(translator, imProg, Optional.empty(), Optional.empty());
         if (res.getPassedTests() < res.getTotalTests()) {
             throw new Error("tests failed: " + res.getPassedTests() + " / " + res.getTotalTests() + "\n" +
-                    gui.getErrors());
+                    describeFailures(runTests) + gui.getErrors());
         }
         return res.getTotalTests();
+    }
+
+    /**
+     * Names the tests which failed, and says how each one did.
+     * <p>
+     * The count alone does not say which of several hundred it was, and the name is only printed to
+     * stdout, which a CI run does not keep - so a failure on a runner one does not have says that one
+     * test of the library failed and nothing else. Ahead of the warnings deliberately: a library
+     * compiles with hundreds of them, and a report which truncates a long message cuts off the end,
+     * which is where the name would otherwise sit.
+     */
+    private static String describeFailures(RunTests runTests) {
+        List<RunTests.TestFailure> failures = runTests.getFailTests();
+        if (failures.isEmpty()) {
+            // The counts disagreed without a recorded failure, which is itself worth saying rather
+            // than leaving a blank where the explanation belongs.
+            return "no failure was recorded, which is the thing to look at\n";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (RunTests.TestFailure failure : failures) {
+            sb.append("FAILED ").append(failure.getFunction().getName());
+            String message = failure.getMessage();
+            if (message != null && !message.isEmpty()) {
+                sb.append(": ").append(message);
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
     }
 
     /**


### PR DESCRIPTION
### The macOS failure, fixed

`macos-15-intel` was the only failing job on master, for several runs, while `ubuntu-latest`, `windows-latest` and `macos-latest` all passed. It was `StdLibOwnTests.standardLibraryTestsPass`, one library test of 460.

Two different causes were mixed into that history, worth separating:

- Run `32044793479` failed in 59s on `actions/setup-java` returning 503 then 429. GitHub infrastructure, not a test.
- Runs `32072039746` and `32028255014` are the real one: 459/460, on the slowest runner only.

The test was `PolygonTests.acceleratedClassificationMatchesLinearFor10000Points`. Both strides in its point sequence are coprime to 1152, so ten thousand iterations asked the same 1152 questions nearly nine times over — no extra coverage, and enough interpreted work to reach the twenty second per-test budget on a loaded machine. WurstStdlib2#467 fixed that; this bumps the pinned library from `98b1140` to `a85001e`, which carries it.

Verified against the new pin: **460/460**. The test is now named `acceleratedClassificationMatchesLinearForEveryBenchmarkPoint` and reports 1152 lookups rather than 10000; the count is unchanged because it was made cheaper rather than removed.

### And why placing it was so hard

A failing library test threw the counts followed by every warning the library compiles with. The test's name went only to stdout, which a CI run does not keep, so the failure said one test of 460 had failed and nothing else. Placing it took three runs, the check annotations and the published summary, and still came down to inference — the annotation was cut off at around 8000 characters of warnings before reaching anything useful.

`RunTests` already records each failure with its function and message; only the counts were being passed on. They are now named in the thrown message, ahead of the warnings, because a report which truncates a long message keeps the front of it.

The name is package qualified, reusing `RunTests.qualifiedTestName` rather than spelling it a second time: `standardLibraryTestsPass` imports every test package the library has, so two of them naming a test the same would otherwise still be indistinguishable.

### Testing

`StdLibOwnTests.aFailingLibraryTestIsNamed` runs a deliberately failing `@Test` and asserts the thrown message names it, qualified. It cannot pass vacuously: no error fails the test, and a message without the name fails the assertion.

Green: `StdLibOwnTests` (both tests) and `GenericsWithTypeclassesTests`, the other suite using this path.