### PR TITLE
Handle MPQ maps without HM3W headers

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ProjectConfigBuilder.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ProjectConfigBuilder.java
@@ -107,7 +107,7 @@ public class ProjectConfigBuilder {
         w3I.write(result.w3i);
 
         // Apply map header (this is cheap, so we always do it)
-        applyMapHeader(projectConfig, targetMap, w3I.getPlayers().size(), w3I.getMapName());
+        applyMapHeader(projectConfig, targetMap, w3I.getPlayers().size(), w3I.getMapName(), w3I.getFlags().toInt());
 
         // Update the manifest with new config hash (must open writable to insert)
         try (MpqEditor mpq = MpqEditorFactory.getEditor(Optional.of(targetMap), false)) {
@@ -357,7 +357,8 @@ public class ProjectConfigBuilder {
     }
 
     private static void applyMapHeader(WurstProjectConfigData projectConfig, File targetMap,
-                                       int existingPlayerCount, String existingMapName) throws IOException {
+                                       int existingPlayerCount, String existingMapName,
+                                       int existingMapFlags) throws IOException {
         boolean shouldWrite = false;
         WurstProjectBuildMapData buildMapData = projectConfig.buildMapData();
         if (buildMapData.players().isEmpty() && StringUtils.isBlank(buildMapData.name())) {
@@ -380,6 +381,9 @@ public class ProjectConfigBuilder {
         }
         if (hasNoMapHeader && StringUtils.isBlank(buildMapData.name())) {
             mapHeader.setMapName(existingMapName);
+        }
+        if (hasNoMapHeader) {
+            mapHeader.setFlags(existingMapFlags);
         }
         if (StringUtils.isNotBlank(buildMapData.name())) {
             mapHeader.setMapName(buildMapData.name());

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ProjectConfigBuilder.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ProjectConfigBuilder.java
@@ -107,7 +107,7 @@ public class ProjectConfigBuilder {
         w3I.write(result.w3i);
 
         // Apply map header (this is cheap, so we always do it)
-        applyMapHeader(projectConfig, targetMap);
+        applyMapHeader(projectConfig, targetMap, w3I.getPlayers().size());
 
         // Update the manifest with new config hash (must open writable to insert)
         try (MpqEditor mpq = MpqEditorFactory.getEditor(Optional.of(targetMap), false)) {
@@ -356,7 +356,8 @@ public class ProjectConfigBuilder {
         }
     }
 
-    private static void applyMapHeader(WurstProjectConfigData projectConfig, File targetMap) throws IOException {
+    private static void applyMapHeader(WurstProjectConfigData projectConfig, File targetMap,
+                                       int existingPlayerCount) throws IOException {
         boolean shouldWrite = false;
         WurstProjectBuildMapData buildMapData = projectConfig.buildMapData();
         if (buildMapData.players().isEmpty() && StringUtils.isBlank(buildMapData.name())) {
@@ -367,12 +368,15 @@ public class ProjectConfigBuilder {
         // directly with its MPQ archive. MapHeader.ofFile only reads the prefix,
         // so use a new header in that case; writeToMapFile will insert it before
         // the archive.
-        MapHeader mapHeader = startsWithMpqArchive(targetMap)
+        boolean hasNoMapHeader = startsWithMpqArchive(targetMap);
+        MapHeader mapHeader = hasNoMapHeader
             ? new MapHeader()
             : MapHeader.ofFile(targetMap);
         if (!buildMapData.players().isEmpty()) {
             mapHeader.setMaxPlayersCount(buildMapData.players().size());
             shouldWrite = true;
+        } else if (hasNoMapHeader) {
+            mapHeader.setMaxPlayersCount(existingPlayerCount);
         }
         if (StringUtils.isNotBlank(buildMapData.name())) {
             mapHeader.setMapName(buildMapData.name());

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ProjectConfigBuilder.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ProjectConfigBuilder.java
@@ -358,18 +358,37 @@ public class ProjectConfigBuilder {
 
     private static void applyMapHeader(WurstProjectConfigData projectConfig, File targetMap) throws IOException {
         boolean shouldWrite = false;
-        MapHeader mapHeader = MapHeader.ofFile(targetMap);
-        if (!projectConfig.buildMapData().players().isEmpty()) {
-            mapHeader.setMaxPlayersCount(projectConfig.buildMapData().players().size());
+        WurstProjectBuildMapData buildMapData = projectConfig.buildMapData();
+        if (buildMapData.players().isEmpty() && StringUtils.isBlank(buildMapData.name())) {
+            return;
+        }
+
+        // A Warcraft III map may omit the optional 512-byte HM3W prefix and start
+        // directly with its MPQ archive. MapHeader.ofFile only reads the prefix,
+        // so use a new header in that case; writeToMapFile will insert it before
+        // the archive.
+        MapHeader mapHeader = startsWithMpqArchive(targetMap)
+            ? new MapHeader()
+            : MapHeader.ofFile(targetMap);
+        if (!buildMapData.players().isEmpty()) {
+            mapHeader.setMaxPlayersCount(buildMapData.players().size());
             shouldWrite = true;
         }
-        if (StringUtils.isNotBlank(projectConfig.buildMapData().name())) {
-            mapHeader.setMapName(projectConfig.buildMapData().name());
+        if (StringUtils.isNotBlank(buildMapData.name())) {
+            mapHeader.setMapName(buildMapData.name());
             shouldWrite = true;
         }
         if (shouldWrite) {
             WLogger.info("Applying map header");
             mapHeader.writeToMapFile(targetMap);
+        }
+    }
+
+    private static boolean startsWithMpqArchive(File targetMap) throws IOException {
+        try (InputStream input = new FileInputStream(targetMap)) {
+            byte[] startToken = input.readNBytes(4);
+            return startToken.length == 4
+                && new String(startToken, StandardCharsets.US_ASCII).startsWith("MPQ");
         }
     }
 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ProjectConfigBuilder.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/ProjectConfigBuilder.java
@@ -107,7 +107,7 @@ public class ProjectConfigBuilder {
         w3I.write(result.w3i);
 
         // Apply map header (this is cheap, so we always do it)
-        applyMapHeader(projectConfig, targetMap, w3I.getPlayers().size());
+        applyMapHeader(projectConfig, targetMap, w3I.getPlayers().size(), w3I.getMapName());
 
         // Update the manifest with new config hash (must open writable to insert)
         try (MpqEditor mpq = MpqEditorFactory.getEditor(Optional.of(targetMap), false)) {
@@ -357,7 +357,7 @@ public class ProjectConfigBuilder {
     }
 
     private static void applyMapHeader(WurstProjectConfigData projectConfig, File targetMap,
-                                       int existingPlayerCount) throws IOException {
+                                       int existingPlayerCount, String existingMapName) throws IOException {
         boolean shouldWrite = false;
         WurstProjectBuildMapData buildMapData = projectConfig.buildMapData();
         if (buildMapData.players().isEmpty() && StringUtils.isBlank(buildMapData.name())) {
@@ -377,6 +377,9 @@ public class ProjectConfigBuilder {
             shouldWrite = true;
         } else if (hasNoMapHeader) {
             mapHeader.setMaxPlayersCount(existingPlayerCount);
+        }
+        if (hasNoMapHeader && StringUtils.isBlank(buildMapData.name())) {
+            mapHeader.setMapName(existingMapName);
         }
         if (StringUtils.isNotBlank(buildMapData.name())) {
             mapHeader.setMapName(buildMapData.name());

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstBuildConfigTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstBuildConfigTests.java
@@ -1,11 +1,13 @@
 package tests.wurstscript.tests;
 
 import org.wurstscript.projectconfig.WurstProjectConfigData;
+import org.wurstscript.projectconfig.WurstProjectBuildMapData;
 import de.peeeq.wurstio.languageserver.WFile;
 import de.peeeq.wurstio.languageserver.ProjectConfigBuilder;
 import de.peeeq.wurstio.languageserver.WurstBuildConfig;
 import de.peeeq.wurstio.languageserver.WurstCommands;
 import de.peeeq.wurstio.utils.W3InstallationData;
+import net.moonlightflower.wc3libs.bin.app.MapHeader;
 import net.moonlightflower.wc3libs.port.GameVersion;
 import org.testng.annotations.Test;
 
@@ -221,6 +223,57 @@ public class WurstBuildConfigTests {
             effectiveConfigInjectionVersion(project.resolve("_build").toFile(), detectedReforged),
             new GameVersion("1.27")
         );
+    }
+
+    @Test
+    public void mapHeaderConfigAcceptsAnArchiveWithoutAnHm3wPrefix() throws Exception {
+        Path mapWithoutHeader = Files.createTempFile("wurst-map-without-header", ".w3x");
+        byte[] original = new byte[1024];
+        original[0] = 'M';
+        original[1] = 'P';
+        original[2] = 'Q';
+        original[3] = 0x1a;
+        Files.write(mapWithoutHeader, original);
+
+        Method applyMapHeader = ProjectConfigBuilder.class.getDeclaredMethod(
+            "applyMapHeader", WurstProjectConfigData.class, File.class
+        );
+        applyMapHeader.setAccessible(true);
+
+        applyMapHeader.invoke(
+            null,
+            new WurstProjectConfigData(
+                "Test",
+                List.of(),
+                new WurstProjectBuildMapData("Configured map", null, null, null, null, List.of(), List.of()),
+                null,
+                null
+            ),
+            mapWithoutHeader.toFile()
+        );
+
+        assertEquals(Files.readAllBytes(mapWithoutHeader)[0], (byte) 'H');
+        assertEquals(MapHeader.ofFile(mapWithoutHeader.toFile()).getMaxPlayersCount(), 0);
+        assertEquals(Files.size(mapWithoutHeader), original.length + 512);
+    }
+
+    @Test
+    public void mapHeaderConfigDoesNotReadAnArchiveWhenNothingNeedsChanging() throws Exception {
+        Path mapWithoutHeader = Files.createTempFile("wurst-map-without-header-noop", ".w3x");
+        byte[] original = new byte[1024];
+        original[0] = 'M';
+        original[1] = 'P';
+        original[2] = 'Q';
+        original[3] = 0x1a;
+        Files.write(mapWithoutHeader, original);
+
+        Method applyMapHeader = ProjectConfigBuilder.class.getDeclaredMethod(
+            "applyMapHeader", WurstProjectConfigData.class, File.class
+        );
+        applyMapHeader.setAccessible(true);
+        applyMapHeader.invoke(null, WurstProjectConfigData.empty(), mapWithoutHeader.toFile());
+
+        assertEquals(Files.readAllBytes(mapWithoutHeader), original);
     }
 
     private static String calculateProjectConfigHash(File buildDir) throws Exception {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstBuildConfigTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstBuildConfigTests.java
@@ -238,7 +238,7 @@ public class WurstBuildConfigTests {
         Files.write(mapWithoutHeader, original);
 
         Method applyMapHeader = ProjectConfigBuilder.class.getDeclaredMethod(
-            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class, String.class
+            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class, String.class, int.class
         );
         applyMapHeader.setAccessible(true);
 
@@ -253,7 +253,8 @@ public class WurstBuildConfigTests {
             ),
             mapWithoutHeader.toFile(),
             3,
-            "Existing map"
+            "Existing map",
+            0x1234
         );
 
         assertEquals(Files.readAllBytes(mapWithoutHeader)[0], (byte) 'H');
@@ -272,10 +273,10 @@ public class WurstBuildConfigTests {
         Files.write(mapWithoutHeader, original);
 
         Method applyMapHeader = ProjectConfigBuilder.class.getDeclaredMethod(
-            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class, String.class
+            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class, String.class, int.class
         );
         applyMapHeader.setAccessible(true);
-        applyMapHeader.invoke(null, WurstProjectConfigData.empty(), mapWithoutHeader.toFile(), 0, null);
+        applyMapHeader.invoke(null, WurstProjectConfigData.empty(), mapWithoutHeader.toFile(), 0, null, 0);
 
         assertEquals(Files.readAllBytes(mapWithoutHeader), original);
     }
@@ -291,7 +292,7 @@ public class WurstBuildConfigTests {
         Files.write(mapWithoutHeader, original);
 
         Method applyMapHeader = ProjectConfigBuilder.class.getDeclaredMethod(
-            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class, String.class
+            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class, String.class, int.class
         );
         applyMapHeader.setAccessible(true);
 
@@ -310,11 +311,13 @@ public class WurstBuildConfigTests {
             ),
             mapWithoutHeader.toFile(),
             4,
-            "Existing map"
+            "Existing map",
+            0x1234
         );
 
         byte[] result = Files.readAllBytes(mapWithoutHeader);
         assertEquals(MapHeader.ofFile(mapWithoutHeader.toFile()).getMaxPlayersCount(), 1);
+        assertEquals(MapHeader.ofFile(mapWithoutHeader.toFile()).getFlags(), 0x1234);
         assertTrue(new String(result, StandardCharsets.UTF_8).contains("Existing map"));
     }
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstBuildConfigTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstBuildConfigTests.java
@@ -2,6 +2,7 @@ package tests.wurstscript.tests;
 
 import org.wurstscript.projectconfig.WurstProjectConfigData;
 import org.wurstscript.projectconfig.WurstProjectBuildMapData;
+import org.wurstscript.projectconfig.WurstProjectBuildPlayer;
 import de.peeeq.wurstio.languageserver.WFile;
 import de.peeeq.wurstio.languageserver.ProjectConfigBuilder;
 import de.peeeq.wurstio.languageserver.WurstBuildConfig;
@@ -13,6 +14,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -236,7 +238,7 @@ public class WurstBuildConfigTests {
         Files.write(mapWithoutHeader, original);
 
         Method applyMapHeader = ProjectConfigBuilder.class.getDeclaredMethod(
-            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class
+            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class, String.class
         );
         applyMapHeader.setAccessible(true);
 
@@ -250,7 +252,8 @@ public class WurstBuildConfigTests {
                 null
             ),
             mapWithoutHeader.toFile(),
-            3
+            3,
+            "Existing map"
         );
 
         assertEquals(Files.readAllBytes(mapWithoutHeader)[0], (byte) 'H');
@@ -269,12 +272,50 @@ public class WurstBuildConfigTests {
         Files.write(mapWithoutHeader, original);
 
         Method applyMapHeader = ProjectConfigBuilder.class.getDeclaredMethod(
-            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class
+            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class, String.class
         );
         applyMapHeader.setAccessible(true);
-        applyMapHeader.invoke(null, WurstProjectConfigData.empty(), mapWithoutHeader.toFile(), 0);
+        applyMapHeader.invoke(null, WurstProjectConfigData.empty(), mapWithoutHeader.toFile(), 0, null);
 
         assertEquals(Files.readAllBytes(mapWithoutHeader), original);
+    }
+
+    @Test
+    public void mapHeaderConfigPreservesExistingMapNameWhenOnlyPlayersChange() throws Exception {
+        Path mapWithoutHeader = Files.createTempFile("wurst-map-without-header-name", ".w3x");
+        byte[] original = new byte[1024];
+        original[0] = 'M';
+        original[1] = 'P';
+        original[2] = 'Q';
+        original[3] = 0x1a;
+        Files.write(mapWithoutHeader, original);
+
+        Method applyMapHeader = ProjectConfigBuilder.class.getDeclaredMethod(
+            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class, String.class
+        );
+        applyMapHeader.setAccessible(true);
+
+        applyMapHeader.invoke(
+            null,
+            new WurstProjectConfigData(
+                "Test",
+                List.of(),
+                new WurstProjectBuildMapData(
+                    "", null, null, null, null,
+                    List.of(new WurstProjectBuildPlayer(0, null, null, null, null)),
+                    List.of()
+                ),
+                null,
+                null
+            ),
+            mapWithoutHeader.toFile(),
+            4,
+            "Existing map"
+        );
+
+        byte[] result = Files.readAllBytes(mapWithoutHeader);
+        assertEquals(MapHeader.ofFile(mapWithoutHeader.toFile()).getMaxPlayersCount(), 1);
+        assertTrue(new String(result, StandardCharsets.UTF_8).contains("Existing map"));
     }
 
     private static String calculateProjectConfigHash(File buildDir) throws Exception {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstBuildConfigTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstBuildConfigTests.java
@@ -236,7 +236,7 @@ public class WurstBuildConfigTests {
         Files.write(mapWithoutHeader, original);
 
         Method applyMapHeader = ProjectConfigBuilder.class.getDeclaredMethod(
-            "applyMapHeader", WurstProjectConfigData.class, File.class
+            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class
         );
         applyMapHeader.setAccessible(true);
 
@@ -249,11 +249,12 @@ public class WurstBuildConfigTests {
                 null,
                 null
             ),
-            mapWithoutHeader.toFile()
+            mapWithoutHeader.toFile(),
+            3
         );
 
         assertEquals(Files.readAllBytes(mapWithoutHeader)[0], (byte) 'H');
-        assertEquals(MapHeader.ofFile(mapWithoutHeader.toFile()).getMaxPlayersCount(), 0);
+        assertEquals(MapHeader.ofFile(mapWithoutHeader.toFile()).getMaxPlayersCount(), 3);
         assertEquals(Files.size(mapWithoutHeader), original.length + 512);
     }
 
@@ -268,10 +269,10 @@ public class WurstBuildConfigTests {
         Files.write(mapWithoutHeader, original);
 
         Method applyMapHeader = ProjectConfigBuilder.class.getDeclaredMethod(
-            "applyMapHeader", WurstProjectConfigData.class, File.class
+            "applyMapHeader", WurstProjectConfigData.class, File.class, int.class
         );
         applyMapHeader.setAccessible(true);
-        applyMapHeader.invoke(null, WurstProjectConfigData.empty(), mapWithoutHeader.toFile());
+        applyMapHeader.invoke(null, WurstProjectConfigData.empty(), mapWithoutHeader.toFile(), 0);
 
         assertEquals(Files.readAllBytes(mapWithoutHeader), original);
     }


### PR DESCRIPTION
## Summary

- Handle valid Warcraft III maps whose MPQ archive starts at byte 0 without an `HM3W` prefix.
- Create a fresh map header when configuration needs to update such a map; `MapHeader.writeToMapFile` then inserts it before the archive.
- Avoid parsing the map header when no header-related configuration changes are requested.
- Add regression coverage for both cases.

## Checks

- `.\gradlew.bat test --tests tests.wurstscript.tests.WurstBuildConfigTests --no-daemon` — passed.
- `git diff --check` — passed.

## Known gaps

- No full test-suite run; this is a focused map-header regression fix.
