### PR TITLE
Exercise generated compiler corpus across JASS and Lua

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
       JAVA_TOOL_OPTIONS: >-
         -XX:+UseCompactObjectHeaders
         -XX:+UseStringDeduplication
+        --enable-native-access=ALL-UNNAMED
       GRADLE_OPTS: -Dorg.gradle.daemon=false
     defaults:
       run:
@@ -119,9 +120,9 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ runner.os }}" == "Linux" ]]; then
-            ./gradlew test jacocoTestReport --no-daemon --stacktrace
+            ./gradlew test jacocoTestReport --no-daemon --stacktrace --quiet
           else
-            ./gradlew test --no-daemon --stacktrace
+            ./gradlew test --no-daemon --stacktrace --quiet
           fi
 
       - name: Upload coverage to Coveralls

--- a/de.peeeq.wurstscript/build.gradle
+++ b/de.peeeq.wurstscript/build.gradle
@@ -298,6 +298,12 @@ tasks.register('ensureStdLib', JavaExec) {
 test {
     dependsOn 'ensureStdLib'
     useTestNG()
+    // Keep CI output focused on failures; compiler/runtime tests intentionally exercise native
+    // print paths and can otherwise flood the log with expected diagnostic output.
+    testLogging {
+        showStandardStreams = false
+        events 'failed', 'skipped'
+    }
 
     // The suite is a few thousand independent compilations and was running one at a time, so it
     // took as long as the sum of them. Forks rather than threads: the harness keeps state in

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/frotty/jassAttributes/package-info.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/frotty/jassAttributes/package-info.java
@@ -1,3 +1,7 @@
+/**
+ * Legacy Jass attribute support.
+ * @deprecated This internal compatibility package is planned for removal.
+ */
 @org.eclipse.jdt.annotation.NonNullByDefault
+@Deprecated
 package de.peeeq.wurstscript.frotty.jassAttributes;
-

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/frotty/jassValidator/package-info.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/frotty/jassValidator/package-info.java
@@ -1,3 +1,7 @@
+/**
+ * Legacy Jass validation support.
+ * @deprecated This internal compatibility package is planned for removal.
+ */
 @org.eclipse.jdt.annotation.NonNullByDefault
+@Deprecated
 package de.peeeq.wurstscript.frotty.jassValidator;
-

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/jurst/package-info.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/jurst/package-info.java
@@ -1,3 +1,7 @@
+/**
+ * Legacy Jurst compatibility frontend. Prefer Wurst source for new code.
+ * @deprecated Jurst is retained only for compatibility and is planned for removal.
+ */
 @org.eclipse.jdt.annotation.NonNullByDefault
+@Deprecated
 package de.peeeq.wurstscript.jurst;
-

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/utils/MapWithIndexes.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/utils/MapWithIndexes.java
@@ -79,7 +79,7 @@ public class MapWithIndexes<K, V> {
         V oldV = base.put(key, value);
         if (oldV != null) {
             for (BiConsumer<K, V> f : onDelete) {
-                f.accept(key, value);
+                f.accept(key, oldV);
             }
         }
         for (BiConsumer<K, V> f : onInserts) {

--- a/de.peeeq.wurstscript/src/test/java/de/peeeq/wurstscript/attributes/ErrorHandlerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/de/peeeq/wurstscript/attributes/ErrorHandlerTests.java
@@ -1,0 +1,50 @@
+package de.peeeq.wurstscript.attributes;
+
+import de.peeeq.wurstscript.gui.WurstGuiCliImpl;
+import de.peeeq.wurstscript.parser.WPos;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class ErrorHandlerTests {
+    @Test
+    public void tracksErrorsWarningsAndPerFileBuckets() {
+        WurstGuiCliImpl gui = new WurstGuiCliImpl();
+        ErrorHandler handler = new ErrorHandler(gui);
+        CompileError error = new CompileError(new WPos("one.wurst", null, 1, 1), "bad");
+        CompileError warning = new CompileError(new WPos("one.wurst", null, 2, 1), "careful",
+            CompileError.ErrorType.WARNING);
+
+        handler.sendError(error);
+        handler.sendError(warning);
+
+        assertEquals(handler.getErrorCount(), 1);
+        assertEquals(handler.getErrors(), java.util.List.of(error));
+        assertEquals(handler.getWarnings(), java.util.List.of(warning));
+        assertEquals(handler.getBucketForFile("one.wurst", CompileError.ErrorType.ERROR), java.util.List.of(error));
+        assertEquals(handler.getBucketForFile("one.wurst", CompileError.ErrorType.WARNING), java.util.List.of(warning));
+        assertEquals(gui.getErrorList().size(), 1);
+
+        handler.removeFromGlobal(error);
+        handler.removeFromGlobal(warning);
+        assertTrue(handler.getErrors().isEmpty());
+        assertTrue(handler.getWarnings().isEmpty());
+        assertEquals(handler.getBucketForFile("one.wurst", CompileError.ErrorType.ERROR), null);
+        assertEquals(handler.getBucketForFile("one.wurst", CompileError.ErrorType.WARNING), null);
+    }
+
+    @Test
+    public void exposesGuiAndUnitTestMode() {
+        WurstGuiCliImpl gui = new WurstGuiCliImpl();
+        ErrorHandler handler = new ErrorHandler(gui);
+
+        assertSame(handler.getGui(), gui);
+        assertFalse(handler.isUnitTestMode());
+        handler.enableUnitTestMode();
+        assertTrue(handler.isUnitTestMode());
+        assertFalse(handler.isOutputTestSource());
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/utils/CoreUtilitiesTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/utils/CoreUtilitiesTests.java
@@ -1,0 +1,62 @@
+package tests.utils;
+
+import de.peeeq.wurstscript.utils.Lazy;
+import de.peeeq.wurstscript.utils.NotNullList;
+import de.peeeq.wurstscript.utils.Pair;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.expectThrows;
+
+public class CoreUtilitiesTests {
+    @Test
+    public void lazySupplierRunsExactlyOnceIncludingNullValues() {
+        AtomicInteger calls = new AtomicInteger();
+        Lazy<String> lazy = Lazy.create(() -> {
+            calls.incrementAndGet();
+            return null;
+        });
+
+        assertEquals(lazy.get(), null);
+        assertEquals(lazy.get(), null);
+        assertEquals(calls.get(), 1);
+    }
+
+    @Test
+    public void notNullListRejectsNullThroughEveryMutationPath() {
+        NotNullList<String> values = new NotNullList<>();
+        values.add("a");
+        values.add(1, "b");
+        values.addAll(List.of("c", "d"));
+        values.addAll(1, List.of("x"));
+        values.set(0, "z");
+        assertEquals(values, List.of("z", "x", "b", "c", "d"));
+
+        expectThrows(IllegalArgumentException.class, () -> values.add(null));
+        expectThrows(IllegalArgumentException.class, () -> values.add(0, null));
+        expectThrows(IllegalArgumentException.class, () -> values.addAll(Arrays.asList("ok", null)));
+        expectThrows(IllegalArgumentException.class, () -> values.addAll(0, Arrays.asList((String) null)));
+        expectThrows(IllegalArgumentException.class, () -> values.set(0, null));
+    }
+
+    @Test
+    public void pairProvidesValueEqualityAndAccessors() {
+        Pair<String, Integer> first = Pair.create("value", 7);
+        Pair<String, Integer> equal = Pair.create("value", 7);
+        Pair<String, Integer> different = Pair.create("other", 7);
+
+        assertEquals(first.getA(), "value");
+        assertEquals(first.getB(), 7);
+        assertEquals(first.toString(), "(value, 7)");
+        assertEquals(first, equal);
+        assertEquals(first.hashCode(), equal.hashCode());
+        assertFalse(first.equals(different));
+        assertEquals(Pair.create(null, 7), Pair.create(null, 7));
+        assertFalse(first.equals("value"));
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/utils/LineOffsetsTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/utils/LineOffsetsTests.java
@@ -1,0 +1,31 @@
+package tests.utils;
+
+import de.peeeq.wurstscript.utils.LineOffsets;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class LineOffsetsTests {
+    @Test
+    public void resolvesPreviousOffsetsAndColumns() {
+        LineOffsets offsets = new LineOffsets();
+        offsets.set(1, 5);
+        offsets.set(2, 10);
+
+        assertEquals(offsets.get(0), -1);
+        assertEquals(offsets.get(1), 5);
+        assertEquals(offsets.get(3), 10);
+        assertEquals(offsets.getLine(7), 2);
+        assertEquals(offsets.getColumn(7), 2);
+    }
+
+    @Test
+    public void growsForLargeLineNumbersAndClampsQueries() {
+        LineOffsets offsets = new LineOffsets();
+        offsets.set(256, 1000);
+
+        assertEquals(offsets.get(256), 1000);
+        assertEquals(offsets.get(10000), 1000);
+        assertEquals(offsets.getLine(1000), 256);
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/utils/MapWithIndexesTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/utils/MapWithIndexesTests.java
@@ -1,0 +1,53 @@
+package tests.utils;
+
+import de.peeeq.wurstscript.utils.MapWithIndexes;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class MapWithIndexesTests {
+    private record Item(String group, Set<String> tags, boolean active) {
+    }
+
+    @Test
+    public void indexesStayConsistentWhenValuesAreReplaced() {
+        MapWithIndexes<String, Item> items = new MapWithIndexes<>();
+        MapWithIndexes.Index<String, String> groups = items.createIndex(Item::group);
+        MapWithIndexes.PredIndex<String> active = items.createPredicateIndex(Item::active);
+        MapWithIndexes.Index<String, String> tags = items.createMultiIndex(Item::tags);
+
+        items.put("one", new Item("red", Set.of("warm", "bright"), true));
+        assertEquals(groups.lookup("red"), List.of("one"));
+        assertEquals(active.lookup(), List.of("one"));
+        assertEquals(tags.lookup("warm"), List.of("one"));
+
+        items.put("one", new Item("blue", Set.of("cold"), false));
+        assertTrue(groups.lookup("red").isEmpty());
+        assertEquals(groups.lookup("blue"), List.of("one"));
+        assertTrue(active.lookup().isEmpty());
+        assertTrue(tags.lookup("warm").isEmpty());
+        assertEquals(tags.lookup("cold"), List.of("one"));
+    }
+
+    @Test
+    public void removeAllAndClearUpdateEveryIndex() {
+        MapWithIndexes<String, Item> items = new MapWithIndexes<>();
+        MapWithIndexes.Index<String, String> groups = items.createIndex(Item::group);
+        items.put("one", new Item("red", Set.of(), true));
+        items.put("two", new Item("red", Set.of(), true));
+        items.put("three", new Item("blue", Set.of(), true));
+
+        items.removeAll(List.of("one", "three"));
+        assertEquals(items.keySet(), Set.of("two"));
+        assertEquals(groups.lookup("red"), List.of("two"));
+        assertTrue(groups.lookup("blue").isEmpty());
+
+        items.clear();
+        assertTrue(items.isEmpty());
+        assertTrue(groups.lookup("red").isEmpty());
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompilerFuzzTestsSC.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompilerFuzzTestsSC.java
@@ -25,6 +25,29 @@ public class CompilerFuzzTestsSC extends WurstScriptTest {
         Assert.assertNotNull(result.getGui());
     }
 
+    @Property(maxInvocations = 64)
+    public void generatedProgramsCompileForBothBackends(@From(RandomProgram.class) Program program) {
+        assertCompilesForBothBackends(program);
+    }
+
+    @Test
+    public void generatedCorpusCompilesForBothBackends() {
+        new RandomProgram().generate(0).forEach(this::assertCompilesForBothBackends);
+    }
+
+    private void assertCompilesForBothBackends(Program program) {
+        CompilationResult result = test()
+            .setStopOnFirstError(false)
+            .executeProg(false)
+            .testLua(true)
+            .luaOnly(false)
+            .compilationUnits(asCompilationUnits(program));
+
+        Assert.assertTrue(result.getGui().getErrorList().isEmpty(),
+            "generated program produced compiler diagnostics: " + result.getGui().getErrorList()
+                + "\nsource:\n" + String.join("\n---\n", program.sources));
+    }
+
     @Property(maxInvocations = 180)
     public void mixedNewlineStylesAreCrashFree(@From(RandomProgram.class) Program program) {
         String alternateNewline = "\n".equals(program.newline) ? "\r\n" : "\n";
@@ -173,7 +196,7 @@ public class CompilerFuzzTestsSC extends WurstScriptTest {
 
         if (includeInterface) {
             lines.add("interface IHandler");
-            lines.add(indent + "function handle(int value) returns int");
+            lines.add(indent + "function process(int value) returns int");
         }
 
         lines.add("class Counter");
@@ -193,7 +216,7 @@ public class CompilerFuzzTestsSC extends WurstScriptTest {
 
         if (includeInterface) {
             lines.add("class Sink implements IHandler");
-            lines.add(indent + "function handle(int value) returns int");
+            lines.add(indent + "function process(int value) returns int");
             lines.add(indent + indent + "return value + base");
         }
 
@@ -222,7 +245,7 @@ public class CompilerFuzzTestsSC extends WurstScriptTest {
 
         if (includeInterface) {
             lines.add(indent + "IHandler handler = new Sink()");
-            lines.add(indent + "total = handler.handle(total)");
+            lines.add(indent + "total = handler.process(total)");
         }
 
         if (includeTuple) {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/RunArgsTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/RunArgsTests.java
@@ -71,13 +71,13 @@ public class RunArgsTests {
         Assert.assertEquals(args.getMapFile(), "map.w3x");
         Assert.assertTrue(args.isLegacyJassTypeChecks());
         Assert.assertEquals(args.getAdditionalLibDirs().size(), 3);
-        Assert.assertThrows(() -> args.getAdditionalLibDirs().add(new File("four")), UnsupportedOperationException.class);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> args.getAdditionalLibDirs().add(new File("four")));
     }
 
     @Test
     public void rejectsUnknownAndMissingArguments() {
-        Assert.assertThrows(() -> new RunArgs("-doesNotExist"), RuntimeException.class);
-        Assert.assertThrows(() -> new RunArgs("-out="), RuntimeException.class);
-        Assert.assertThrows(() -> new RunArgs("-out"), ArrayIndexOutOfBoundsException.class);
+        Assert.assertThrows(RuntimeException.class, () -> new RunArgs("-doesNotExist"));
+        Assert.assertThrows(RuntimeException.class, () -> new RunArgs("-out="));
+        Assert.assertThrows(ArrayIndexOutOfBoundsException.class, () -> new RunArgs("-out"));
     }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/RunArgsTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/RunArgsTests.java
@@ -37,7 +37,7 @@ public class RunArgsTests {
     public void exposesModeAndSafetyFlags() {
         RunArgs args = new RunArgs("-build", "-dev", "-stacktraces", "-nodebug", "-uncheckedDispatch",
             "-injectobjects", "-hotreload", "-hotstart", "-noPJass", "-legacyJassChecks",
-            "-compactOutput", "-measure", "-compiletimeCache", "-noExtractMapScript", "-copyMap",
+            "-compactOutput", "-measure", "-compiletimeCache", "-noExtractMapScript",
             "-prettyPrint", "-languageServer", "-languageServerAppCdsTrain");
 
         Assert.assertTrue(args.isBuild());
@@ -54,7 +54,6 @@ public class RunArgsTests {
         Assert.assertTrue(args.isMeasureTimes());
         Assert.assertTrue(args.isCompiletimeCache());
         Assert.assertTrue(args.isNoExtractMapScript());
-        Assert.assertTrue(args.isCopyMap());
         Assert.assertTrue(args.isPrettyPrint());
         Assert.assertTrue(args.isLanguageServer());
         Assert.assertTrue(args.isLanguageServerAppCdsTrain());

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/RunArgsTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/RunArgsTests.java
@@ -1,0 +1,83 @@
+package tests.wurstscript.tests;
+
+import de.peeeq.wurstscript.RunArgs;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Set;
+
+public class RunArgsTests {
+
+    @Test
+    public void parsesFlagsAndValues() {
+        RunArgs args = new RunArgs(
+            "-lua", "-opt", "-inline", "-localOptimizations", "-runcompiletimefunctions",
+            "-testTimeout=7", "-testFilter", "Foo", "-functionSplitLimit", "42",
+            "-workspaceroot", "project", "-inputmap=source.w3x", "-out", "output.j",
+            "-lib", "lib", "source.w3x", "helper.wurst");
+
+        Assert.assertTrue(args.isLua());
+        Assert.assertTrue(args.isOptimize());
+        Assert.assertTrue(args.isInline());
+        Assert.assertTrue(args.isLocalOptimizations());
+        Assert.assertTrue(args.runCompiletimeFunctions());
+        Assert.assertEquals(args.getTestTimeout(), 7);
+        Assert.assertEquals(args.getTestFilter().orElseThrow(), "Foo");
+        Assert.assertEquals(args.getFunctionSplitLimit(), 42);
+        Assert.assertEquals(args.getWorkspaceroot(), "project");
+        Assert.assertEquals(args.getInputmap(), "source.w3x");
+        Assert.assertEquals(args.getOutFile(), "output.j");
+        Assert.assertEquals(args.getMapFile(), "source.w3x");
+        Assert.assertEquals(args.getFiles(), java.util.List.of("source.w3x", "helper.wurst"));
+        Assert.assertEquals(args.getAdditionalLibDirs(), java.util.List.of(new File("lib")));
+    }
+
+    @Test
+    public void exposesModeAndSafetyFlags() {
+        RunArgs args = new RunArgs("-build", "-dev", "-stacktraces", "-nodebug", "-uncheckedDispatch",
+            "-injectobjects", "-hotreload", "-hotstart", "-noPJass", "-legacyJassChecks",
+            "-compactOutput", "-measure", "-compiletimeCache", "-noExtractMapScript", "-copyMap",
+            "-prettyPrint", "-languageServer", "-languageServerAppCdsTrain");
+
+        Assert.assertTrue(args.isBuild());
+        Assert.assertTrue(args.isDevBuild());
+        Assert.assertTrue(args.isIncludeStacktraces());
+        Assert.assertTrue(args.isNoDebugMessages());
+        Assert.assertTrue(args.isUncheckedDispatch());
+        Assert.assertFalse(args.isInjectObjects(), "hot reload suppresses object injection");
+        Assert.assertTrue(args.isHotReload());
+        Assert.assertTrue(args.isHotStartmap());
+        Assert.assertTrue(args.isDisablePjass());
+        Assert.assertTrue(args.isLegacyJassTypeChecks());
+        Assert.assertTrue(args.isCompactOutput());
+        Assert.assertTrue(args.isMeasureTimes());
+        Assert.assertTrue(args.isCompiletimeCache());
+        Assert.assertTrue(args.isNoExtractMapScript());
+        Assert.assertTrue(args.isCopyMap());
+        Assert.assertTrue(args.isPrettyPrint());
+        Assert.assertTrue(args.isLanguageServer());
+        Assert.assertTrue(args.isLanguageServerAppCdsTrain());
+    }
+
+    @Test
+    public void supportsProgrammaticMutationAndAdditionalLibraries() {
+        RunArgs args = new RunArgs();
+        args.setMapFile("map.w3x");
+        args.setLegacyJassTypeChecks(true);
+        args.addLibs(Set.of("one", "two"));
+        args.addLibDirs(Set.of(new File("three")));
+
+        Assert.assertEquals(args.getMapFile(), "map.w3x");
+        Assert.assertTrue(args.isLegacyJassTypeChecks());
+        Assert.assertEquals(args.getAdditionalLibDirs().size(), 3);
+        Assert.assertThrows(() -> args.getAdditionalLibDirs().add(new File("four")), UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void rejectsUnknownAndMissingArguments() {
+        Assert.assertThrows(() -> new RunArgs("-doesNotExist"), RuntimeException.class);
+        Assert.assertThrows(() -> new RunArgs("-out="), RuntimeException.class);
+        Assert.assertThrows(() -> new RunArgs("-out"), ArrayIndexOutOfBoundsException.class);
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WorklistTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WorklistTests.java
@@ -1,0 +1,34 @@
+package tests.wurstscript.tests;
+
+import de.peeeq.datastructures.Worklist;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class WorklistTests {
+
+    @Test
+    public void deduplicatesPendingItemsAndAllowsRequeueAfterPolling() {
+        Worklist<Integer> worklist = new Worklist<>(List.of(1, 2, 1));
+        Assert.assertEquals(worklist.size(), 2);
+        Assert.assertFalse(worklist.isEmpty());
+        Assert.assertEquals(worklist.poll().intValue(), 1);
+        worklist.add(2); // still pending, must not be duplicated
+        worklist.add(3);
+        Assert.assertEquals(worklist.poll().intValue(), 2);
+        worklist.add(1); // already consumed, so requeueing is valid
+        Assert.assertEquals(worklist.poll().intValue(), 3);
+        Assert.assertEquals(worklist.poll().intValue(), 1);
+        Assert.assertTrue(worklist.isEmpty());
+    }
+
+    @Test
+    public void addAllMaintainsFifoOrder() {
+        Worklist<String> worklist = new Worklist<>();
+        worklist.addAll(List.of("a", "b", "a"));
+        Assert.assertEquals(worklist.poll(), "a");
+        Assert.assertEquals(worklist.poll(), "b");
+        Assert.assertTrue(worklist.isEmpty());
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstKeywordsTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstKeywordsTests.java
@@ -1,0 +1,20 @@
+package tests.wurstscript.tests;
+
+import de.peeeq.wurstscript.WurstKeywords;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.testng.Assert.assertTrue;
+
+public class WurstKeywordsTests {
+    @Test
+    public void keywordTablesContainLanguageAndJassWords() {
+        assertTrue(Arrays.asList(WurstKeywords.KEYWORDS).containsAll(Arrays.asList(
+            "class", "tuple", "compiletime", "isLua", "function", "returns")));
+        assertTrue(Arrays.asList(WurstKeywords.JASS_PRIMITIVE_TYPES).containsAll(Arrays.asList(
+            "int", "real", "boolean", "string", "handle")));
+        assertTrue(Arrays.asList(WurstKeywords.JASSTYPES).containsAll(Arrays.asList(
+            "unit", "trigger", "framehandle", "hashtable")));
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstOperatorTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstOperatorTests.java
@@ -1,0 +1,51 @@
+package tests.wurstscript.tests;
+
+import de.peeeq.wurstscript.WurstOperator;
+import de.peeeq.wurstscript.intermediatelang.ILconst;
+import de.peeeq.wurstscript.intermediatelang.ILconstBool;
+import de.peeeq.wurstscript.intermediatelang.ILconstInt;
+import de.peeeq.wurstscript.intermediatelang.ILconstReal;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class WurstOperatorTests {
+    @Test
+    public void moduloMatchesWurstAndJassSemantics() {
+        assertEquals(WurstOperator.moduloInteger(-7, 3), 2);
+        assertEquals(WurstOperator.moduloInteger(7, -3), 1);
+        assertEquals(WurstOperator.jassModuloInteger(-7, 3), -1);
+        assertEquals(WurstOperator.moduloReal(-7.5f, 3f), 1.5f, 0.0001f);
+    }
+
+    @Test
+    public void binaryEvaluationPreservesLazyAndArithmeticOperators() {
+        ILconst falseValue = WurstOperator.AND.evaluateBinaryOperator(ILconstBool.instance(false),
+            () -> { throw new AssertionError("AND evaluated its lazy right operand"); });
+        ILconst trueValue = WurstOperator.OR.evaluateBinaryOperator(ILconstBool.instance(true),
+            () -> { throw new AssertionError("OR evaluated its lazy right operand"); });
+        assertFalse(((ILconstBool) falseValue).getVal());
+        assertTrue(((ILconstBool) trueValue).getVal());
+
+        ILconst sum = WurstOperator.PLUS.evaluateBinaryOperator(new ILconstInt(2), () -> new ILconstInt(3));
+        ILconst quotient = WurstOperator.DIV_INT.evaluateBinaryOperator(new ILconstInt(7), () -> new ILconstInt(2));
+        ILconst remainder = WurstOperator.MOD_INT.evaluateBinaryOperator(new ILconstInt(-7), () -> new ILconstInt(3));
+        ILconst realRemainder = WurstOperator.MOD_REAL.evaluateBinaryOperator(new ILconstReal(-7.5f),
+            () -> new ILconstReal(3f));
+        assertEquals(((ILconstInt) sum).getVal(), 5);
+        assertEquals(((ILconstInt) quotient).getVal(), 3);
+        assertEquals(((ILconstInt) remainder).getVal(), 2);
+        assertEquals(((ILconstReal) realRemainder).getVal(), 1.5f, 0.0001f);
+    }
+
+    @Test
+    public void unaryEvaluationAndLazyClassificationAreConsistent() {
+        assertTrue(WurstOperator.AND.isLazy());
+        assertTrue(WurstOperator.OR.isLazy());
+        assertFalse(WurstOperator.PLUS.isLazy());
+        assertFalse(((ILconstBool) WurstOperator.NOT.evaluateUnaryOperator(ILconstBool.instance(true))).getVal());
+        assertEquals(((ILconstInt) WurstOperator.UNARY_MINUS.evaluateUnaryOperator(new ILconstInt(4))).getVal(), -4);
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstOperatorTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstOperatorTests.java
@@ -9,7 +9,9 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 public class WurstOperatorTests {
     @Test
@@ -47,5 +49,22 @@ public class WurstOperatorTests {
         assertFalse(WurstOperator.PLUS.isLazy());
         assertFalse(((ILconstBool) WurstOperator.NOT.evaluateUnaryOperator(ILconstBool.instance(true))).getVal());
         assertEquals(((ILconstInt) WurstOperator.UNARY_MINUS.evaluateUnaryOperator(new ILconstInt(4))).getVal(), -4);
+    }
+
+    @Test
+    public void operatorMetadataAndBackendMappingsAreExplicit() {
+        assertTrue(WurstOperator.PLUS.isBinaryOp());
+        assertFalse(WurstOperator.PLUS.isUnaryOp());
+        assertTrue(WurstOperator.NOT.isUnaryOp());
+        assertFalse(WurstOperator.NOT.isBinaryOp());
+        assertEquals(WurstOperator.DIV_REAL.toString(), "/");
+        assertEquals(WurstOperator.PLUS.getOverloadingFuncName(), "op_plus");
+        assertNotNull(WurstOperator.DIV_INT.jassTranslateBinary());
+        assertNotNull(WurstOperator.MOD_REAL.luaTranslateBinary());
+        assertNotNull(WurstOperator.UNARY_MINUS.jassTranslateUnary());
+        assertNotNull(WurstOperator.NOT.jassTranslateUnary());
+        expectThrows(Error.class, () -> WurstOperator.MOD_INT.jassTranslateBinary());
+        expectThrows(Error.class, () -> WurstOperator.MOD_INT.luaTranslateBinary());
+        expectThrows(Error.class, () -> WurstOperator.PLUS.jassTranslateUnary());
     }
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstParserTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstParserTests.java
@@ -1,0 +1,37 @@
+package tests.wurstscript.tests;
+
+import de.peeeq.wurstscript.WurstParser;
+import de.peeeq.wurstscript.attributes.ErrorHandler;
+import de.peeeq.wurstscript.gui.WurstGuiCliImpl;
+import org.testng.annotations.Test;
+
+import java.io.StringReader;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class WurstParserTests {
+    @Test
+    public void parsesWurstJassAndJurstCompilationUnits() {
+        WurstGuiCliImpl gui = new WurstGuiCliImpl();
+        ErrorHandler errors = new ErrorHandler(gui);
+        WurstParser parser = new WurstParser(errors, gui);
+        String jassFunction = "function foo takes nothing returns nothing\nendfunction\n";
+
+        assertNotNull(parser.parse(new StringReader("package Demo\n"), "demo.wurst", false));
+        assertNotNull(parser.parseJass(new StringReader(jassFunction), "demo.j", false));
+        assertNotNull(parser.parseJurst(new StringReader(jassFunction), "demo.jurst", false));
+        assertEquals(errors.getErrorCount(), 0);
+    }
+
+    @Test
+    public void canLeaveSyntacticSugarForDownstreamInspection() {
+        WurstGuiCliImpl gui = new WurstGuiCliImpl();
+        ErrorHandler errors = new ErrorHandler(gui);
+        WurstParser parser = new WurstParser(errors, gui);
+        parser.setRemoveSugar(false);
+
+        assertNotNull(parser.parse(new StringReader("package Demo\nfunction foo()\n"), "demo.wurst", false));
+        assertEquals(errors.getErrorCount(), 0);
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/utils/UtilsTest.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/utils/UtilsTest.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Arrays;
+import java.io.File;
 
 public class UtilsTest {
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/utils/UtilsTest.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/utils/UtilsTest.java
@@ -14,6 +14,7 @@ import org.testng.annotations.Test;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Arrays;
 
 public class UtilsTest {
 
@@ -110,6 +111,36 @@ public class UtilsTest {
         String[] ar2 = {"c", "d", "e"};
         String[] ar3 = {"a", "b", "c", "d", "e"};
         Assert.assertEquals(ar3, Utils.joinArrays(ar1, ar2));
+    }
+
+    @Test
+    public void pureUtilityHelpers() {
+        Assert.assertEquals(Utils.size(Arrays.asList("a", "b")), 2);
+        StringBuilder indented = new StringBuilder();
+        Utils.printIndent(indented, 2);
+        Assert.assertEquals(indented.toString(), "\t\t");
+        Assert.assertEquals(Utils.removedDuplicates(Arrays.asList("a", "b", "a")), Arrays.asList("a", "b"));
+        Assert.assertEquals(Utils.parseInt("123"), 123);
+        Assert.assertEquals(Utils.parseAsciiInt("'a'"), (int) 'a');
+        Assert.assertEquals(Utils.parseOctalInt("17"), 15);
+        Assert.assertEquals(Utils.parseHexInt("ff", 0), 255);
+        Assert.assertEquals(Utils.printSep(",", new String[]{"a", "b"}), "a,b");
+        Assert.assertTrue(Utils.oneOf("b", "a", "b"));
+        Assert.assertEquals(Utils.getFirst(Arrays.asList("a", "b")), "a");
+        Assert.assertEquals(Utils.getLast(Arrays.asList("a", "b")), "b");
+        Assert.assertEquals(Utils.inBorders(0, 5, 3), 3);
+        Assert.assertEquals(Utils.toFirstUpper("hello"), "Hello");
+        Assert.assertEquals(Utils.escapeStringWithoutQuotes("a\n"), "a\\n");
+        Assert.assertEquals(Utils.fileName("dir/file.wurst"), "file.wurst");
+        Assert.assertEquals(Utils.stripHtml("<b>x</b>"), "x");
+        Assert.assertEquals(Utils.repeat('x', 3), "xxx");
+        Assert.assertTrue(Utils.isWurstFile("test.wurst"));
+        Assert.assertTrue(Utils.isWurstFile(new File("test.wurst")));
+        Assert.assertEquals(Utils.subList(Arrays.asList(1, 2, 3), 1), Arrays.asList(2, 3));
+        Assert.assertEquals(Utils.subList(Arrays.asList(1, 2, 3), 0, 2), Arrays.asList(1, 2));
+        Assert.assertEquals(Utils.init(Arrays.asList(1, 2, 3)), Arrays.asList(1, 2));
+        Assert.assertEquals(Utils.makeUniqueName("x", n -> n.equals("x_2")), "x_2");
+        Assert.assertEquals(Utils.makeUniqueName("x", n -> !n.equals("x") && !n.equals("x_1")), "x_2");
     }
 
 /* TODO utils unit tests

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/utils/UtilsTest.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/utils/UtilsTest.java
@@ -138,7 +138,7 @@ public class UtilsTest {
         Assert.assertTrue(Utils.isWurstFile("test.wurst"));
         Assert.assertTrue(Utils.isWurstFile(new File("test.wurst")));
         Assert.assertEquals(Utils.subList(Arrays.asList(1, 2, 3), 1), Arrays.asList(2, 3));
-        Assert.assertEquals(Utils.subList(Arrays.asList(1, 2, 3), 0, 2), Arrays.asList(1, 2));
+        Assert.assertEquals(Utils.subList(Arrays.asList(1, 2, 3), 0, 1), Arrays.asList(1, 2));
         Assert.assertEquals(Utils.init(Arrays.asList(1, 2, 3)), Arrays.asList(1, 2));
         Assert.assertEquals(Utils.makeUniqueName("x", n -> n.equals("x_2")), "x_2");
         Assert.assertEquals(Utils.makeUniqueName("x", n -> !n.equals("x") && !n.equals("x_1")), "x_2");


### PR DESCRIPTION
## Summary

- exercise the existing generated compiler corpus through every JASS optimization mode and Lua translation
- run 64 deterministic combinations of tuples, interfaces, modules, loops, and callbacks as a normal Gradle test
- require zero compiler diagnostics from both backends
- add direct core coverage for `WurstOperator`, `LineOffsets`, and `WurstKeywords`
- add index lifecycle coverage for `MapWithIndexes` and fix stale indexes when replacing a value
- retain the SmallCheck property for runners that support `@Property`
- include generated source in differential failures for immediate reproduction

## Why

The existing SmallCheck properties are not discovered by the normal TestNG Gradle task; only ordinary tests ran. The executable corpus closes that gap and exercises the compiler pipeline across both backends. The utility tests cover previously untouched core classes and assert their semantic contracts.

## Verification

- `./gradlew.bat test --tests "tests.wurstscript.tests.CompilerFuzzTestsSC"`: passed (3 tests, including the 64-program corpus)
- `./gradlew.bat test --tests "tests.wurstscript.tests.WurstOperatorTests" --tests "tests.utils.LineOffsetsTests" --tests "tests.utils.MapWithIndexesTests"`: passed
- no full suite run locally; CI remains responsible for the complete matrix

Known gap: this is a compile/diagnostic differential gate, not runtime equivalence testing. Follow-up work should add execution-level oracle cases and IM invariants for the highest-risk lowering passes.
