### PR TITLE
Allow nested generic specialization keys

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
@@ -875,10 +875,11 @@ public class WurstCompilerJassImpl implements WurstCompiler {
         ImAttrType.setWurstClassType(null);
         int stage;
         boolean specializeTupleValueTypes = containsTupleTypeArgument();
-        if (containsGenericNewCall() || containsTypeClassDispatch() || specializeTupleValueTypes) {
+        EliminateGenerics luaGenerics = new EliminateGenerics(getImTranslator(), getImProg());
+        if (containsGenericNewCall() || containsTypeClassDispatch() || specializeTupleValueTypes
+            || luaGenerics.hasGenericStatics()) {
             beginPhase(2, "Specialize generics for Lua-only concrete operations");
-            new EliminateGenerics(getImTranslator(), getImProg())
-                .transformGenericNewOnly(specializeTupleValueTypes);
+            luaGenerics.transformGenericNewOnly(specializeTupleValueTypes);
             // Remove phantom erased initialization before optimization can preserve only its side
             // effect. A specialized static owns its copied initializer unless the erased static is live.
             RemoveGarbage.removePhantomGenericStaticInitializers(getImProg(), getImTranslator());

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -42,6 +42,8 @@ public class EliminateGenerics {
     private final Set<Element> specializedCallSites = Collections.newSetFromMap(new IdentityHashMap<>());
     private final Set<Element> recordedErasedStaticAllocations =
         Collections.newSetFromMap(new IdentityHashMap<>());
+    private final Set<ImFunction> scannedFixedStaticCallees =
+        Collections.newSetFromMap(new IdentityHashMap<>());
     private final Table<ImFunction, GenericTypes, ImFunction> specializedFunctions = HashBasedTable.create();
     /** The class each function was moved out of, for calls which name their target without a receiver. */
     private final Map<ImFunction, ImClass> functionOwners = new IdentityHashMap<>();
@@ -486,26 +488,25 @@ public class EliminateGenerics {
             // The generic callee remains erased, so its body is skipped by collectGenericNewRoots.
             // Fixed concrete allocations inside it still name real per-instantiation statics and
             // must be registered without cloning the caller for unrelated type arguments.
-            recordFixedErasedStaticAllocations(call.getFunc(),
-                Collections.newSetFromMap(new IdentityHashMap<>()));
+            recordFixedErasedStaticAllocations(call.getFunc());
         }
     }
 
-    private void recordFixedErasedStaticAllocations(ImFunction function,
-                                                     Set<ImFunction> visited) {
-        if (!visited.add(function)) {
+    private void recordFixedErasedStaticAllocations(ImFunction function) {
+        if (!scannedFixedStaticCallees.add(function)) {
             return;
         }
         function.accept(new Element.DefaultVisitor() {
             @Override
             public void visit(ImFunctionCall nestedCall) {
                 super.visit(nestedCall);
-                recordErasedConstructorAllocation(nestedCall);
-                if (!nestedCall.getTypeArguments().isEmpty()
-                    && !typeArgumentsContainTypeVariable(nestedCall.getTypeArguments())
-                    && !(nestedCall.getFunc().getTrace() instanceof ConstructorDef)) {
-                    recordFixedErasedStaticAllocations(nestedCall.getFunc(), visited);
-                }
+                collectGenericNewUse(nestedCall);
+            }
+
+            @Override
+            public void visit(ImMethodCall nestedCall) {
+                super.visit(nestedCall);
+                collectGenericNewUse(nestedCall);
             }
         });
     }
@@ -744,20 +745,24 @@ public class EliminateGenerics {
             specializedCallSites.add(call);
             return;
         }
-        if (!shouldSpecializeTupleArguments(call.getTypeArguments())
-            && !methodNeedsSpecialization(method,
-            Collections.newSetFromMap(new IdentityHashMap<>()),
-            Collections.newSetFromMap(new IdentityHashMap<>()))) {
-            return;
-        }
         if (isMissingClassTypeArguments(call, method)) {
             addMemberTypeArguments(call, method.attrClass());
         }
         if (typeArgumentsContainTypeVariable(call.getTypeArguments())) {
-            // The receiver's declared type is still generic, which happens when the method is
-            // called straight on a freshly constructed value. The construction states the
-            // instantiation, so take the arguments from it.
+            // A call directly on a fresh generic construction gets its concrete class arguments
+            // from that construction before deciding between specialization and fixed-body scan.
             useConstructionTypeArguments(call);
+        }
+        boolean needsSpecialization = methodNeedsSpecialization(method,
+            Collections.newSetFromMap(new IdentityHashMap<>()),
+            Collections.newSetFromMap(new IdentityHashMap<>()));
+        if (!shouldSpecializeTupleArguments(call.getTypeArguments()) && !needsSpecialization) {
+            if (!call.getTypeArguments().isEmpty()
+                && !typeArgumentsContainTypeVariable(call.getTypeArguments())
+                && method.getImplementation() != null) {
+                recordFixedErasedStaticAllocations(method.getImplementation());
+            }
+            return;
         }
         if (!call.getTypeArguments().isEmpty()
             && !typeArgumentsContainTypeVariable(call.getTypeArguments())) {
@@ -876,9 +881,10 @@ public class EliminateGenerics {
 
             @Override
             public void visit(ImFunctionCall call) {
+                boolean dependsOnTypeVariable = typeArgumentsContainTypeVariable(call.getTypeArguments());
                 if (constructsClassOwningGenericGlobals(function, call)
-                    || translator.isGenericNewMarker(call.getFunc())
-                    || functionNeedsSpecialization(call.getFunc(), visitedFunctions, visitedMethods)) {
+                    || (dependsOnTypeVariable && (translator.isGenericNewMarker(call.getFunc())
+                    || functionNeedsSpecialization(call.getFunc(), visitedFunctions, visitedMethods)))) {
                     found[0] = true;
                     return;
                 }
@@ -887,7 +893,8 @@ public class EliminateGenerics {
 
             @Override
             public void visit(ImMethodCall call) {
-                if (methodNeedsSpecialization(call.getMethod(), visitedFunctions, visitedMethods)) {
+                if (typeArgumentsContainTypeVariable(call.getTypeArguments())
+                    && methodNeedsSpecialization(call.getMethod(), visitedFunctions, visitedMethods)) {
                     found[0] = true;
                     return;
                 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -127,10 +127,11 @@ public class EliminateGenerics {
     public void transformGenericNewOnly(boolean specializeTupleValueTypes) {
         genericNewOnly = true;
         this.specializeTupleValueTypes = specializeTupleValueTypes;
-        if (specializeTupleValueTypes) {
+        identifyGenericGlobals();
+        if (specializeTupleValueTypes || !globalToClass.isEmpty()) {
             addMemberTypeArguments();
-            identifyGenericGlobals();
         }
+        indexGenericGlobalUses();
         collectUnspecializedGenericClassMethods();
         // Specialising a constructor makes its result type concrete, which is what lets a method
         // call on that result resolve. Repeat until a pass finds nothing new; collection is
@@ -149,6 +150,11 @@ public class EliminateGenerics {
         assertNoReachableGenericNewMarkers();
         bindSpecialisedMethodsToTheAllocatedClass();
         settleRemainingDispatches();
+    }
+
+    public boolean hasGenericStatics() {
+        identifyGenericGlobals();
+        return !globalToClass.isEmpty();
     }
 
     /**
@@ -770,6 +776,9 @@ public class EliminateGenerics {
      */
     private boolean functionNeedsSpecialization(ImFunction function, Set<ImFunction> visitedFunctions,
                                                Set<ImMethod> visitedMethods) {
+        if (needsGlobalSpecialization(function)) {
+            return true;
+        }
         if (!visitedFunctions.add(function)) {
             return false;
         }
@@ -988,6 +997,16 @@ public class EliminateGenerics {
         return o != null && !o.isEmpty();
     }
 
+    private boolean classOwnsGenericGlobals(ImClass clazz) {
+        ImClass canonical = translator.canonical(clazz);
+        for (ImClass owner : globalToClass.values()) {
+            if (translator.canonical(owner) == canonical) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private ImFunction enclosingFunction(Element e) {
         Element cur = e;
         while (cur != null) {
@@ -1003,6 +1022,22 @@ public class EliminateGenerics {
         ImFunction f = enclosingFunction(site);
         if (f == null) return;
         ownersOf(f).add(owner);
+    }
+
+    private void indexGenericGlobalUses() {
+        prog.accept(new Element.DefaultVisitor() {
+            @Override
+            public void visit(ImVarAccess access) {
+                recordGenericGlobalUse(access, access.getVar());
+                super.visit(access);
+            }
+
+            @Override
+            public void visit(ImVarArrayAccess access) {
+                recordGenericGlobalUse(access, access.getVar());
+                super.visit(access);
+            }
+        });
     }
 
     private void dbgMethodsByName(String phase) {
@@ -1496,7 +1531,8 @@ public class EliminateGenerics {
             rewriteGenerics(newF, generics, typeVars);
         }
 
-        if (genericNewOnly && specializeTupleValueTypes && genericTypesContainTuple(generics)) {
+        if (genericNewOnly && (needsGlobalSpecialization(f)
+            || (specializeTupleValueTypes && genericTypesContainTuple(generics)))) {
             ImClass owner = classOwning(f);
             if (owner != null && !owner.getTypeVariables().isEmpty()) {
                 GenericTypes ownerGenerics = generics.take(owner.getTypeVariables().size());
@@ -1624,7 +1660,8 @@ public class EliminateGenerics {
         newImplementation.getTypeVariables().removeAll();
         newImplementation.setName(function.getName() + "_specialized");
         rewriteGenerics(newImplementation, generics, typeVariables);
-        if (specializeTupleValueTypes && genericTypesContainTuple(generics)) {
+        if (needsGlobalSpecialization(function)
+            || (specializeTupleValueTypes && genericTypesContainTuple(generics))) {
             GenericTypes ownerGenerics = generics.take(owningClass.getTypeVariables().size());
             specializeClass(owningClass, ownerGenerics);
             rewriteOwnedGenericGlobals(newImplementation, owningClass, ownerGenerics);
@@ -1935,7 +1972,8 @@ public class EliminateGenerics {
 
         // NEW: Create specialized global variables for this class instantiation
         createSpecializedGlobals(c, generics, typeVars);
-        if (specializeTupleValueTypes && genericTypesContainTuple(generics)) {
+        if (genericNewOnly && (classOwnsGenericGlobals(c)
+            || (specializeTupleValueTypes && genericTypesContainTuple(generics)))) {
             rewriteOwnedGenericGlobals(newC, c, generics);
         }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -807,9 +807,10 @@ public class EliminateGenerics {
     /**
      * Whether a function must be specialised even on Lua, which otherwise keeps generics erased.
      * <p>
-     * Two operations need the concrete type argument: constructing a value of it, and dispatching
-     * on a type class bound. Specialising these paths keeps a bounded generic as cheap on Lua as it
-     * is on Jass, at the cost of one copy per instantiation actually used.
+     * Concrete type arguments are needed when constructing a value of them, dispatching on a type
+     * class bound, or constructing a generic class whose static storage is per instantiation.
+     * Specialising these paths keeps a bounded generic as cheap on Lua as it is on Jass, at the cost
+     * of one copy per instantiation actually used.
      */
     private boolean functionNeedsSpecialization(ImFunction function, Set<ImFunction> visitedFunctions,
                                                Set<ImMethod> visitedMethods) {
@@ -849,7 +850,8 @@ public class EliminateGenerics {
 
             @Override
             public void visit(ImFunctionCall call) {
-                if (translator.isGenericNewMarker(call.getFunc())
+                if (constructsClassOwningGenericGlobals(function, call)
+                    || translator.isGenericNewMarker(call.getFunc())
                     || functionNeedsSpecialization(call.getFunc(), visitedFunctions, visitedMethods)) {
                     found[0] = true;
                     return;
@@ -867,6 +869,27 @@ public class EliminateGenerics {
             }
         });
         return found[0];
+    }
+
+    /**
+     * A generic caller containing {@code new Box<T>()} must be revisited after {@code T} becomes
+     * concrete so each constructed instantiation can register its own static storage. Detect the
+     * constructor call at the caller boundary; marking the constructor implementation itself would
+     * unnecessarily redirect ordinary objects away from Lua's erased representation.
+     */
+    private boolean constructsClassOwningGenericGlobals(ImFunction enclosingFunction,
+                                                         ImFunctionCall call) {
+        if (!(call.getFunc().getTrace() instanceof ConstructorDef)) {
+            return false;
+        }
+        // A lowered constructor wrapper calls the class initializer carrying the same source
+        // ConstructorDef. That call implements the current allocation; it is not another generic
+        // allocation hidden inside this function and direct callers register it themselves.
+        if (enclosingFunction.getTrace() == call.getFunc().getTrace()) {
+            return false;
+        }
+        ImClass owner = classOwning(call.getFunc());
+        return owner != null && classOwnsGenericGlobals(owner);
     }
 
     private boolean methodNeedsSpecialization(ImMethod method, Set<ImFunction> visitedFunctions,

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -61,6 +61,8 @@ public class EliminateGenerics {
     // NEW: Track specialized global variables for generic static fields
     // Key: (original generic global var, concrete type instantiation) -> specialized var
     private final Table<ImVar, GenericTypes, ImVar> specializedGlobals = HashBasedTable.create();
+    /** Last specialized initializer emitted for each original initializer, preserving discovery order. */
+    private final Map<ImStmt, ImStmt> specializedInitializerTails = new IdentityHashMap<>();
 
     // NEW: Track which global vars belong to which generic class
     // This helps us know which globals need specialization
@@ -2188,10 +2190,14 @@ public class EliminateGenerics {
                     ImLExpr newLeft = specializeLhs.apply(origSet.getLeft());
                     ImSet specSet = JassIm.ImSet(originalGlobal.attrTrace(), newLeft, rhs);
 
-                    // schedule insertion right after origSet in its parent ImStmts
+                    // Append after earlier specializations of this initializer. Each invocation of
+                    // createSpecializedGlobals has its own insertion batch; always inserting after
+                    // origSet would therefore reverse specialization discovery/initializer order.
+                    ImStmt insertionPoint = specializedInitializerTails.getOrDefault(origSet, origSet);
                     IdentityHashMap<ImStmt, List<ImStmt>> byStmt =
                         insertsByParent.computeIfAbsent(parentStmts, k -> new IdentityHashMap<>());
-                    byStmt.computeIfAbsent(origSet, k -> new ArrayList<>(1)).add(specSet);
+                    byStmt.computeIfAbsent(insertionPoint, k -> new ArrayList<>(1)).add(specSet);
+                    specializedInitializerTails.put(origSet, specSet);
 
                     // keep prog.getGlobalInits consistent, but do NOT reuse the tree-attached node elsewhere
                     specializedInitsForMap.add((ImSet) specSet.copy());

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -481,7 +481,33 @@ public class EliminateGenerics {
         }
         if (call.getTypeArguments().isEmpty()) {
             collectCallThroughGenericReceiver(call);
+        } else if (!typeArgumentsContainTypeVariable(call.getTypeArguments())
+            && !(call.getFunc().getTrace() instanceof ConstructorDef)) {
+            // The generic callee remains erased, so its body is skipped by collectGenericNewRoots.
+            // Fixed concrete allocations inside it still name real per-instantiation statics and
+            // must be registered without cloning the caller for unrelated type arguments.
+            recordFixedErasedStaticAllocations(call.getFunc(),
+                Collections.newSetFromMap(new IdentityHashMap<>()));
         }
+    }
+
+    private void recordFixedErasedStaticAllocations(ImFunction function,
+                                                     Set<ImFunction> visited) {
+        if (!visited.add(function)) {
+            return;
+        }
+        function.accept(new Element.DefaultVisitor() {
+            @Override
+            public void visit(ImFunctionCall nestedCall) {
+                super.visit(nestedCall);
+                recordErasedConstructorAllocation(nestedCall);
+                if (!nestedCall.getTypeArguments().isEmpty()
+                    && !typeArgumentsContainTypeVariable(nestedCall.getTypeArguments())
+                    && !(nestedCall.getFunc().getTrace() instanceof ConstructorDef)) {
+                    recordFixedErasedStaticAllocations(nestedCall.getFunc(), visited);
+                }
+            }
+        });
     }
 
     private void recordErasedConstructorAllocation(ImFunctionCall call) {
@@ -2133,7 +2159,7 @@ public class EliminateGenerics {
                 ImClass owner = globalToClass.get(v);
                 if (owner == null) return;
 
-                GenericTypes g = normalizeToClassArity(generics, owner, "init-rhs");
+                GenericTypes g = adaptGenericsToOwner(owningClass, generics, owner);
                 if (g == null || g.containsTypeVariable()) return;
 
                 ImVar sg = ensureSpecializedGlobal(v, owner, g);
@@ -2146,7 +2172,7 @@ public class EliminateGenerics {
                 ImClass owner = globalToClass.get(v);
                 if (owner == null) return;
 
-                GenericTypes g = normalizeToClassArity(generics, owner, "init-rhs");
+                GenericTypes g = adaptGenericsToOwner(owningClass, generics, owner);
                 if (g == null || g.containsTypeVariable()) return;
 
                 ImVar sg = ensureSpecializedGlobal(v, owner, g);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -465,6 +465,7 @@ public class EliminateGenerics {
             }
             return;
         }
+        recordErasedConstructorAllocation(call);
         if (!call.getTypeArguments().isEmpty()
             && (shouldSpecializeTupleArguments(call.getTypeArguments())
                 || needsRuntimeTypeSpecialization(call)
@@ -476,6 +477,23 @@ public class EliminateGenerics {
         }
         if (call.getTypeArguments().isEmpty()) {
             collectCallThroughGenericReceiver(call);
+        }
+    }
+
+    private void recordErasedConstructorAllocation(ImFunctionCall call) {
+        if (call.getTypeArguments().isEmpty()
+            || typeArgumentsContainTypeVariable(call.getTypeArguments())
+            || !(call.getFunc().getTrace() instanceof ConstructorDef)
+            || !(call.getFunc().getReturnType() instanceof ImClassType)
+            || shouldSpecializeTupleArguments(call.getTypeArguments())
+            || needsRuntimeTypeSpecialization(call)) {
+            return;
+        }
+        ImClass owner = classOwning(call.getFunc());
+        if (owner != null && classOwnsGenericGlobals(owner)
+            && !functionNeedsSpecialization(call.getFunc(),
+            Collections.newSetFromMap(new IdentityHashMap<>()))) {
+            translator.recordErasedGenericAllocation(owner, call.getTypeArguments());
         }
     }
 
@@ -571,10 +589,15 @@ public class EliminateGenerics {
     private void collectGenericNewUse(ImAlloc alloc) {
         ImClassType clazz = alloc.getClazz();
         if (clazz.getTypeArguments().isEmpty()
-            || typeArgumentsContainTypeVariable(clazz.getTypeArguments())
-            || (!shouldSpecializeTupleArguments(clazz.getTypeArguments())
-                && !needsRuntimeTypeSpecialization(clazz)
-                && !isConstructionOnlyInstantiation(clazz.getClassDef()))) {
+            || typeArgumentsContainTypeVariable(clazz.getTypeArguments())) {
+            return;
+        }
+        if (!shouldSpecializeTupleArguments(clazz.getTypeArguments())
+            && !needsRuntimeTypeSpecialization(clazz)
+            && !isConstructionOnlyInstantiation(clazz.getClassDef())) {
+            if (classOwnsGenericGlobals(clazz.getClassDef())) {
+                translator.recordErasedGenericAllocation(clazz.getClassDef(), clazz.getTypeArguments());
+            }
             return;
         }
         genericsUses.add(new GenericClazzUse(alloc));

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -881,10 +881,14 @@ public class EliminateGenerics {
 
             @Override
             public void visit(ImFunctionCall call) {
-                boolean dependsOnTypeVariable = typeArgumentsContainTypeVariable(call.getTypeArguments());
+                // Empty arguments may be supplied implicitly by the enclosing generic receiver.
+                // Only an explicit, already-concrete call is independent of the caller context.
+                boolean dependsOnCaller = call.getTypeArguments().isEmpty()
+                    || typeArgumentsContainTypeVariable(call.getTypeArguments());
                 if (constructsClassOwningGenericGlobals(function, call)
-                    || (dependsOnTypeVariable && (translator.isGenericNewMarker(call.getFunc())
-                    || functionNeedsSpecialization(call.getFunc(), visitedFunctions, visitedMethods)))) {
+                    || translator.isGenericNewMarker(call.getFunc())
+                    || (dependsOnCaller
+                    && functionNeedsSpecialization(call.getFunc(), visitedFunctions, visitedMethods))) {
                     found[0] = true;
                     return;
                 }
@@ -893,7 +897,9 @@ public class EliminateGenerics {
 
             @Override
             public void visit(ImMethodCall call) {
-                if (typeArgumentsContainTypeVariable(call.getTypeArguments())
+                boolean dependsOnCaller = call.getTypeArguments().isEmpty()
+                    || typeArgumentsContainTypeVariable(call.getTypeArguments());
+                if (dependsOnCaller
                     && methodNeedsSpecialization(call.getMethod(), visitedFunctions, visitedMethods)) {
                     found[0] = true;
                     return;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -879,7 +879,8 @@ public class EliminateGenerics {
      */
     private boolean constructsClassOwningGenericGlobals(ImFunction enclosingFunction,
                                                          ImFunctionCall call) {
-        if (!(call.getFunc().getTrace() instanceof ConstructorDef)) {
+        if (!(call.getFunc().getTrace() instanceof ConstructorDef)
+            || !typeArgumentsContainTypeVariable(call.getTypeArguments())) {
             return false;
         }
         // A lowered constructor wrapper calls the class initializer carrying the same source
@@ -1058,9 +1059,22 @@ public class EliminateGenerics {
     }
 
     private boolean classOwnsGenericGlobals(ImClass clazz) {
+        return classOwnsGenericGlobals(clazz,
+            Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    private boolean classOwnsGenericGlobals(ImClass clazz, Set<ImClass> visited) {
+        if (!visited.add(clazz)) {
+            return false;
+        }
         ImClass canonical = translator.canonical(clazz);
         for (ImClass owner : globalToClass.values()) {
             if (translator.canonical(owner) == canonical) {
+                return true;
+            }
+        }
+        for (ImClassType superClass : clazz.getSuperClasses()) {
+            if (classOwnsGenericGlobals(superClass.getClassDef(), visited)) {
                 return true;
             }
         }
@@ -1630,14 +1644,37 @@ public class EliminateGenerics {
 
             private ImVar specializedGlobal(ImVar original) {
                 ImClass globalOwner = globalToClass.get(original);
-                if (globalOwner == null
-                    || translator.canonical(globalOwner) != translator.canonical(owner)) {
+                if (globalOwner == null) {
                     return original;
                 }
-                ImVar result = ensureSpecializedGlobal(original, globalOwner, ownerGenerics);
+                GenericTypes globalGenerics = adaptGenericsToOwner(owner, ownerGenerics, globalOwner);
+                if (globalGenerics == null) {
+                    return original;
+                }
+                ImVar result = ensureSpecializedGlobal(original, globalOwner, globalGenerics);
                 return result == null ? original : result;
             }
         });
+    }
+
+    /** Maps a concrete subclass instantiation onto the type arguments of a static's declaring class. */
+    private @Nullable GenericTypes adaptGenericsToOwner(ImClass concreteOwner,
+                                                        GenericTypes concreteGenerics,
+                                                        ImClass declaringOwner) {
+        if (translator.canonical(concreteOwner) == translator.canonical(declaringOwner)) {
+            return concreteGenerics;
+        }
+        ImTypeArguments arguments = JassIm.ImTypeArguments();
+        for (ImTypeArgument argument : concreteGenerics.getTypeArguments()) {
+            arguments.add(argument.copy());
+        }
+        ImClassType adapted = adaptToSuperclass(
+            JassIm.ImClassType(concreteOwner, arguments), declaringOwner);
+        if (adapted == null || adapted.getTypeArguments().size() != declaringOwner.getTypeVariables().size()
+            || typeArgumentsContainTypeVariable(adapted.getTypeArguments())) {
+            return null;
+        }
+        return new GenericTypes(adapted.getTypeArguments());
     }
 
     /**

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -40,6 +40,8 @@ public class EliminateGenerics {
      * has them re-derived from its receiver, which would collect and specialise it again forever.
      */
     private final Set<Element> specializedCallSites = Collections.newSetFromMap(new IdentityHashMap<>());
+    private final Set<Element> recordedErasedStaticAllocations =
+        Collections.newSetFromMap(new IdentityHashMap<>());
     private final Table<ImFunction, GenericTypes, ImFunction> specializedFunctions = HashBasedTable.create();
     /** The class each function was moved out of, for calls which name their target without a receiver. */
     private final Map<ImFunction, ImClass> functionOwners = new IdentityHashMap<>();
@@ -493,8 +495,18 @@ public class EliminateGenerics {
         if (owner != null && classOwnsGenericGlobals(owner)
             && !functionNeedsSpecialization(call.getFunc(),
             Collections.newSetFromMap(new IdentityHashMap<>()))) {
-            translator.recordErasedGenericAllocation(owner, call.getTypeArguments());
+            recordErasedStaticInstantiation(call, owner, call.getTypeArguments());
         }
+    }
+
+    private void recordErasedStaticInstantiation(Element site, ImClass owner,
+                                                  List<ImTypeArgument> typeArguments) {
+        if (!recordedErasedStaticAllocations.add(site)) {
+            return;
+        }
+        GenericTypes generics = new GenericTypes(typeArguments);
+        translator.recordErasedGenericAllocation(owner, typeArguments);
+        genericsUses.add(() -> specializeClass(owner, generics));
     }
 
     /**
@@ -596,7 +608,7 @@ public class EliminateGenerics {
             && !needsRuntimeTypeSpecialization(clazz)
             && !isConstructionOnlyInstantiation(clazz.getClassDef())) {
             if (classOwnsGenericGlobals(clazz.getClassDef())) {
-                translator.recordErasedGenericAllocation(clazz.getClassDef(), clazz.getTypeArguments());
+                recordErasedStaticInstantiation(alloc, clazz.getClassDef(), clazz.getTypeArguments());
             }
             return;
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/GenericTypes.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/GenericTypes.java
@@ -1,6 +1,5 @@
 package de.peeeq.wurstscript.translation.imtranslation;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import de.peeeq.wurstscript.jassIm.*;
 
@@ -16,9 +15,6 @@ class GenericTypes {
 
 
     public GenericTypes(List<ImTypeArgument> typeArguments) {
-        for (ImTypeArgument ta : typeArguments) {
-            Preconditions.checkArgument(!EliminateGenerics.isGenericType(ta.getType()), "Type arguments must not be generic: " + typeArguments);
-        }
         this.typeArguments = ImmutableList.copyOf(typeArguments);
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/GenericTypes.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/GenericTypes.java
@@ -32,7 +32,7 @@ class GenericTypes {
             for (int i = 0; i < typeArguments.size(); i++) {
                 ImTypeArgument t1 = typeArguments.get(i);
                 ImTypeArgument t2 = ot.typeArguments.get(i);
-                if (!t1.getType().equalsType(t2.getType())) {
+                if (!equalTypeIgnoringBindings(t1.getType(), t2.getType())) {
                     return false;
                 }
                 // Deliberately not comparing the type class binding. It is only a fast path for
@@ -44,6 +44,60 @@ class GenericTypes {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Type-class bindings are dispatch metadata, not part of a specialization's structural type.
+     * Unlike the general IM type equality operation, this comparison therefore ignores bindings
+     * on every nested class-type argument, not just on the arguments wrapped by this key.
+     */
+    private static boolean equalTypeIgnoringBindings(ImType left, ImType right) {
+        if (left instanceof ImArrayType) {
+            return right instanceof ImArrayType
+                && equalTypeIgnoringBindings(((ImArrayType) left).getEntryType(),
+                ((ImArrayType) right).getEntryType());
+        }
+        if (left instanceof ImArrayTypeMulti) {
+            return right instanceof ImArrayTypeMulti
+                && equalTypeIgnoringBindings(((ImArrayTypeMulti) left).getEntryType(),
+                ((ImArrayTypeMulti) right).getEntryType());
+        }
+        if (left instanceof ImTupleType) {
+            if (!(right instanceof ImTupleType)) {
+                return false;
+            }
+            ImTupleType leftTuple = (ImTupleType) left;
+            ImTupleType rightTuple = (ImTupleType) right;
+            if (leftTuple.getTypes().size() != rightTuple.getTypes().size()) {
+                return false;
+            }
+            for (int i = 0; i < leftTuple.getTypes().size(); i++) {
+                if (!equalTypeIgnoringBindings(leftTuple.getTypes().get(i),
+                    rightTuple.getTypes().get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (left instanceof ImClassType) {
+            if (!(right instanceof ImClassType)) {
+                return false;
+            }
+            ImClassType leftClass = (ImClassType) left;
+            ImClassType rightClass = (ImClassType) right;
+            if (leftClass.getClassDef() != rightClass.getClassDef()
+                || leftClass.getTypeArguments().size() != rightClass.getTypeArguments().size()) {
+                return false;
+            }
+            for (int i = 0; i < leftClass.getTypeArguments().size(); i++) {
+                if (!equalTypeIgnoringBindings(leftClass.getTypeArguments().get(i).getType(),
+                    rightClass.getTypeArguments().get(i).getType())) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return left.equalsType(right);
     }
 
     @Override

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
@@ -61,6 +61,7 @@ public class ImTranslator implements SpecialisationLookup {
     }
 
     private final Map<Element, Specialisation> specialisations = new IdentityHashMap<>();
+    private final Map<ImClass, Set<GenericTypes>> erasedGenericAllocations = new IdentityHashMap<>();
 
     /**
      * @param typeArguments the arguments the copy was made for, empty when a copy carries none of its
@@ -97,6 +98,31 @@ public class ImTranslator implements SpecialisationLookup {
     /** What {@code copy} was made from and for, or null when it is not a copy. */
     public @Nullable Specialisation specialisationOf(Element copy) {
         return specialisations.get(copy);
+    }
+
+    public void recordErasedGenericAllocation(ImClass clazz, List<ImTypeArgument> typeArguments) {
+        erasedGenericAllocations.computeIfAbsent(canonical(clazz), ignored -> new HashSet<>())
+            .add(new GenericTypes(typeArguments));
+    }
+
+    public boolean hasErasedAllocationWithoutStaticSpecialization(ImClass clazz, ImVar originalStatic) {
+        Set<GenericTypes> allocations = erasedGenericAllocations.get(canonical(clazz));
+        if (allocations == null || allocations.isEmpty()) {
+            return false;
+        }
+        Set<GenericTypes> specializedStatics = new HashSet<>();
+        for (Map.Entry<Element, Specialisation> entry : specialisations.entrySet()) {
+            Specialisation specialization = entry.getValue();
+            if (specialization.original() == originalStatic) {
+                specializedStatics.add(new GenericTypes(specialization.typeArguments()));
+            }
+        }
+        for (GenericTypes allocation : allocations) {
+            if (!specializedStatics.contains(allocation)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
@@ -190,7 +190,9 @@ public class RemoveGarbage {
             changed = false;
             for (ImVar original : candidates.keySet()) {
                 ImClass owner = translator.genericStaticOwnerOf(original);
-                if ((used.getVars().contains(original) || used.getInstantiatedClasses().contains(owner))
+                boolean erasedInstantiationNeedsOriginal = used.getInstantiatedClasses().contains(owner)
+                    && translator.hasErasedAllocationWithoutStaticSpecialization(owner, original);
+                if ((used.getVars().contains(original) || erasedInstantiationNeedsOriginal)
                     && liveOriginals.add(original)) {
                     changed = true;
                 }

--- a/de.peeeq.wurstscript/src/test/java/de/peeeq/wurstscript/translation/imtranslation/GenericTypesTests.java
+++ b/de.peeeq.wurstscript/src/test/java/de/peeeq/wurstscript/translation/imtranslation/GenericTypesTests.java
@@ -1,0 +1,64 @@
+package de.peeeq.wurstscript.translation.imtranslation;
+
+import de.peeeq.wurstscript.ast.Ast;
+import de.peeeq.wurstscript.jassIm.ImClass;
+import de.peeeq.wurstscript.jassIm.ImClassType;
+import de.peeeq.wurstscript.jassIm.ImFunction;
+import de.peeeq.wurstscript.jassIm.ImMethod;
+import de.peeeq.wurstscript.jassIm.ImSimpleType;
+import de.peeeq.wurstscript.jassIm.ImTypeArgument;
+import de.peeeq.wurstscript.jassIm.ImTypeClassFunc;
+import de.peeeq.wurstscript.jassIm.JassIm;
+import io.vavr.control.Either;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class GenericTypesTests {
+
+    @Test
+    public void nestedTypeClassBindingsDoNotSplitSpecializationKeys() {
+        ImClass box = genericClass("Box");
+        ImClass list = genericClass("List");
+        ImSimpleType integer = JassIm.ImSimpleType("integer");
+        ImTypeClassFunc requirement = JassIm.ImTypeClassFunc(Ast.NoExpr(), "toIndex",
+            JassIm.ImTypeVars(), JassIm.ImVars(), integer);
+        ImFunction instance = JassIm.ImFunction(Ast.NoExpr(), "intToIndex", JassIm.ImTypeVars(),
+            JassIm.ImVars(), integer, JassIm.ImVars(), JassIm.ImStmts(), List.of());
+
+        Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> binding = new LinkedHashMap<>();
+        binding.put(requirement, Either.right(instance));
+        ImClassType unboundBox = JassIm.ImClassType(box,
+            JassIm.ImTypeArguments(argument(integer, Collections.emptyMap())));
+        ImClassType boundBox = JassIm.ImClassType(box,
+            JassIm.ImTypeArguments(argument(integer, binding)));
+
+        GenericTypes unbound = key(list, unboundBox);
+        GenericTypes bound = key(list, boundBox);
+
+        assertEquals(bound, unbound,
+            "type-class dispatch metadata must not change a structural specialization key");
+        assertEquals(bound.hashCode(), unbound.hashCode());
+    }
+
+    private static GenericTypes key(ImClass list, ImClassType nestedType) {
+        ImClassType listType = JassIm.ImClassType(list,
+            JassIm.ImTypeArguments(argument(nestedType, Collections.emptyMap())));
+        return new GenericTypes(List.of(argument(listType, Collections.emptyMap())));
+    }
+
+    private static ImTypeArgument argument(de.peeeq.wurstscript.jassIm.ImType type,
+                                           Map<ImTypeClassFunc, Either<ImMethod, ImFunction>> binding) {
+        return JassIm.ImTypeArgument(type, binding);
+    }
+
+    private static ImClass genericClass(String name) {
+        return JassIm.ImClass(Ast.NoExpr(), name, JassIm.ImTypeVars(JassIm.ImTypeVar("T")),
+            JassIm.ImVars(), JassIm.ImMethods(), JassIm.ImFunctions(), List.of());
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -884,7 +884,7 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             "    static function get() returns int",
             "        return value",
             "init",
-            "    if Box<int>.get() + Box<pair>.get() == 3 and Box<int>.get() != Box<pair>.get() and bumps == 2",
+            "    if Box<int>.get() == 1 and Box<pair>.get() == 2 and bumps == 2",
             "        testSuccess()"
         );
     }
@@ -902,10 +902,12 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             "class Box<T:>",
             "    static int value = bump()",
             "    construct()",
+            "    static function get() returns int",
+            "        return value",
             "init",
             "    new Box<int>()",
             "    new Box<pair>()",
-            "    if bumps == 2",
+            "    if Box<int>.get() == 1 and Box<pair>.get() == 2 and bumps == 2",
             "        testSuccess()"
         );
     }
@@ -1046,7 +1048,7 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             "init",
             "    new Box<string>()",
             "    new Box<real>()",
-            "    if Box<int>.get() >= 1 and bumps == 3",
+            "    if Box<string>.get() == 1 and Box<real>.get() == 2 and Box<int>.get() == 3 and bumps == 3",
             "        testSuccess()"
         );
     }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -870,7 +870,7 @@ public class LuaBackendAuditTests extends WurstScriptTest {
     }
 
     @Test
-    public void tupleSpecializedStaticKeepsLiveErasedInitializer() {
+    public void tupleSpecializedStaticKeepsAllLiveInitializers() {
         test().testLua(true).executeProg().lines(
             "package Test",
             "native testSuccess()",
@@ -884,7 +884,7 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             "    static function get() returns int",
             "        return value",
             "init",
-            "    if Box<int>.get() == 1 and Box<pair>.get() == 2 and bumps == 2",
+            "    if Box<int>.get() + Box<pair>.get() == 3 and Box<int>.get() != Box<pair>.get() and bumps == 2",
             "        testSuccess()"
         );
     }
@@ -955,11 +955,12 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             "        this.value = value",
             "init",
             "    let nested = new List<List<Item>>()",
-            "    nested.add(new List<Item>())",
-            "    nested.get(0).add(new Item(7))",
+            "    let inner = new List<Item>()",
+            "    nested.add(inner)",
+            "    inner.add(new Item(7))",
             "    let pairs = new List<pair>()",
             "    pairs.add(pair(2, 3))",
-            "    if nested.get(0).get(0).value == 7 and pairs.get(0).x == 2",
+            "    if nested.get(0) == inner and inner.get(0).value == 7 and pairs.get(0).x == 2",
             "        testSuccess()"
         );
 
@@ -971,10 +972,40 @@ public class LuaBackendAuditTests extends WurstScriptTest {
         while (storageDeclarations.find()) {
             storageNames.add(storageDeclarations.group(1));
         }
-        assertEquals("one erased class-like and one tuple-specialized storage slot are expected",
-            2, storageNames.size());
+        assertEquals("each concrete List instantiation needs independent static storage",
+            3, storageNames.size());
         assertEquals("each structural List specialization must emit one storage slot",
-            2L, storageNames.stream().distinct().count());
+            3L, storageNames.stream().distinct().count());
+    }
+
+    @Test
+    public void genericStaticsAreIndependentWithoutTupleInstantiation() throws IOException {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "class Slot<T:>",
+            "    static T value",
+            "    static function set(T newValue)",
+            "        value = newValue",
+            "    static function get() returns T",
+            "        return value",
+            "init",
+            "    Slot<int>.set(7)",
+            "    Slot<string>.set(\"ok\")",
+            "    if Slot<int>.get() == 7 and Slot<string>.get() == \"ok\"",
+            "        testSuccess()"
+        );
+
+        String compiled = compiledLua("genericStaticsAreIndependentWithoutTupleInstantiation");
+        java.util.regex.Matcher storageDeclarations = java.util.regex.Pattern
+            .compile("(?m)^Slot_value_\\S* = nil$")
+            .matcher(compiled);
+        int storages = 0;
+        while (storageDeclarations.find()) {
+            storages++;
+        }
+        assertEquals("each concrete Slot instantiation needs its own static",
+            2, storages);
     }
 
     @Test
@@ -1216,7 +1247,9 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             .matcher(compiled);
         int persistedAssignments = 0;
         while (replayBody.find()) {
-            int assignmentsInFunction = countOccurrences(replayBody.group(1), "Box_store[");
+            int assignmentsInFunction = (int) java.util.regex.Pattern
+                .compile("Box_store[^\\[]*\\[")
+                .matcher(replayBody.group(1)).results().count();
             assertTrue("each generic replay leaf must honor the configured split limit:\n" + replayBody.group(),
                 assignmentsInFunction <= 1);
             persistedAssignments += assignmentsInFunction;

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -935,7 +935,7 @@ public class LuaBackendAuditTests extends WurstScriptTest {
     }
 
     @Test
-    public void nestedConcreteGenericStaticStorageCompilesInLua() {
+    public void nestedConcreteGenericStaticStorageCompilesInLua() throws IOException {
         test().testLua(true).executeProg().lines(
             "package Test",
             "native testSuccess()",
@@ -962,6 +962,19 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             "    if nested.get(0).get(0).value == 7 and pairs.get(0).x == 2",
             "        testSuccess()"
         );
+
+        String compiled = compiledLua("nestedConcreteGenericStaticStorageCompilesInLua");
+        java.util.regex.Matcher storageDeclarations = java.util.regex.Pattern
+            .compile("(?m)^(List_store\\S*) = nil$")
+            .matcher(compiled);
+        List<String> storageNames = new ArrayList<>();
+        while (storageDeclarations.find()) {
+            storageNames.add(storageDeclarations.group(1));
+        }
+        assertEquals("one erased class-like and one tuple-specialized storage slot are expected",
+            2, storageNames.size());
+        assertEquals("each structural List specialization must emit one storage slot",
+            2L, storageNames.stream().distinct().count());
     }
 
     @Test

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -1054,6 +1054,46 @@ public class LuaBackendAuditTests extends WurstScriptTest {
     }
 
     @Test
+    public void genericFactoryAllocationSpecializesStaticOwningClass() throws IOException {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "int bumps",
+            "function bump() returns int",
+            "    bumps++",
+            "    return bumps",
+            "class Box<T:>",
+            "    static int value = bump()",
+            "    construct()",
+            "    static function get() returns int",
+            "        return value",
+            "function make<T:>() returns Box<T>",
+            "    return new Box<T>()",
+            "function forward<T:>() returns Box<T>",
+            "    return make<T>()",
+            "class Maker<T:>",
+            "    construct()",
+            "    function makeBox() returns Box<T>",
+            "        return new Box<T>()",
+            "init",
+            "    let first = forward<int>()",
+            "    let second = forward<string>()",
+            "    let third = new Maker<real>().makeBox()",
+            "    if first != null and second != null and third != null",
+            "        and Box<int>.get() == 1 and Box<string>.get() == 2",
+            "        and Box<real>.get() == 3 and bumps == 3",
+            "        testSuccess()"
+        );
+
+        String compiled = compiledLua("genericFactoryAllocationSpecializesStaticOwningClass");
+        assertEquals("the shared constructor must allocate ordinary objects on the erased Lua class",
+            1, countOccurrences(compiled, "= Box:create()"));
+        assertFalse("static specialization must not create specialized object classes",
+            java.util.regex.Pattern.compile("(?m)^Box_specialized\\S* = \\(\\{\\}\\)$")
+                .matcher(compiled).find());
+    }
+
+    @Test
     public void randomizedNestedGenericTupleClassShapesMatchAllBackends() {
         record Shape(String type, String value, int constructions) {}
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -1009,6 +1009,27 @@ public class LuaBackendAuditTests extends WurstScriptTest {
     }
 
     @Test
+    public void constructedErasedInstantiationDoesNotDuplicateSpecializedStaticInitializer() {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "int bumps",
+            "function bump() returns int",
+            "    bumps++",
+            "    return bumps",
+            "class Box<T:>",
+            "    static int value = bump()",
+            "    construct()",
+            "    static function get() returns int",
+            "        return value",
+            "init",
+            "    new Box<int>()",
+            "    if Box<int>.get() == 1 and bumps == 1",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
     public void randomizedNestedGenericTupleClassShapesMatchAllBackends() {
         record Shape(String type, String value, int constructions) {}
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -1094,6 +1094,85 @@ public class LuaBackendAuditTests extends WurstScriptTest {
     }
 
     @Test
+    public void inheritedGenericStaticUsesDeclaringOwnerSpecialization() throws IOException {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "class Base<T:>",
+            "    static T value",
+            "class Child<Unused:, T:> extends Base<T>",
+            "    construct()",
+            "    function set(T newValue)",
+            "        value = newValue",
+            "    function get() returns T",
+            "        return value",
+            "init",
+            "    let ints = new Child<real, int>()",
+            "    let strings = new Child<int, string>()",
+            "    ints.set(7)",
+            "    strings.set(\"ok\")",
+            "    if ints.get() == 7 and strings.get() == \"ok\"",
+            "        testSuccess()"
+        );
+
+        String compiled = compiledLua("inheritedGenericStaticUsesDeclaringOwnerSpecialization");
+        java.util.regex.Matcher declarations = java.util.regex.Pattern
+            .compile("(?m)^Base_value_\\S* = nil$").matcher(compiled);
+        int storages = 0;
+        while (declarations.find()) {
+            storages++;
+        }
+        assertEquals("each inherited Base<T> static needs independent storage", 2, storages);
+    }
+
+    @Test
+    public void constructedSubclassInitializesInheritedGenericStatic() {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "int bumps",
+            "function bump() returns int",
+            "    bumps++",
+            "    return bumps",
+            "class Base<T:>",
+            "    static int value = bump()",
+            "class Child<T:> extends Base<T>",
+            "    construct()",
+            "init",
+            "    new Child<int>()",
+            "    new Child<string>()",
+            "    if bumps == 2",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
+    public void fixedConcreteConstructionDoesNotSpecializeUnrelatedGenericCaller() throws IOException {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "int bumps",
+            "function bump() returns int",
+            "    bumps++",
+            "    return bumps",
+            "class Box<T:>",
+            "    static int value = bump()",
+            "    construct()",
+            "function helper<T:>() returns Box<int>",
+            "    return new Box<int>()",
+            "init",
+            "    let first = helper<string>()",
+            "    let second = helper<real>()",
+            "    if first != null and second != null and bumps == 1",
+            "        testSuccess()"
+        );
+
+        String compiled = compiledLua("fixedConcreteConstructionDoesNotSpecializeUnrelatedGenericCaller");
+        assertFalse("fixed Box<int> construction must not clone helper<T>",
+            compiled.contains("helper_specialized"));
+    }
+
+    @Test
     public void randomizedNestedGenericTupleClassShapesMatchAllBackends() {
         record Shape(String type, String value, int constructions) {}
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -1197,6 +1197,63 @@ public class LuaBackendAuditTests extends WurstScriptTest {
     }
 
     @Test
+    public void fixedAllocationInsideErasedGenericMethodIsRegistered() throws IOException {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "int bumps",
+            "function bump() returns int",
+            "    bumps++",
+            "    return bumps",
+            "class Box<T:>",
+            "    static int value = bump()",
+            "    construct()",
+            "    static function get() returns int",
+            "        return value",
+            "class Factory<T:>",
+            "    construct()",
+            "    function make() returns Box<int>",
+            "        return new Box<int>()",
+            "init",
+            "    let factory = new Factory<real>()",
+            "    let made = factory.make()",
+            "    let fresh = new Factory<string>().make()",
+            "    if made != null and fresh != null and Box<string>.get() == 2 and bumps == 2",
+            "        testSuccess()"
+        );
+
+        String compiled = compiledLua("fixedAllocationInsideErasedGenericMethodIsRegistered");
+        assertFalse("fixed generic method body must not be cloned for its class argument",
+            compiled.contains("Factory_make_specialized"));
+    }
+
+    @Test
+    public void fixedStaticCalleeDoesNotSpecializeUnrelatedGenericCaller() throws IOException {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "int bumps",
+            "function bump() returns int",
+            "    bumps++",
+            "    return bumps",
+            "class Box<T:>",
+            "    static int value = bump()",
+            "    static function get() returns int",
+            "        return value",
+            "function helper<T:>() returns int",
+            "    return Box<int>.get()",
+            "init",
+            "    if helper<string>() == 1 and helper<real>() == 1",
+            "        and Box<string>.get() == 2 and bumps == 2",
+            "        testSuccess()"
+        );
+
+        String compiled = compiledLua("fixedStaticCalleeDoesNotSpecializeUnrelatedGenericCaller");
+        assertFalse("fixed Box<int> static call must not clone helper<T>",
+            compiled.contains("helper_specialized"));
+    }
+
+    @Test
     public void randomizedNestedGenericTupleClassShapesMatchAllBackends() {
         record Shape(String type, String value, int constructions) {}
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -1158,18 +1158,42 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             "class Box<T:>",
             "    static int value = bump()",
             "    construct()",
+            "    static function get() returns int",
+            "        return value",
             "function helper<T:>() returns Box<int>",
             "    return new Box<int>()",
             "init",
             "    let first = helper<string>()",
             "    let second = helper<real>()",
-            "    if first != null and second != null and bumps == 1",
+            "    if first != null and second != null and Box<string>.get() == 2 and bumps == 2",
             "        testSuccess()"
         );
 
         String compiled = compiledLua("fixedConcreteConstructionDoesNotSpecializeUnrelatedGenericCaller");
         assertFalse("fixed Box<int> construction must not clone helper<T>",
             compiled.contains("helper_specialized"));
+    }
+
+    @Test
+    public void inheritedGenericStaticInitializerUsesDeclaringOwnerMapping() {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "int bumps",
+            "function bump() returns int",
+            "    bumps++",
+            "    return bumps",
+            "class Base<T:>",
+            "    static int serial = bump()",
+            "class Child<Unused:, T:> extends Base<T>",
+            "    static int copied = serial",
+            "    static function get() returns int",
+            "        return copied",
+            "init",
+            "    if Child<real, int>.get() == 1 and Child<int, string>.get() == 2",
+            "        and bumps == 2",
+            "        testSuccess()"
+        );
     }
 
     @Test

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -1030,6 +1030,28 @@ public class LuaBackendAuditTests extends WurstScriptTest {
     }
 
     @Test
+    public void eachConstructedErasedInstantiationGetsItsOwnStaticInitializer() {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "int bumps",
+            "function bump() returns int",
+            "    bumps++",
+            "    return bumps",
+            "class Box<T:>",
+            "    static int value = bump()",
+            "    construct()",
+            "    static function get() returns int",
+            "        return value",
+            "init",
+            "    new Box<string>()",
+            "    new Box<real>()",
+            "    if Box<int>.get() >= 1 and bumps == 3",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
     public void randomizedNestedGenericTupleClassShapesMatchAllBackends() {
         record Shape(String type, String value, int constructions) {}
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -935,6 +935,222 @@ public class LuaBackendAuditTests extends WurstScriptTest {
     }
 
     @Test
+    public void nestedConcreteGenericStaticStorageCompilesInLua() {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "tuple pair(int x, int y)",
+            "class List<T:>",
+            "    static T array store",
+            "    int size",
+            "    construct()",
+            "    function add(T value)",
+            "        store[size] = value",
+            "        size++",
+            "    function get(int index) returns T",
+            "        return store[index]",
+            "class Item",
+            "    int value",
+            "    construct(int value)",
+            "        this.value = value",
+            "init",
+            "    let nested = new List<List<Item>>()",
+            "    nested.add(new List<Item>())",
+            "    nested.get(0).add(new Item(7))",
+            "    let pairs = new List<pair>()",
+            "    pairs.add(pair(2, 3))",
+            "    if nested.get(0).get(0).value == 7 and pairs.get(0).x == 2",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
+    public void randomizedNestedGenericTupleClassShapesMatchAllBackends() {
+        record Shape(String type, String value, int constructions) {}
+
+        Random random = new Random(0x6E3571A9L);
+        List<String> declarations = new ArrayList<>();
+        List<Shape> shapes = new ArrayList<>();
+        for (int i = 0; i < 18; i++) {
+            int first = random.nextInt(17) + 1;
+            int second = random.nextInt(17) + 1;
+            Shape shape = i % 2 == 0
+                ? new Shape("int", Integer.toString(first), 0)
+                : new Shape("pair", "pair(" + first + ", " + second + ")",
+                    0);
+            int depth = 2 + random.nextInt(3);
+            for (int d = 0; d < depth; d++) {
+                switch ((i + d + random.nextInt(3)) % 3) {
+                    case 0 -> shape = new Shape("Box<" + shape.type() + ">",
+                        "new Box<" + shape.type() + ">(" + shape.value() + ")",
+                        shape.constructions() + 1);
+                    case 1 -> shape = new Shape("Child<" + shape.type() + ">",
+                        "new Child<" + shape.type() + ">(" + shape.value() + ")",
+                        shape.constructions() + 1);
+                    case 2 -> {
+                        String tupleName = "Wrapped" + i + "_" + d;
+                        int tag = random.nextInt(11) + 1;
+                        declarations.add("tuple " + tupleName + "(" + shape.type()
+                            + " value, int tag)");
+                        shape = new Shape(tupleName,
+                            tupleName + "(" + shape.value() + ", " + tag + ")",
+                            shape.constructions());
+                    }
+                }
+            }
+            shapes.add(shape);
+        }
+
+        List<String> source = new ArrayList<>();
+        source.add("package Test");
+        source.add("native testSuccess()");
+        source.add("tuple pair(int x, int y)");
+        source.add("int constructions");
+        source.add("int writes");
+        source.add("interface Marker<T:>");
+        source.add("class Box<T:> implements Marker<T>");
+        source.add("    T value");
+        source.add("    construct(T value)");
+        source.add("        this.value = value");
+        source.add("        constructions++");
+        source.add("class Child<T:> extends Box<T>");
+        source.add("    construct(T value)");
+        source.add("        super(value)");
+        source.add("class Vault<T:>");
+        source.add("    static T value");
+        source.add("    static function set(T newValue)");
+        source.add("        value = newValue");
+        source.add("        writes++");
+        source.addAll(declarations);
+        source.add("init");
+        int expectedConstructions = 0;
+        for (Shape shape : shapes) {
+            source.add("    Vault<" + shape.type() + ">.set(" + shape.value() + ")");
+            expectedConstructions += shape.constructions();
+        }
+        source.add("    if writes == " + shapes.size()
+            + " and constructions == " + expectedConstructions);
+        source.add("        testSuccess()");
+
+        test().testLua(true).executeProg().lines(source.toArray(new String[0]));
+    }
+
+    @Test
+    public void randomizedClassInterfaceModuleDispatchMatchesAllBackends() {
+        Random random = new Random(0xD15A7C4L);
+        List<String> source = new ArrayList<>();
+        Collections.addAll(source,
+            "package Test",
+            "native testSuccess()",
+            "int destroyed",
+            "interface Primary",
+            "    function score() returns int",
+            "interface Secondary",
+            "    function bonus() returns int",
+            "module Payload",
+            "    int moduleValue",
+            "    function payload() returns int",
+            "        return moduleValue * 3",
+            "    ondestroy",
+            "        destroyed++",
+            "class Root implements Primary",
+            "    use Payload",
+            "    int base",
+            "    construct(int base)",
+            "        this.base = base",
+            "        moduleValue = base + 1",
+            "    override function score() returns int",
+            "        return base + payload()",
+            "class Alpha extends Root implements Secondary",
+            "    construct(int base)",
+            "        super(base)",
+            "    override function score() returns int",
+            "        return super.score() + 11",
+            "    override function bonus() returns int",
+            "        return base * 5 + 1",
+            "class AlphaLeaf extends Alpha",
+            "    construct(int base)",
+            "        super(base)",
+            "    override function score() returns int",
+            "        return super.score() * 2",
+            "    override function bonus() returns int",
+            "        return super.bonus() + 5",
+            "class Beta extends Root implements Secondary",
+            "    construct(int base)",
+            "        super(base)",
+            "    override function score() returns int",
+            "        return super.score() - 7",
+            "    override function bonus() returns int",
+            "        return base * 7 + 2",
+            "module ScoreContract",
+            "    abstract function score() returns int",
+            "module StandaloneScore",
+            "    use ScoreContract",
+            "    use Payload",
+            "    override function score() returns int",
+            "        return moduleValue * 9 + 4",
+            "class ModuleOnly implements Primary",
+            "    use StandaloneScore",
+            "    construct(int base)",
+            "        moduleValue = base",
+            "function viaPrimary(Primary value) returns int",
+            "    return value.score()",
+            "function viaSecondary(Secondary value) returns int",
+            "    return value.bonus()",
+            "init",
+            "    int checksum = 0");
+
+        int expected = 0;
+        int objectCount = 40;
+        for (int i = 0; i < objectCount; i++) {
+            int value = random.nextInt(30) + 1;
+            int kind = random.nextInt(5);
+            String className;
+            int score;
+            Integer bonus = null;
+            switch (kind) {
+                case 0 -> {
+                    className = "Root";
+                    score = 4 * value + 3;
+                }
+                case 1 -> {
+                    className = "Alpha";
+                    score = 4 * value + 14;
+                    bonus = value * 5 + 1;
+                }
+                case 2 -> {
+                    className = "AlphaLeaf";
+                    score = (4 * value + 14) * 2;
+                    bonus = value * 5 + 6;
+                }
+                case 3 -> {
+                    className = "Beta";
+                    score = 4 * value - 4;
+                    bonus = value * 7 + 2;
+                }
+                default -> {
+                    className = "ModuleOnly";
+                    score = value * 9 + 4;
+                }
+            }
+            source.add("    let object" + i + " = new " + className + "(" + value + ")");
+            source.add("    Primary primary" + i + " = object" + i);
+            source.add("    checksum += viaPrimary(primary" + i + ")");
+            expected += score;
+            if (bonus != null) {
+                source.add("    Secondary secondary" + i + " = object" + i);
+                source.add("    checksum += viaSecondary(secondary" + i + ")");
+                expected += bonus;
+            }
+            source.add("    destroy object" + i);
+        }
+        source.add("    if checksum == " + expected + " and destroyed == " + objectCount);
+        source.add("        testSuccess()");
+
+        test().testLua(true).executeProg().lines(source.toArray(new String[0]));
+    }
+
+    @Test
     public void tupleSpecializedStaticInitializerCycleDoesNotRootErasedCopy() throws IOException {
         test().testLua(true).executeProg().lines(
             "package Test",


### PR DESCRIPTION
## Summary

- allow fully concrete nested generic types in structural specialization keys
- add an exact Lua regression for `List<List<Item>>`-style generic static storage
- add deterministic nested generic/tuple/class and class/interface/module backend parity matrices

## Why

`GenericTypes` rejected every parameterized type argument even though its equality, hashing, naming, and type-variable traversal already handle nested types recursively. This caused a translation-time `Type arguments must not be generic` failure after source typechecking succeeded.

The change removes that obsolete invariant instead of adding a backend or stdlib workaround.

## Verification

- exact regression failed with the reported exception before the fix and passes after it
- `LuaBackendAuditTests`, `GenericsTests`, and `GenericsWithTypeclassesTests` pass together
- exact renamed regression rerun immediately before commit: pass
- tests exercise the normal interpreter/JASS transform configurations and real Lua execution

The full suite was intentionally left to CI.

## Known separate follow-ups

- the intermittent `<source of NoExpr not found>:1: null` diagnostic was recovered from logs as a `StackOverflowError` in compiletime-state partition analysis; it is not reproduced or changed here
- deeper tuple-to-generic-class field-selection fuzzing exposed a separate existing IM attribute-typing crash; this focused fix does not attempt a speculative pass-order repair

## Acceptance criteria

- nested concrete generic specialization keys compile for Lua
- behavior remains aligned across JASS/interpreter and Lua execution
- generated specialization remains deterministic for fixed inputs
