### PR TITLE
Require explicit build optimization flags

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/WurstCommands.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/languageserver/WurstCommands.java
@@ -140,11 +140,6 @@ public class WurstCommands {
                         .filter(s -> s.startsWith("-") || (forBuild && s.startsWith("+")))
                         .map(s -> forBuild && s.startsWith("+") ? "-" + s.substring(1) : s)
                         .collect(Collectors.toList()));
-                    if (forBuild) {
-                        addBuildDefault(args, "-opt");
-                        addBuildDefault(args, "-inline");
-                        addBuildDefault(args, "-localOptimizations");
-                    }
                     args.addAll(List.of(additionalArgs));
                     return WurstBuildConfig.fromWorkspaceRoot(rootPath).applyToCompileArgs(args);
                 }
@@ -163,12 +158,6 @@ public class WurstCommands {
             }
         } catch (IOException e) {
             throw new RuntimeException("Could not access wurst_run.args config file", e);
-        }
-    }
-
-    private static void addBuildDefault(List<String> args, String option) {
-        if (!args.contains(option)) {
-            args.add(option);
         }
     }
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstCommandsTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstCommandsTests.java
@@ -35,7 +35,7 @@ public class WurstCommandsTests {
         assertTrue(buildArgs.contains("-stacktraces"));
         assertTrue(buildArgs.contains("-inline"));
         assertTrue(buildArgs.contains("-localOptimizations"));
-        assertTrue(buildArgs.contains("-opt"), "builds enable output optimization by default");
+        assertFalse(buildArgs.contains("-opt"), "build options require their corresponding '+' entry");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- stop Build Map from unconditionally enabling `opt`, `inline`, and `localOptimizations`
- require each build-only optimization to have its corresponding `+` entry in `wurst_run.args`
- update the regression test to prove an omitted `+opt` stays disabled

## Acceptance criteria

- `+inline` enables inline only for builds
- `+localOptimizations` enables local optimizations only for builds
- omitted `+opt` does not enable output optimization

## Checks

- `./gradlew.bat test --tests tests.wurstscript.tests.WurstCommandsTests` — passed
- `git diff --check` — passed

## Known gaps

- none
