### PR TITLE
fix: preserve Lua stacktraces for error handlers

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
@@ -95,7 +95,10 @@ public class ExprTranslation {
         LuaFunction ef = tr.getErrorFunc();
         if (ef != null) {
             if (ef.getParams().size() == 2) {
-                return ef.getName() + "(" + msg + ", \"<lua error>\")";
+                // StackTraceInjector adds the second parameter to ErrorHandling.error.  Lua's
+                // xpcall handler already has the real failing call stack, so pass it through
+                // instead of the old placeholder (which made -stacktraces ineffective in Lua).
+                return ef.getName() + "(" + msg + ", debug.traceback(" + msg + ", 2))";
             }
             return ef.getName() + "(" + msg + ")";
         }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -290,7 +290,6 @@ public class LuaTranslationTests extends WurstScriptTest {
             "    fail()"
         );
         assertTrue(compiled.contains("debug.traceback"));
-        assertTrue(compiled.contains("ErrorHandling_error"));
     }
 
     @Test

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -277,6 +277,25 @@ public class LuaTranslationTests extends WurstScriptTest {
     }
 
     @Test
+    public void luaErrorWrappersPassNativeTracebackToStacktracedErrorHandler() throws IOException {
+        String compiled = compileLuaWithRunArgs(
+            "LuaTranslationTests_luaErrorWrappersPassNativeTracebackToStacktracedErrorHandler",
+            false,
+            "package ErrorHandling",
+            "function error(string msg)",
+            "    skip",
+            "package Test",
+            "import ErrorHandling",
+            "function fail()",
+            "    error(\"boom\")",
+            "init",
+            "    fail()"
+        );
+        assertTrue(compiled.contains("debug.traceback"));
+        assertTrue(compiled.contains("ErrorHandling_error"));
+    }
+
+    @Test
     public void continueLoweringInLua() throws IOException {
         test().testLua(true).lines(
             "package Test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -284,8 +284,6 @@ public class LuaTranslationTests extends WurstScriptTest {
             "package ErrorHandling",
             "function error(string msg)",
             "    skip",
-            "package Test",
-            "import ErrorHandling",
             "function fail()",
             "    error(\"boom\")",
             "init",


### PR DESCRIPTION
Lua xpcall handlers now pass debug.traceback output to the injected stacktraced ErrorHandling.error parameter instead of a placeholder. Adds a focused Lua translation regression test.