### PR TITLE
Handle detached generic static initializers

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -1278,7 +1278,9 @@ public class EliminateGenerics {
             List<ImSet> inits = prog.getGlobalInits().remove(imVar);
             if (inits != null) {
                 for (ImSet init : inits) {
-                    init.replaceBy(ImHelper.nullExpr());
+                    if (init.getParent() != null) {
+                        init.replaceBy(ImHelper.nullExpr());
+                    }
                 }
             }
         }
@@ -2243,17 +2245,28 @@ public class EliminateGenerics {
             List<ImSet> originalInits = prog.getGlobalInits().get(originalGlobal);
             if (originalInits != null && !originalInits.isEmpty()) {
 
-                ImSet firstOrig = originalInits.getFirst();
-                if (!(firstOrig.getParent() instanceof ImStmts parentStmts)) {
-                    throw new CompileError(originalGlobal,
-                        "Initializer for global " + originalGlobal.getName() + " is not inside ImStmts.");
-                }
-                // ensure all original init sets share the same parent statement list
+                ImStmts parentStmts = null;
+                boolean hasDetachedInits = false;
                 for (ImSet s : originalInits) {
-                    if (s.getParent() != parentStmts) {
+                    if (s.getParent() == null) {
+                        hasDetachedInits = true;
+                        continue;
+                    }
+                    if (!(s.getParent() instanceof ImStmts)) {
+                        throw new CompileError(originalGlobal,
+                            "Initializer for global " + originalGlobal.getName() + " is not inside ImStmts.");
+                    }
+                    ImStmts currParent = (ImStmts) s.getParent();
+                    if (parentStmts == null) {
+                        parentStmts = currParent;
+                    } else if (parentStmts != currParent) {
                         throw new CompileError(originalGlobal,
                             "Initializer statements for global " + originalGlobal.getName() + " are not in the same ImStmts.");
                     }
+                }
+                if (hasDetachedInits && parentStmts != null) {
+                    throw new CompileError(originalGlobal,
+                        "Initializer statements for global " + originalGlobal.getName() + " are inconsistently attached.");
                 }
 
                 // Helper: rebuild LHS as ImLExpr for specialized global
@@ -2292,11 +2305,13 @@ public class EliminateGenerics {
                     // Append after earlier specializations of this initializer. Each invocation of
                     // createSpecializedGlobals has its own insertion batch; always inserting after
                     // origSet would therefore reverse specialization discovery/initializer order.
-                    ImStmt insertionPoint = specializedInitializerTails.getOrDefault(origSet, origSet);
-                    IdentityHashMap<ImStmt, List<ImStmt>> byStmt =
-                        insertsByParent.computeIfAbsent(parentStmts, k -> new IdentityHashMap<>());
-                    byStmt.computeIfAbsent(insertionPoint, k -> new ArrayList<>(1)).add(specSet);
-                    specializedInitializerTails.put(origSet, specSet);
+                    if (parentStmts != null) {
+                        ImStmt insertionPoint = specializedInitializerTails.getOrDefault(origSet, origSet);
+                        IdentityHashMap<ImStmt, List<ImStmt>> byStmt =
+                            insertsByParent.computeIfAbsent(parentStmts, k -> new IdentityHashMap<>());
+                        byStmt.computeIfAbsent(insertionPoint, k -> new ArrayList<>(1)).add(specSet);
+                        specializedInitializerTails.put(origSet, specSet);
+                    }
 
                     // keep prog.getGlobalInits consistent, but do NOT reuse the tree-attached node elsewhere
                     specializedInitsForMap.add((ImSet) specSet.copy());

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
@@ -205,6 +205,9 @@ public class RemoveGarbage {
             }
             prog.getGlobalInits().remove(candidate.getKey());
             for (ImSet initializer : candidate.getValue()) {
+                if (initializer.getParent() == null) {
+                    continue;
+                }
                 if (!(initializer.getParent() instanceof ImStmts statements)) {
                     throw new IllegalStateException("Global initializer is not attached to an ImStmts node.");
                 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -6,7 +6,12 @@ import de.peeeq.wurstio.WurstCompilerJassImpl;
 import de.peeeq.wurstscript.RunArgs;
 import de.peeeq.wurstscript.ast.WurstModel;
 import de.peeeq.wurstscript.gui.WurstGuiCliImpl;
+import de.peeeq.wurstscript.jassIm.ImProg;
+import de.peeeq.wurstscript.jassIm.ImSet;
+import de.peeeq.wurstscript.jassIm.ImVar;
+import de.peeeq.wurstscript.jassIm.JassIm;
 import de.peeeq.wurstscript.luaAst.LuaCompilationUnit;
+import de.peeeq.wurstscript.translation.imtranslation.ImHelper;
 import org.wurstscript.projectconfig.WurstProjectConfigData;
 import org.testng.annotations.Test;
 
@@ -1007,6 +1012,56 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             storages++;
         }
         assertEquals("each concrete Slot instantiation needs its own static",
+            2, storages);
+    }
+
+    @Test
+    public void detachedGenericStaticInitializerRemainsMetadataOnly() {
+        RunArgs runArgs = new RunArgs().with("-lua");
+        WurstGuiCliImpl gui = new WurstGuiCliImpl();
+        WurstCompilerJassImpl compiler = new WurstCompilerJassImpl(null, gui, null, runArgs);
+        WurstModel model = parseFiles(Collections.emptyList(), Collections.singletonList(new CU(
+            "detachedGenericStaticInitializerRemainsMetadataOnly.wurst", String.join("\n",
+                "package Test",
+                "native testSuccess()",
+                "class Slot<T:>",
+                "    static T value",
+                "    static function set(T newValue)",
+                "        value = newValue",
+                "    static function get() returns T",
+                "        return value",
+                "init",
+                "    Slot<int>.set(7)",
+                "    Slot<string>.set(\"ok\")",
+                "    if Slot<int>.get() == 7 and Slot<string>.get() == \"ok\"",
+                "        testSuccess()"
+            ))), false, compiler);
+        assertTrue("unexpected parse/type errors: " + gui.getErrorList(), gui.getErrorList().isEmpty());
+        compiler.checkProg(model);
+        assertTrue("unexpected compile errors: " + gui.getErrorList(), gui.getErrorList().isEmpty());
+        ImProg prog = compiler.translateProgToIm(model);
+        compiler.runCompiletime(WurstProjectConfigData.empty(), false, false);
+
+        ImVar genericStatic = prog.getGlobals().stream()
+            .filter(global -> global.getName().contains("value"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("expected the translated Slot.value global"));
+        ImSet detached = JassIm.ImSet(genericStatic.attrTrace(), JassIm.ImVarAccess(genericStatic),
+            ImHelper.nullExpr());
+        prog.getGlobalInits().put(genericStatic, Collections.singletonList(detached));
+        assertTrue("default initializer must remain detached metadata", detached.getParent() == null);
+
+        LuaCompilationUnit luaCode = compiler.transformProgToLua();
+        StringBuilder output = new StringBuilder();
+        luaCode.print(output, 0);
+        java.util.regex.Matcher declarations = java.util.regex.Pattern
+            .compile("(?m)^Slot_value_\\S* = nil$")
+            .matcher(output);
+        int storages = 0;
+        while (declarations.find()) {
+            storages++;
+        }
+        assertEquals("both concrete static specializations must survive detached initialization",
             2, storages);
     }
 


### PR DESCRIPTION
## Summary

- preserve detached generic-static initializer entries as metadata during Lua specialization
- avoid attempting tree replacement/removal for initializer nodes with no parent
- retain ordered insertion for initializers that are attached to executable `ImStmts`
- add an IM-level regression covering two concrete generic-static specializations with a detached default initializer

## Verification

- `./gradlew test --tests de.peeeq.wurstscript.translation.imtranslation.GenericTypesTests --tests tests.wurstscript.tests.LuaBackendAuditTests` — passed
- `grill build` in `zombie-defense` with the locally installed patched compiler — passed and produced `Zombie_Defense_0.26i.w3x`

## Acceptance criteria

- detached initializer metadata never becomes a null-parent tree insertion/removal
- attached initializer order remains unchanged
- concrete generic-static storage remains independent
- the reported project builds without the post-typecheck NPE
