### PR TITLE
fix: align Lua generic dispatch slots with descriptors

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/GenericTypes.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/GenericTypes.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 /**
  * wraps an imType and adds a hashmap and equals method
  */
-class GenericTypes {
+public class GenericTypes {
     private final List<ImTypeArgument> typeArguments;
 
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaAssertions.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaAssertions.java
@@ -14,6 +14,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Static assertion helpers for the Lua backend.
@@ -130,6 +132,37 @@ public class LuaAssertions {
         if (!missingHelpers.isEmpty()) {
             throw new RuntimeException("Wurst Lua backend assertion failed: missing __wurst hashtable helper definitions in generated Lua: "
                 + String.join(", ", missingHelpers));
+        }
+    }
+
+    /**
+     * Every statically emitted descriptor lookup must have a matching descriptor assignment.
+     *
+     * <p>Virtual calls are deliberately emitted as {@code __wurst_objectClass[id].slot(...)}.
+     * A missing slot is valid Lua syntax but fails only when that dispatch path executes, which
+     * makes generic/specialized combinations particularly easy to miss in ordinary compilation
+     * tests. Keep this invariant at the generated-program boundary so every such mismatch is
+     * reported before a map can reach Warcraft.</p>
+     */
+    public static void assertDispatchSlotsHaveAssignments(String luaCode) {
+        Set<String> lookedUp = new TreeSet<>();
+        Matcher lookup = Pattern.compile(
+            "__wurst_objectClass\\s*\\[[^\\]\\r\\n]+\\]\\s*\\.\\s*([A-Za-z_][A-Za-z0-9_]*)")
+            .matcher(luaCode);
+        while (lookup.find()) {
+            lookedUp.add(lookup.group(1));
+        }
+
+        Set<String> assigned = new TreeSet<>();
+        Matcher assignment = Pattern.compile("\\.\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*=").matcher(luaCode);
+        while (assignment.find()) {
+            assigned.add(assignment.group(1));
+        }
+
+        lookedUp.removeAll(assigned);
+        if (!lookedUp.isEmpty()) {
+            throw new RuntimeException("Wurst Lua backend assertion failed: descriptor lookup has no "
+                + "matching class-table assignment: " + String.join(", ", lookedUp));
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaAssertions.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaAssertions.java
@@ -14,8 +14,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Static assertion helpers for the Lua backend.
@@ -132,37 +130,6 @@ public class LuaAssertions {
         if (!missingHelpers.isEmpty()) {
             throw new RuntimeException("Wurst Lua backend assertion failed: missing __wurst hashtable helper definitions in generated Lua: "
                 + String.join(", ", missingHelpers));
-        }
-    }
-
-    /**
-     * Every statically emitted descriptor lookup must have a matching descriptor assignment.
-     *
-     * <p>Virtual calls are deliberately emitted as {@code __wurst_objectClass[id].slot(...)}.
-     * A missing slot is valid Lua syntax but fails only when that dispatch path executes, which
-     * makes generic/specialized combinations particularly easy to miss in ordinary compilation
-     * tests. Keep this invariant at the generated-program boundary so every such mismatch is
-     * reported before a map can reach Warcraft.</p>
-     */
-    public static void assertDispatchSlotsHaveAssignments(String luaCode) {
-        Set<String> lookedUp = new TreeSet<>();
-        Matcher lookup = Pattern.compile(
-            "__wurst_objectClass\\s*\\[[^\\]\\r\\n]+\\]\\s*\\.\\s*([A-Za-z_][A-Za-z0-9_]*)")
-            .matcher(luaCode);
-        while (lookup.find()) {
-            lookedUp.add(lookup.group(1));
-        }
-
-        Set<String> assigned = new TreeSet<>();
-        Matcher assignment = Pattern.compile("\\.\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*=").matcher(luaCode);
-        while (assignment.find()) {
-            assigned.add(assignment.group(1));
-        }
-
-        lookedUp.removeAll(assigned);
-        if (!lookedUp.isEmpty()) {
-            throw new RuntimeException("Wurst Lua backend assertion failed: descriptor lookup has no "
-                + "matching class-table assignment: " + String.join(", ", lookedUp));
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -1250,14 +1250,19 @@ public class LuaTranslator {
             Set<String> candidates = new TreeSet<>();
             String methodName = dispatchSlotName(pending.method.getName());
             String segment = dispatchSlotName(imTr.dispatchSegmentOf(pending.method));
-            Set<String> commonSlots = hasClosureReceiver(pending.method)
-                ? commonConcreteReceiverSlots(pending.method)
-                : Collections.emptySet();
-            // Some erased generic override chains do not retain one shared structural key in the
-            // IM even though their normalized aliases are compatible. Preserve the established
-            // global resolution for those chains; the family intersection is authoritative when
-            // it is available (which is the specialization/closure case this guards).
-            Set<String> resolutionSlots = commonSlots.isEmpty() ? emittedDispatchSlots : commonSlots;
+            Set<ImClass> receivers = concreteReceiversFor(pending.method);
+            Set<String> commonSlots = receivers.isEmpty()
+                ? Collections.emptySet()
+                : commonConcreteReceiverSlots(pending.method);
+            // A concrete receiver family with no common emitted slot must be canonicalized. Never
+            // fall back to the program-wide slot union: an unrelated dispatch group can otherwise
+            // satisfy the name check and silently bind the wrong implementation. Opaque native
+            // callbacks are the only case where there is no compiler-known receiver descriptor.
+            Set<String> resolutionSlots = receivers.isEmpty() ? emittedDispatchSlots : commonSlots;
+            if (!receivers.isEmpty() && commonSlots.isEmpty()) {
+                ensureCanonicalDispatchSlot(pending);
+                continue;
+            }
             if (isDestroyDispatchMethod(pending.method)
                 && emittedDispatchSlots.contains("__wurst_destroy")) {
                 setResolvedDispatchSlot(pending, "__wurst_destroy");
@@ -1439,15 +1444,6 @@ public class LuaTranslator {
             }
         }
         return common == null ? Collections.emptySet() : common;
-    }
-
-    private boolean hasClosureReceiver(ImMethod method) {
-        for (ImClass c : concreteReceiversFor(method)) {
-            if (c.attrTrace() instanceof ExprClosure) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void buildDispatchReceiverIndex() {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -79,6 +79,8 @@ public class LuaTranslator {
     private final Set<String> usedNames = LuaReservedNames.all();
     private final Set<String> emittedDispatchSlots = new HashSet<>();
     private final Map<ImClass, Set<String>> emittedDispatchSlotsByClass = new IdentityHashMap<>();
+    private final Map<String, Set<ImClass>> concreteReceiverClassesByAlias = new HashMap<>();
+    private boolean dispatchReceiverIndexBuilt;
     private final List<PendingDispatch> pendingDispatches = new ArrayList<>();
 
     private static final class PendingDispatch {
@@ -1202,6 +1204,7 @@ public class LuaTranslator {
 
     /** Resolve dispatch helper targets against the slots actually registered by class descriptors. */
     private void resolveDispatchSlots() {
+        buildDispatchReceiverIndex();
         for (PendingDispatch pending : pendingDispatches) {
             String current = pending.target.getFieldName();
             Set<String> candidates = new TreeSet<>();
@@ -1251,10 +1254,11 @@ public class LuaTranslator {
      */
     private Set<String> commonConcreteReceiverSlots(ImMethod method) {
         Set<String> common = null;
-        for (ImClass c : prog.getClasses()) {
-            if (!hasConcreteDispatchImplementation(c, method)) {
-                continue;
-            }
+        Set<ImClass> receivers = new HashSet<>();
+        for (String key : dispatchReceiverKeys(method)) {
+            receivers.addAll(concreteReceiverClassesByAlias.getOrDefault(key, Collections.emptySet()));
+        }
+        for (ImClass c : receivers) {
             Set<String> slots = emittedDispatchSlotsByClass.get(c);
             if (slots == null || slots.isEmpty()) {
                 continue;
@@ -1269,37 +1273,51 @@ public class LuaTranslator {
     }
 
     private boolean hasClosureReceiver(ImMethod method) {
-        for (ImClass c : prog.getClasses()) {
-            if (c.attrTrace() instanceof ExprClosure && hasConcreteDispatchImplementation(c, method)) {
-                return true;
+        for (String key : dispatchReceiverKeys(method)) {
+            for (ImClass c : concreteReceiverClassesByAlias.getOrDefault(key, Collections.emptySet())) {
+                if (c.attrTrace() instanceof ExprClosure) {
+                    return true;
+                }
             }
         }
         return false;
     }
 
-    private boolean hasConcreteDispatchImplementation(ImClass receiverClass, ImMethod method) {
-        Set<String> aliases = new HashSet<>();
-        aliases.add(dispatchSlotName(method.getName()));
-        aliases.add(dispatchSlotName(imTr.dispatchSegmentOf(method)));
+    private void buildDispatchReceiverIndex() {
+        if (dispatchReceiverIndexBuilt) {
+            return;
+        }
+        dispatchReceiverIndexBuilt = true;
+        for (ImClass receiver : prog.getClasses()) {
+            for (ImMethod candidate : collectMethodsInHierarchy(receiver)) {
+                if (candidate.getIsAbstract() || candidate.getImplementation() == null) {
+                    continue;
+                }
+                for (String key : dispatchReceiverKeys(candidate)) {
+                    concreteReceiverClassesByAlias.computeIfAbsent(key, ignored -> new HashSet<>()).add(receiver);
+                }
+            }
+        }
+    }
+
+    private Set<String> dispatchReceiverKeys(ImMethod method) {
+        Set<String> keys = new HashSet<>();
+        keys.add(dispatchSlotName(method.getName()));
+        keys.add(dispatchSlotName(imTr.dispatchSegmentOf(method)));
         for (String alias : method.getLuaMethodDispatchAliases()) {
             if (alias != null && !alias.isEmpty()) {
-                aliases.add(dispatchSlotName(alias));
+                keys.add(dispatchSlotName(alias));
             }
         }
         String declaredName = LuaDispatchPreparation.declaredName(method);
-        String sourceName = sourceSemanticName(method);
-        for (ImMethod candidate : collectMethodsInHierarchy(receiverClass)) {
-            if (!candidate.getIsAbstract()
-                && candidate.getImplementation() != null
-                && (aliases.contains(dispatchSlotName(candidate.getName()))
-                    || aliases.contains(dispatchSlotName(imTr.dispatchSegmentOf(candidate)))
-                    || (!declaredName.isEmpty() && declaredName.equals(LuaDispatchPreparation.declaredName(candidate)))
-                    || (!sourceName.isEmpty() && sourceName.equals(sourceSemanticName(candidate))
-                        && LuaDispatchPreparation.compatibleReturnTypes(method, candidate, imTr)))) {
-                return true;
-            }
+        if (!declaredName.isEmpty()) {
+            keys.add(dispatchSlotName(declaredName));
         }
-        return false;
+        String sourceName = sourceSemanticName(method);
+        if (!sourceName.isEmpty()) {
+            keys.add(dispatchSlotName(sourceName));
+        }
+        return keys;
     }
 
     /**

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -8,6 +8,7 @@ import de.peeeq.wurstscript.translation.imtranslation.FunctionFlagEnum;
 import de.peeeq.wurstscript.translation.imtranslation.GetAForB;
 import de.peeeq.wurstscript.translation.imtranslation.ImHelper;
 import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
+import de.peeeq.wurstscript.translation.imtranslation.GenericTypes;
 import de.peeeq.wurstscript.translation.imtranslation.LuaDispatchPreparation;
 import de.peeeq.wurstscript.translation.imtranslation.LuaNativeLowering;
 import de.peeeq.wurstscript.types.TypesHelper;
@@ -103,12 +104,15 @@ public class LuaTranslator {
     /**
      * Identity of a dispatch group. The root is an IM method, not a generated Lua name: two
      * unrelated groups are allowed to have equal names after generic elimination. Specializations
-     * of one override chain intentionally share this identity even when lowering changes types.
+     * moved onto one erased class retain their structural type arguments so distinct lowered
+     * signatures cannot overwrite one another's descriptor slot.
      */
     private static final class DispatchGroupIdentity {
         final ImMethod root;
-        DispatchGroupIdentity(ImMethod root) {
+        final GenericTypes specialization;
+        DispatchGroupIdentity(ImMethod root, GenericTypes specialization) {
             this.root = root;
+            this.specialization = specialization;
         }
 
         @Override
@@ -116,12 +120,13 @@ public class LuaTranslator {
             if (!(other instanceof DispatchGroupIdentity that)) {
                 return false;
             }
-            return root == that.root;
+            return root == that.root
+                && Objects.equals(specialization, that.specialization);
         }
 
         @Override
         public int hashCode() {
-            return System.identityHashCode(root);
+            return 31 * System.identityHashCode(root) + Objects.hashCode(specialization);
         }
     }
 
@@ -1592,12 +1597,28 @@ public class LuaTranslator {
                 }
             }
         }
-        Map<ImMethod, DispatchGroupIdentity> identities = new IdentityHashMap<>();
+        Map<DispatchGroupIdentity, DispatchGroupIdentity> identities = new HashMap<>();
         for (ImMethod method : methods) {
             ImMethod root = findDispatchGroupRoot(parent, method);
-            DispatchGroupIdentity identity = identities.computeIfAbsent(root, DispatchGroupIdentity::new);
+            DispatchGroupIdentity candidate = new DispatchGroupIdentity(root, dispatchSpecializationOf(method));
+            DispatchGroupIdentity identity = identities.computeIfAbsent(candidate, ignored -> candidate);
             dispatchGroups.put(method, identity);
         }
+    }
+
+    /**
+     * Specialised methods which were moved back onto their erased allocation class can coexist
+     * with another specialization of the same virtual root. Keep their structural arguments in
+     * the dispatch identity; specialised methods still living on a specialised class are already
+     * reached through that class and must continue sharing the root family with its overrides.
+     */
+    private GenericTypes dispatchSpecializationOf(ImMethod method) {
+        ImTranslator.Specialisation specialization = imTr.specialisationOf(method);
+        ImClass owner = method.attrClass();
+        if (specialization == null || owner == null || imTr.canonical(owner) != owner) {
+            return null;
+        }
+        return new GenericTypes(specialization.typeArguments());
     }
 
     private static ImMethod findDispatchGroupRoot(Map<ImMethod, ImMethod> parent, ImMethod method) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -80,7 +80,9 @@ public class LuaTranslator {
     private final Set<String> emittedDispatchSlots = new HashSet<>();
     private final Map<ImClass, Set<String>> emittedDispatchSlotsByClass = new IdentityHashMap<>();
     private final Map<DispatchGroupIdentity, Set<ImClass>> concreteReceiverClassesByGroup = new HashMap<>();
+    private final Map<ImClass, Set<ImClass>> concreteReceiverClassesByNominalType = new IdentityHashMap<>();
     private final Map<ImMethod, DispatchGroupIdentity> dispatchGroups = new IdentityHashMap<>();
+    private final Map<DispatchGroupIdentity, String> canonicalDispatchSlots = new HashMap<>();
     private boolean dispatchGroupsBuilt;
     private boolean dispatchReceiverIndexBuilt;
     private final List<PendingDispatch> pendingDispatches = new ArrayList<>();
@@ -97,15 +99,13 @@ public class LuaTranslator {
 
     /**
      * Identity of a dispatch group. The root is an IM method, not a generated Lua name: two
-     * unrelated groups are allowed to have equal names after generic elimination.
+     * unrelated groups are allowed to have equal names after generic elimination. Specializations
+     * of one override chain intentionally share this identity even when lowering changes types.
      */
     private static final class DispatchGroupIdentity {
         final ImMethod root;
-        final String signature;
-
-        DispatchGroupIdentity(ImMethod root, String signature) {
+        DispatchGroupIdentity(ImMethod root) {
             this.root = root;
-            this.signature = signature;
         }
 
         @Override
@@ -113,12 +113,12 @@ public class LuaTranslator {
             if (!(other instanceof DispatchGroupIdentity that)) {
                 return false;
             }
-            return root == that.root && Objects.equals(signature, that.signature);
+            return root == that.root;
         }
 
         @Override
         public int hashCode() {
-            return 31 * System.identityHashCode(root) + Objects.hashCode(signature);
+            return System.identityHashCode(root);
         }
     }
 
@@ -244,10 +244,13 @@ public class LuaTranslator {
             // implementing closure classes register the normalized alias (e.g. Predicate_test
             // vs. test); the descriptor table is the authoritative source for that choice.
             LuaExprFieldAccess target = LuaAst.LuaExprFieldAccess(
-                descriptor, dispatchSlotName(imTr.dispatchSegmentOf(method)));
+                descriptor, isDestroyDispatchMethod(method)
+                    ? "__wurst_destroy"
+                    : dispatchSlotName(imTr.dispatchSegmentOf(method)));
+            LuaExprFunctionCallE call = LuaAst.LuaExprFunctionCallE(target,
+                LuaAst.LuaExprlist(LuaAst.LuaExprVarAccess(receiver), LuaAst.LuaExprVarAccess(dots)));
             pendingDispatches.add(new PendingDispatch(method, target));
-            result.getBody().add(LuaAst.LuaReturn(LuaAst.LuaExprFunctionCallE(target,
-                LuaAst.LuaExprlist(LuaAst.LuaExprVarAccess(receiver), LuaAst.LuaExprVarAccess(dots)))));
+            result.getBody().add(LuaAst.LuaReturn(call));
             luaModel.add(result);
             return result;
         }
@@ -1204,6 +1207,14 @@ public class LuaTranslator {
             }
         }
 
+        List<ImMethod> destroyMethods = allMethods.stream()
+            .filter(this::isDestroyDispatchMethod)
+            .toList();
+        ImMethod destroyImplementation = chooseBestImplementationForClass(c, destroyMethods);
+        if (destroyImplementation != null) {
+            slotToImpl.put("__wurst_destroy", destroyImplementation);
+        }
+
         // Constructor helpers (create, create1, ...) live in the same class-table
         // key namespace as dispatch slots. If a slot would overwrite this class's
         // constructor at main() time, rename the constructor instead (allocation
@@ -1226,6 +1237,19 @@ public class LuaTranslator {
                 LuaAst.LuaExprFuncRef(luaFunc.getFor(impl.getImplementation()))
             ));
         }
+
+        // Closures and erased generic interface implementations may not carry an explicit
+        // destructor method in their specialized IM class.  They are still destroyable objects:
+        // the common deallocator clears their captured fields and recycles the object id.  Give
+        // those descriptors the same destroy slot so a destroy through an interface can never
+        // end up indexing a missing, mangled method name.
+        if (destroyImplementation == null && !isInterfaceClass(c)
+            && emittedDispatchSlotsByClass.computeIfAbsent(c, ignored -> new HashSet<>()).add("__wurst_destroy")) {
+            emittedDispatchSlots.add("__wurst_destroy");
+            deferMainInit(LuaAst.LuaAssignment(
+                LuaAst.LuaExprFieldAccess(LuaAst.LuaExprVarAccess(classVar), "__wurst_destroy"),
+                LuaAst.LuaExprFuncRef(objectDealloc)));
+        }
     }
 
     /** Resolve dispatch helper targets against the slots actually registered by class descriptors. */
@@ -1244,45 +1268,150 @@ public class LuaTranslator {
             // global resolution for those chains; the family intersection is authoritative when
             // it is available (which is the specialization/closure case this guards).
             Set<String> resolutionSlots = commonSlots.isEmpty() ? emittedDispatchSlots : commonSlots;
+            if (isDestroyDispatchMethod(pending.method)
+                && emittedDispatchSlots.contains("__wurst_destroy")) {
+                setResolvedDispatchSlot(pending, "__wurst_destroy");
+                continue;
+            }
             if (resolutionSlots.contains(methodName)) {
-                pending.target.setFieldName(methodName);
+                setResolvedDispatchSlot(pending, methodName);
                 continue;
             }
             if (resolutionSlots.contains(segment)) {
-                pending.target.setFieldName(segment);
+                setResolvedDispatchSlot(pending, segment);
                 continue;
             }
             if (resolutionSlots.contains(current)) {
+                setResolvedDispatchSlot(pending, current);
                 continue;
             }
-            candidates.add(methodName);
-            candidates.add(segment);
-            for (String alias : pending.method.getLuaMethodDispatchAliases()) {
-                if (alias != null && !alias.isEmpty()) {
-                    candidates.add(dispatchSlotName(alias));
-                }
-            }
+            candidates.addAll(dispatchCandidateSlots(pending.method));
             String resolved = candidates.stream()
                 .filter(resolutionSlots::contains)
                 .sorted(Comparator.comparingInt(String::length).thenComparing(String::compareTo))
                 .findFirst().orElse(null);
             if (resolved != null) {
-                pending.target.setFieldName(resolved);
+                setResolvedDispatchSlot(pending, resolved);
                 continue;
             }
-            if (!commonSlots.isEmpty()) {
-                throw new RuntimeException("Wurst Lua backend assertion failed: dispatch slot '"
-                    + current + "' is not registered by every concrete receiver descriptor.");
+            if (!concreteReceiversFor(pending.method).isEmpty()) {
+                ensureCanonicalDispatchSlot(pending);
             }
         }
+    }
+
+    private void setResolvedDispatchSlot(PendingDispatch pending, String slot) {
+        Set<ImClass> receivers = concreteReceiversFor(pending.method);
+        if (!receivers.isEmpty() && receivers.stream().anyMatch(c ->
+            !emittedDispatchSlotsByClass.getOrDefault(c, Collections.emptySet()).contains(slot))) {
+            ensureCanonicalDispatchSlot(pending);
+        } else {
+            pending.target.setFieldName(slot);
+        }
+    }
+
+    /** Give a heterogeneous specialization family one private, consistently registered slot. */
+    private void ensureCanonicalDispatchSlot(PendingDispatch pending) {
+        DispatchGroupIdentity group = dispatchGroupOf(pending.method);
+        if (group == null) {
+            return;
+        }
+        String semantic = dispatchSlotName(imTr.dispatchSegmentOf(pending.method));
+        if (semantic.isEmpty()) {
+            semantic = "method";
+        }
+        String canonicalName = semantic;
+        String slot = canonicalDispatchSlots.computeIfAbsent(group,
+            ignored -> uniqueName("__wurst_dispatch_" + canonicalName));
+        Set<String> semanticNames = new HashSet<>();
+        if (!imTr.dispatchSegmentOf(pending.method).isEmpty()) {
+            semanticNames.add(imTr.dispatchSegmentOf(pending.method));
+        }
+        String sourceName = sourceSemanticName(pending.method);
+        if (!sourceName.isEmpty()) {
+            semanticNames.add(sourceName);
+        }
+        Set<ImClass> receivers = concreteReceiversFor(pending.method);
+        for (ImClass receiver : receivers) {
+            List<ImMethod> candidates = new ArrayList<>();
+            for (ImMethod candidate : collectMethodsInHierarchy(receiver)) {
+                if (sameDispatchFamily(pending.method, candidate)
+                    && sharesDispatchSemanticName(candidate, semanticNames)) {
+                    candidates.add(candidate);
+                }
+            }
+            ImMethod implementation = chooseBestImplementationForClass(receiver, candidates);
+            if (implementation == null) {
+                throw new RuntimeException("Wurst Lua backend assertion failed: no implementation for dispatch slot '"
+                    + slot + "' in descriptor for " + receiver.getName() + ".");
+            }
+            Set<String> registered = emittedDispatchSlotsByClass.computeIfAbsent(receiver, ignored -> new HashSet<>());
+            if (registered.add(slot)) {
+                emittedDispatchSlots.add(slot);
+                deferMainInit(LuaAst.LuaAssignment(
+                    LuaAst.LuaExprFieldAccess(LuaAst.LuaExprVarAccess(luaClassVar.getFor(receiver)), slot),
+                    LuaAst.LuaExprFuncRef(luaFunc.getFor(implementation.getImplementation()))));
+            }
+        }
+        pending.target.setFieldName(slot);
+    }
+
+    private Set<String> dispatchCandidateSlots(ImMethod method) {
+        Set<String> candidates = new TreeSet<>();
+        candidates.add(dispatchSlotName(method.getName()));
+        candidates.add(dispatchSlotName(imTr.dispatchSegmentOf(method)));
+        for (String alias : method.getLuaMethodDispatchAliases()) {
+            if (alias != null && !alias.isEmpty()) {
+                candidates.add(dispatchSlotName(alias));
+            }
+        }
+        Set<ImClass> receivers = concreteReceiversFor(method);
+        Set<String> semanticNames = new HashSet<>();
+        String segment = imTr.dispatchSegmentOf(method);
+        if (!segment.isEmpty()) {
+            semanticNames.add(segment);
+        }
+        String sourceName = sourceSemanticName(method);
+        if (!sourceName.isEmpty()) {
+            semanticNames.add(sourceName);
+        }
+        for (ImClass receiver : receivers) {
+            for (ImMethod candidate : collectMethodsInHierarchy(receiver)) {
+                if (!sameDispatchFamily(method, candidate)
+                    || !sharesDispatchSemanticName(candidate, semanticNames)) {
+                    continue;
+                }
+                candidates.add(dispatchSlotName(candidate.getName()));
+                candidates.add(dispatchSlotName(imTr.dispatchSegmentOf(candidate)));
+                for (String alias : candidate.getLuaMethodDispatchAliases()) {
+                    if (alias != null && !alias.isEmpty()) {
+                        candidates.add(dispatchSlotName(alias));
+                    }
+                }
+            }
+        }
+        candidates.remove("");
+        return candidates;
+    }
+
+    private boolean sharesDispatchSemanticName(ImMethod method, Set<String> semanticNames) {
+        if (isDestroyDispatchMethod(method) && semanticNames.stream().anyMatch(name -> name.startsWith("destroy"))) {
+            return true;
+        }
+        return semanticNames.contains(imTr.dispatchSegmentOf(method))
+            || semanticNames.contains(sourceSemanticName(method));
+    }
+
+    private boolean isDestroyDispatchMethod(ImMethod method) {
+        ImFunction implementation = method.getImplementation();
+        return implementation != null && implementation.attrTrace() instanceof OnDestroyDef;
     }
 
     /** Verify every descriptor slot used by an emitted dispatch helper is registered by its receivers. */
     private void assertResolvedDispatchSlots() {
         for (PendingDispatch pending : pendingDispatches) {
             String slot = pending.target.getFieldName();
-            Set<ImClass> receivers = concreteReceiverClassesByGroup.getOrDefault(
-                dispatchGroupOf(pending.method), Collections.emptySet());
+            Set<ImClass> receivers = concreteReceiversFor(pending.method);
             if (receivers.isEmpty()) {
                 // Native/opaque callback interfaces can have no concrete IM receiver descriptor;
                 // their slot is supplied by the runtime rather than by this program.
@@ -1305,8 +1434,7 @@ public class LuaTranslator {
      */
     private Set<String> commonConcreteReceiverSlots(ImMethod method) {
         Set<String> common = null;
-        Set<ImClass> receivers = concreteReceiverClassesByGroup.getOrDefault(
-            dispatchGroupOf(method), Collections.emptySet());
+        Set<ImClass> receivers = concreteReceiversFor(method);
         for (ImClass c : receivers) {
             Set<String> slots = emittedDispatchSlotsByClass.get(c);
             if (slots == null || slots.isEmpty()) {
@@ -1322,8 +1450,7 @@ public class LuaTranslator {
     }
 
     private boolean hasClosureReceiver(ImMethod method) {
-        for (ImClass c : concreteReceiverClassesByGroup.getOrDefault(
-            dispatchGroupOf(method), Collections.emptySet())) {
+        for (ImClass c : concreteReceiversFor(method)) {
             if (c.attrTrace() instanceof ExprClosure) {
                 return true;
             }
@@ -1338,13 +1465,20 @@ public class LuaTranslator {
         dispatchReceiverIndexBuilt = true;
         buildDispatchGroupIndex();
         for (ImClass receiver : prog.getClasses()) {
+            boolean hasConcreteMethod = false;
             for (ImMethod candidate : collectMethodsInHierarchy(receiver)) {
                 if (candidate.getIsAbstract() || candidate.getImplementation() == null) {
                     continue;
                 }
+                hasConcreteMethod = true;
                 DispatchGroupIdentity group = dispatchGroups.get(candidate);
                 if (group != null) {
                     concreteReceiverClassesByGroup.computeIfAbsent(group, ignored -> new HashSet<>()).add(receiver);
+                }
+            }
+            if (hasConcreteMethod && !isInterfaceClass(receiver)) {
+                for (ImClass nominalType : collectClassesInHierarchy(receiver)) {
+                    concreteReceiverClassesByNominalType.computeIfAbsent(nominalType, ignored -> new HashSet<>()).add(receiver);
                 }
             }
         }
@@ -1353,6 +1487,40 @@ public class LuaTranslator {
     private DispatchGroupIdentity dispatchGroupOf(ImMethod method) {
         buildDispatchGroupIndex();
         return dispatchGroups.get(method);
+    }
+
+    private Set<ImClass> concreteReceiversFor(ImMethod method) {
+        Set<ImClass> receivers = new HashSet<>(concreteReceiverClassesByGroup.getOrDefault(
+            dispatchGroupOf(method), Collections.emptySet()));
+        ImClass owner = method.attrClass();
+        if (owner != null) {
+            receivers.addAll(concreteReceiverClassesByNominalType.getOrDefault(owner, Collections.emptySet()));
+        }
+        Set<String> semanticNames = new HashSet<>();
+        if (!imTr.dispatchSegmentOf(method).isEmpty()) {
+            semanticNames.add(imTr.dispatchSegmentOf(method));
+        }
+        String sourceName = sourceSemanticName(method);
+        if (!sourceName.isEmpty()) {
+            semanticNames.add(sourceName);
+        }
+        receivers.removeIf(receiver -> collectMethodsInHierarchy(receiver).stream()
+            .noneMatch(candidate -> !candidate.getIsAbstract()
+                && candidate.getImplementation() != null
+                && sameDispatchFamily(method, candidate)
+                && sharesDispatchSemanticName(candidate, semanticNames)));
+        return receivers;
+    }
+
+    private boolean sameDispatchFamily(ImMethod reference, ImMethod candidate) {
+        if (dispatchGroupOf(reference) == dispatchGroupOf(candidate)) {
+            return true;
+        }
+        ImClass referenceOwner = reference.attrClass();
+        ImClass candidateOwner = candidate.attrClass();
+        return referenceOwner != null && candidateOwner != null
+            && (collectClassesInHierarchy(referenceOwner).contains(candidateOwner)
+                || collectClassesInHierarchy(candidateOwner).contains(referenceOwner));
     }
 
     /** Reconstruct dispatch-group identity from the IM override graph without using names. */
@@ -1378,13 +1546,10 @@ public class LuaTranslator {
                 }
             }
         }
-        Map<ImMethod, Map<String, DispatchGroupIdentity>> identities = new IdentityHashMap<>();
+        Map<ImMethod, DispatchGroupIdentity> identities = new IdentityHashMap<>();
         for (ImMethod method : methods) {
             ImMethod root = findDispatchGroupRoot(parent, method);
-            String signature = method.getLuaDispatchGroupKey();
-            DispatchGroupIdentity identity = identities
-                .computeIfAbsent(root, ignored -> new HashMap<>())
-                .computeIfAbsent(signature, ignored -> new DispatchGroupIdentity(root, signature));
+            DispatchGroupIdentity identity = identities.computeIfAbsent(root, DispatchGroupIdentity::new);
             dispatchGroups.put(method, identity);
         }
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -77,6 +77,18 @@ public class LuaTranslator {
     private final LuaStatements deferredMainInit = LuaAst.LuaStatements();
     private final Map<String, Integer> uniqueNameCounters = new HashMap<>();
     private final Set<String> usedNames = LuaReservedNames.all();
+    private final Set<String> emittedDispatchSlots = new HashSet<>();
+    private final List<PendingDispatch> pendingDispatches = new ArrayList<>();
+
+    private static final class PendingDispatch {
+        final ImMethod method;
+        final LuaExprFieldAccess target;
+
+        PendingDispatch(ImMethod method, LuaExprFieldAccess target) {
+            this.method = method;
+            this.target = target;
+        }
+    }
 
     private ImProg getProg() {
         return prog;
@@ -195,7 +207,13 @@ public class LuaTranslator {
             LuaExpr descriptor = LuaAst.LuaExprArrayAccess(
                 LuaAst.LuaExprVarAccess(objectClass),
                 LuaAst.LuaExprlist(LuaAst.LuaExprVarAccess(receiver)));
-            LuaExpr target = LuaAst.LuaExprFieldAccess(descriptor, dispatchSlotName(method.getName()));
+            // The final slot is resolved after all class descriptors have been emitted. Generic
+            // lowering can leave an unspecialized call with a mangled method name while the
+            // implementing closure classes register the normalized alias (e.g. Predicate_test
+            // vs. test); the descriptor table is the authoritative source for that choice.
+            LuaExprFieldAccess target = LuaAst.LuaExprFieldAccess(
+                descriptor, dispatchSlotName(imTr.dispatchSegmentOf(method)));
+            pendingDispatches.add(new PendingDispatch(method, target));
             result.getBody().add(LuaAst.LuaReturn(LuaAst.LuaExprFunctionCallE(target,
                 LuaAst.LuaExprlist(LuaAst.LuaExprVarAccess(receiver), LuaAst.LuaExprVarAccess(dots)))));
             luaModel.add(result);
@@ -309,6 +327,8 @@ public class LuaTranslator {
             initClassTables(c);
         }
 
+        resolveDispatchSlots();
+
         createBootstrapFunction();
         cleanStatements();
         enforceLuaLocalLimits();
@@ -408,6 +428,10 @@ public class LuaTranslator {
 
     public static void assertNoLeakedHashtableNativeCalls(String luaCode) {
         LuaAssertions.assertNoLeakedHashtableNativeCalls(luaCode);
+    }
+
+    public static void assertDispatchSlotsHaveAssignments(String luaCode) {
+        LuaAssertions.assertDispatchSlotsHaveAssignments(luaCode);
     }
 
     static List<String> allHashtableNativeNames() {
@@ -1165,12 +1189,68 @@ public class LuaTranslator {
             if (impl == null || impl.getImplementation() == null) {
                 continue;
             }
+            emittedDispatchSlots.add(e.getKey());
             deferMainInit(LuaAst.LuaAssignment(LuaAst.LuaExprFieldAccess(
                 LuaAst.LuaExprVarAccess(classVar),
                 e.getKey()),
                 LuaAst.LuaExprFuncRef(luaFunc.getFor(impl.getImplementation()))
             ));
         }
+    }
+
+    /** Resolve dispatch helper targets against the slots actually registered by class descriptors. */
+    private void resolveDispatchSlots() {
+        for (PendingDispatch pending : pendingDispatches) {
+            String current = pending.target.getFieldName();
+            Set<String> candidates = new TreeSet<>();
+            String methodName = dispatchSlotName(pending.method.getName());
+            String segment = dispatchSlotName(imTr.dispatchSegmentOf(pending.method));
+            if (emittedDispatchSlots.contains(methodName)) {
+                pending.target.setFieldName(methodName);
+                continue;
+            }
+            if (emittedDispatchSlots.contains(segment)) {
+                pending.target.setFieldName(segment);
+                continue;
+            }
+            if (emittedDispatchSlots.contains(current)) {
+                continue;
+            }
+            candidates.add(methodName);
+            candidates.add(segment);
+            for (String alias : pending.method.getLuaMethodDispatchAliases()) {
+                if (alias != null && !alias.isEmpty()) {
+                    candidates.add(dispatchSlotName(alias));
+                }
+            }
+            String resolved = candidates.stream()
+                .filter(emittedDispatchSlots::contains)
+                .sorted(Comparator.comparingInt(String::length).thenComparing(String::compareTo))
+                .findFirst().orElse(null);
+            if (resolved != null) {
+                pending.target.setFieldName(resolved);
+                continue;
+            }
+            if (hasConcreteDispatchImplementation(pending.method)) {
+                throw new RuntimeException("Wurst Lua backend assertion failed: dispatch slot '"
+                    + current + "' has no matching class-table assignment.");
+            }
+        }
+    }
+
+    private boolean hasConcreteDispatchImplementation(ImMethod method) {
+        String groupKey = method.getLuaDispatchGroupKey();
+        for (ImClass c : prog.getClasses()) {
+            for (ImMethod candidate : c.getMethods()) {
+                if (candidate.getIsAbstract() || candidate.getImplementation() == null) {
+                    continue;
+                }
+                if (groupKey != null && groupKey.equals(candidate.getLuaDispatchGroupKey())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -82,6 +82,7 @@ public class LuaTranslator {
     private final Map<DispatchGroupIdentity, Set<ImClass>> concreteReceiverClassesByGroup = new HashMap<>();
     private final Map<ImClass, Set<ImClass>> concreteReceiverClassesByNominalType = new IdentityHashMap<>();
     private final Map<ImMethod, DispatchGroupIdentity> dispatchGroups = new IdentityHashMap<>();
+    private final Map<ImMethod, Set<ImClass>> concreteReceiverFamilyCache = new IdentityHashMap<>();
     private final Map<DispatchGroupIdentity, String> canonicalDispatchSlots = new HashMap<>();
     private boolean dispatchGroupsBuilt;
     private boolean dispatchReceiverIndexBuilt;
@@ -1238,23 +1239,12 @@ public class LuaTranslator {
             ));
         }
 
-        // Closures and erased generic interface implementations may not carry an explicit
-        // destructor method in their specialized IM class.  They are still destroyable objects:
-        // the common deallocator clears their captured fields and recycles the object id.  Give
-        // those descriptors the same destroy slot so a destroy through an interface can never
-        // end up indexing a missing, mangled method name.
-        if (destroyImplementation == null && !isInterfaceClass(c)
-            && emittedDispatchSlotsByClass.computeIfAbsent(c, ignored -> new HashSet<>()).add("__wurst_destroy")) {
-            emittedDispatchSlots.add("__wurst_destroy");
-            deferMainInit(LuaAst.LuaAssignment(
-                LuaAst.LuaExprFieldAccess(LuaAst.LuaExprVarAccess(classVar), "__wurst_destroy"),
-                LuaAst.LuaExprFuncRef(objectDealloc)));
-        }
     }
 
     /** Resolve dispatch helper targets against the slots actually registered by class descriptors. */
     private void resolveDispatchSlots() {
         buildDispatchReceiverIndex();
+        ensureDestroyFallbackSlots();
         for (PendingDispatch pending : pendingDispatches) {
             String current = pending.target.getFieldName();
             Set<String> candidates = new TreeSet<>();
@@ -1492,6 +1482,10 @@ public class LuaTranslator {
     }
 
     private Set<ImClass> concreteReceiversFor(ImMethod method) {
+        Set<ImClass> cached = concreteReceiverFamilyCache.get(method);
+        if (cached != null) {
+            return cached;
+        }
         Set<ImClass> receivers = new HashSet<>(concreteReceiverClassesByGroup.getOrDefault(
             dispatchGroupOf(method), Collections.emptySet()));
         ImClass owner = method.attrClass();
@@ -1506,12 +1500,56 @@ public class LuaTranslator {
         if (!sourceName.isEmpty()) {
             semanticNames.add(sourceName);
         }
+        if (isDestroyDispatchMethod(method)) {
+            // A closure's specialized interface class can omit the generated destroy method from
+            // its IM hierarchy even though it is a valid receiver for the interface's lifecycle
+            // call.  Any concrete receiver of another method declared by that owner is also a
+            // concrete receiver of its destroy slot.
+            if (owner != null) {
+                for (ImMethod ownerMethod : owner.getMethods()) {
+                    receivers.addAll(concreteReceiverClassesByGroup.getOrDefault(
+                        dispatchGroupOf(ownerMethod), Collections.emptySet()));
+                }
+            }
+            receivers.removeIf(this::isInterfaceClass);
+            Set<ImClass> result = Collections.unmodifiableSet(receivers);
+            concreteReceiverFamilyCache.put(method, result);
+            return result;
+        }
         receivers.removeIf(receiver -> collectMethodsInHierarchy(receiver).stream()
             .noneMatch(candidate -> !candidate.getIsAbstract()
                 && candidate.getImplementation() != null
                 && sameDispatchFamily(method, candidate)
                 && sharesDispatchSemanticName(candidate, semanticNames)));
-        return receivers;
+        Set<ImClass> result = Collections.unmodifiableSet(receivers);
+        concreteReceiverFamilyCache.put(method, result);
+        return result;
+    }
+
+    /** Install the fallback only for descriptors that can actually receive a dynamic destroy call. */
+    private void ensureDestroyFallbackSlots() {
+        Set<ImClass> fallbackReceivers = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (PendingDispatch pending : pendingDispatches) {
+            if (!isDestroyDispatchMethod(pending.method)) {
+                continue;
+            }
+            fallbackReceivers.addAll(concreteReceiversFor(pending.method));
+        }
+        List<ImClass> sortedReceivers = new ArrayList<>(fallbackReceivers);
+        sortedReceivers.sort(Comparator.comparing(this::classSortKey));
+        for (ImClass receiver : sortedReceivers) {
+            if (isInterfaceClass(receiver)) {
+                continue;
+            }
+            Set<String> slots = emittedDispatchSlotsByClass.computeIfAbsent(receiver,
+                ignored -> new HashSet<>());
+            if (slots.add("__wurst_destroy")) {
+                emittedDispatchSlots.add("__wurst_destroy");
+                deferMainInit(LuaAst.LuaAssignment(
+                    LuaAst.LuaExprFieldAccess(LuaAst.LuaExprVarAccess(luaClassVar.getFor(receiver)), "__wurst_destroy"),
+                    LuaAst.LuaExprFuncRef(objectDealloc)));
+            }
+        }
     }
 
     private boolean sameDispatchFamily(ImMethod reference, ImMethod candidate) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -1332,7 +1332,9 @@ public class LuaTranslator {
             semanticNames.add(sourceName);
         }
         Set<ImClass> receivers = concreteReceiversFor(pending.method);
-        for (ImClass receiver : receivers) {
+        List<ImClass> sortedReceivers = new ArrayList<>(receivers);
+        sortedReceivers.sort(Comparator.comparing(this::classSortKey));
+        for (ImClass receiver : sortedReceivers) {
             List<ImMethod> candidates = new ArrayList<>();
             for (ImMethod candidate : collectMethodsInHierarchy(receiver)) {
                 if (sameDispatchFamily(pending.method, candidate)
@@ -1513,14 +1515,7 @@ public class LuaTranslator {
     }
 
     private boolean sameDispatchFamily(ImMethod reference, ImMethod candidate) {
-        if (dispatchGroupOf(reference) == dispatchGroupOf(candidate)) {
-            return true;
-        }
-        ImClass referenceOwner = reference.attrClass();
-        ImClass candidateOwner = candidate.attrClass();
-        return referenceOwner != null && candidateOwner != null
-            && (collectClassesInHierarchy(referenceOwner).contains(candidateOwner)
-                || collectClassesInHierarchy(candidateOwner).contains(referenceOwner));
+        return dispatchGroupOf(reference) == dispatchGroupOf(candidate);
     }
 
     /** Reconstruct dispatch-group identity from the IM override graph without using names. */

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -79,7 +79,9 @@ public class LuaTranslator {
     private final Set<String> usedNames = LuaReservedNames.all();
     private final Set<String> emittedDispatchSlots = new HashSet<>();
     private final Map<ImClass, Set<String>> emittedDispatchSlotsByClass = new IdentityHashMap<>();
-    private final Map<String, Set<ImClass>> concreteReceiverClassesByAlias = new HashMap<>();
+    private final Map<DispatchGroupIdentity, Set<ImClass>> concreteReceiverClassesByGroup = new HashMap<>();
+    private final Map<ImMethod, DispatchGroupIdentity> dispatchGroups = new IdentityHashMap<>();
+    private boolean dispatchGroupsBuilt;
     private boolean dispatchReceiverIndexBuilt;
     private final List<PendingDispatch> pendingDispatches = new ArrayList<>();
 
@@ -90,6 +92,33 @@ public class LuaTranslator {
         PendingDispatch(ImMethod method, LuaExprFieldAccess target) {
             this.method = method;
             this.target = target;
+        }
+    }
+
+    /**
+     * Identity of a dispatch group. The root is an IM method, not a generated Lua name: two
+     * unrelated groups are allowed to have equal names after generic elimination.
+     */
+    private static final class DispatchGroupIdentity {
+        final ImMethod root;
+        final String signature;
+
+        DispatchGroupIdentity(ImMethod root, String signature) {
+            this.root = root;
+            this.signature = signature;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof DispatchGroupIdentity that)) {
+                return false;
+            }
+            return root == that.root && Objects.equals(signature, that.signature);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * System.identityHashCode(root) + Objects.hashCode(signature);
         }
     }
 
@@ -331,6 +360,7 @@ public class LuaTranslator {
         }
 
         resolveDispatchSlots();
+        assertResolvedDispatchSlots();
 
         createBootstrapFunction();
         cleanStatements();
@@ -431,10 +461,6 @@ public class LuaTranslator {
 
     public static void assertNoLeakedHashtableNativeCalls(String luaCode) {
         LuaAssertions.assertNoLeakedHashtableNativeCalls(luaCode);
-    }
-
-    public static void assertDispatchSlotsHaveAssignments(String luaCode) {
-        LuaAssertions.assertDispatchSlotsHaveAssignments(luaCode);
     }
 
     static List<String> allHashtableNativeNames() {
@@ -1244,6 +1270,31 @@ public class LuaTranslator {
                 pending.target.setFieldName(resolved);
                 continue;
             }
+            if (!commonSlots.isEmpty()) {
+                throw new RuntimeException("Wurst Lua backend assertion failed: dispatch slot '"
+                    + current + "' is not registered by every concrete receiver descriptor.");
+            }
+        }
+    }
+
+    /** Verify every descriptor slot used by an emitted dispatch helper is registered by its receivers. */
+    private void assertResolvedDispatchSlots() {
+        for (PendingDispatch pending : pendingDispatches) {
+            String slot = pending.target.getFieldName();
+            Set<ImClass> receivers = concreteReceiverClassesByGroup.getOrDefault(
+                dispatchGroupOf(pending.method), Collections.emptySet());
+            if (receivers.isEmpty()) {
+                // Native/opaque callback interfaces can have no concrete IM receiver descriptor;
+                // their slot is supplied by the runtime rather than by this program.
+                continue;
+            }
+            for (ImClass receiver : receivers) {
+                Set<String> slots = emittedDispatchSlotsByClass.getOrDefault(receiver, Collections.emptySet());
+                if (!slots.contains(slot)) {
+                    throw new RuntimeException("Wurst Lua backend assertion failed: dispatch slot '"
+                        + slot + "' is missing from descriptor for " + receiver.getName() + ".");
+                }
+            }
         }
     }
 
@@ -1254,10 +1305,8 @@ public class LuaTranslator {
      */
     private Set<String> commonConcreteReceiverSlots(ImMethod method) {
         Set<String> common = null;
-        Set<ImClass> receivers = new HashSet<>();
-        for (String key : dispatchReceiverKeys(method)) {
-            receivers.addAll(concreteReceiverClassesByAlias.getOrDefault(key, Collections.emptySet()));
-        }
+        Set<ImClass> receivers = concreteReceiverClassesByGroup.getOrDefault(
+            dispatchGroupOf(method), Collections.emptySet());
         for (ImClass c : receivers) {
             Set<String> slots = emittedDispatchSlotsByClass.get(c);
             if (slots == null || slots.isEmpty()) {
@@ -1273,11 +1322,10 @@ public class LuaTranslator {
     }
 
     private boolean hasClosureReceiver(ImMethod method) {
-        for (String key : dispatchReceiverKeys(method)) {
-            for (ImClass c : concreteReceiverClassesByAlias.getOrDefault(key, Collections.emptySet())) {
-                if (c.attrTrace() instanceof ExprClosure) {
-                    return true;
-                }
+        for (ImClass c : concreteReceiverClassesByGroup.getOrDefault(
+            dispatchGroupOf(method), Collections.emptySet())) {
+            if (c.attrTrace() instanceof ExprClosure) {
+                return true;
             }
         }
         return false;
@@ -1288,36 +1336,78 @@ public class LuaTranslator {
             return;
         }
         dispatchReceiverIndexBuilt = true;
+        buildDispatchGroupIndex();
         for (ImClass receiver : prog.getClasses()) {
             for (ImMethod candidate : collectMethodsInHierarchy(receiver)) {
                 if (candidate.getIsAbstract() || candidate.getImplementation() == null) {
                     continue;
                 }
-                for (String key : dispatchReceiverKeys(candidate)) {
-                    concreteReceiverClassesByAlias.computeIfAbsent(key, ignored -> new HashSet<>()).add(receiver);
+                DispatchGroupIdentity group = dispatchGroups.get(candidate);
+                if (group != null) {
+                    concreteReceiverClassesByGroup.computeIfAbsent(group, ignored -> new HashSet<>()).add(receiver);
                 }
             }
         }
     }
 
-    private Set<String> dispatchReceiverKeys(ImMethod method) {
-        Set<String> keys = new HashSet<>();
-        keys.add(dispatchSlotName(method.getName()));
-        keys.add(dispatchSlotName(imTr.dispatchSegmentOf(method)));
-        for (String alias : method.getLuaMethodDispatchAliases()) {
-            if (alias != null && !alias.isEmpty()) {
-                keys.add(dispatchSlotName(alias));
+    private DispatchGroupIdentity dispatchGroupOf(ImMethod method) {
+        buildDispatchGroupIndex();
+        return dispatchGroups.get(method);
+    }
+
+    /** Reconstruct dispatch-group identity from the IM override graph without using names. */
+    private void buildDispatchGroupIndex() {
+        if (dispatchGroupsBuilt) {
+            return;
+        }
+        dispatchGroupsBuilt = true;
+        List<ImMethod> methods = new ArrayList<>();
+        for (ImClass c : prog.getClasses()) {
+            methods.addAll(c.getMethods());
+        }
+        Set<ImMethod> knownMethods = Collections.newSetFromMap(new IdentityHashMap<>());
+        knownMethods.addAll(methods);
+        Map<ImMethod, ImMethod> parent = new IdentityHashMap<>();
+        for (ImMethod method : methods) {
+            parent.put(method, method);
+        }
+        for (ImMethod method : methods) {
+            for (ImMethod subMethod : method.getSubMethods()) {
+                if (knownMethods.contains(subMethod)) {
+                    unionDispatchGroups(parent, method, subMethod);
+                }
             }
         }
-        String declaredName = LuaDispatchPreparation.declaredName(method);
-        if (!declaredName.isEmpty()) {
-            keys.add(dispatchSlotName(declaredName));
+        Map<ImMethod, Map<String, DispatchGroupIdentity>> identities = new IdentityHashMap<>();
+        for (ImMethod method : methods) {
+            ImMethod root = findDispatchGroupRoot(parent, method);
+            String signature = method.getLuaDispatchGroupKey();
+            DispatchGroupIdentity identity = identities
+                .computeIfAbsent(root, ignored -> new HashMap<>())
+                .computeIfAbsent(signature, ignored -> new DispatchGroupIdentity(root, signature));
+            dispatchGroups.put(method, identity);
         }
-        String sourceName = sourceSemanticName(method);
-        if (!sourceName.isEmpty()) {
-            keys.add(dispatchSlotName(sourceName));
+    }
+
+    private static ImMethod findDispatchGroupRoot(Map<ImMethod, ImMethod> parent, ImMethod method) {
+        ImMethod root = method;
+        ImMethod next;
+        while ((next = parent.get(root)) != root) {
+            root = next;
         }
-        return keys;
+        while ((next = parent.get(method)) != method) {
+            parent.put(method, root);
+            method = next;
+        }
+        return root;
+    }
+
+    private static void unionDispatchGroups(Map<ImMethod, ImMethod> parent, ImMethod left, ImMethod right) {
+        ImMethod leftRoot = findDispatchGroupRoot(parent, left);
+        ImMethod rightRoot = findDispatchGroupRoot(parent, right);
+        if (leftRoot != rightRoot) {
+            parent.put(rightRoot, leftRoot);
+        }
     }
 
     /**

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -78,6 +78,7 @@ public class LuaTranslator {
     private final Map<String, Integer> uniqueNameCounters = new HashMap<>();
     private final Set<String> usedNames = LuaReservedNames.all();
     private final Set<String> emittedDispatchSlots = new HashSet<>();
+    private final Map<ImClass, Set<String>> emittedDispatchSlotsByClass = new IdentityHashMap<>();
     private final List<PendingDispatch> pendingDispatches = new ArrayList<>();
 
     private static final class PendingDispatch {
@@ -1190,6 +1191,7 @@ public class LuaTranslator {
                 continue;
             }
             emittedDispatchSlots.add(e.getKey());
+            emittedDispatchSlotsByClass.computeIfAbsent(c, ignored -> new HashSet<>()).add(e.getKey());
             deferMainInit(LuaAst.LuaAssignment(LuaAst.LuaExprFieldAccess(
                 LuaAst.LuaExprVarAccess(classVar),
                 e.getKey()),
@@ -1205,15 +1207,23 @@ public class LuaTranslator {
             Set<String> candidates = new TreeSet<>();
             String methodName = dispatchSlotName(pending.method.getName());
             String segment = dispatchSlotName(imTr.dispatchSegmentOf(pending.method));
-            if (emittedDispatchSlots.contains(methodName)) {
+            Set<String> commonSlots = hasClosureReceiver(pending.method)
+                ? commonConcreteReceiverSlots(pending.method)
+                : Collections.emptySet();
+            // Some erased generic override chains do not retain one shared structural key in the
+            // IM even though their normalized aliases are compatible. Preserve the established
+            // global resolution for those chains; the family intersection is authoritative when
+            // it is available (which is the specialization/closure case this guards).
+            Set<String> resolutionSlots = commonSlots.isEmpty() ? emittedDispatchSlots : commonSlots;
+            if (resolutionSlots.contains(methodName)) {
                 pending.target.setFieldName(methodName);
                 continue;
             }
-            if (emittedDispatchSlots.contains(segment)) {
+            if (resolutionSlots.contains(segment)) {
                 pending.target.setFieldName(segment);
                 continue;
             }
-            if (emittedDispatchSlots.contains(current)) {
+            if (resolutionSlots.contains(current)) {
                 continue;
             }
             candidates.add(methodName);
@@ -1224,30 +1234,69 @@ public class LuaTranslator {
                 }
             }
             String resolved = candidates.stream()
-                .filter(emittedDispatchSlots::contains)
+                .filter(resolutionSlots::contains)
                 .sorted(Comparator.comparingInt(String::length).thenComparing(String::compareTo))
                 .findFirst().orElse(null);
             if (resolved != null) {
                 pending.target.setFieldName(resolved);
                 continue;
             }
-            if (hasConcreteDispatchImplementation(pending.method)) {
-                throw new RuntimeException("Wurst Lua backend assertion failed: dispatch slot '"
-                    + current + "' has no matching class-table assignment.");
-            }
         }
     }
 
-    private boolean hasConcreteDispatchImplementation(ImMethod method) {
-        String groupKey = method.getLuaDispatchGroupKey();
+    /**
+     * Return only slots shared by every concrete descriptor which can receive this dispatch
+     * group. A global slot union is insufficient: an unrelated specialization may register the
+     * mangled method name while closure descriptors for the same helper register only its alias.
+     */
+    private Set<String> commonConcreteReceiverSlots(ImMethod method) {
+        Set<String> common = null;
         for (ImClass c : prog.getClasses()) {
-            for (ImMethod candidate : c.getMethods()) {
-                if (candidate.getIsAbstract() || candidate.getImplementation() == null) {
-                    continue;
-                }
-                if (groupKey != null && groupKey.equals(candidate.getLuaDispatchGroupKey())) {
-                    return true;
-                }
+            if (!hasConcreteDispatchImplementation(c, method)) {
+                continue;
+            }
+            Set<String> slots = emittedDispatchSlotsByClass.get(c);
+            if (slots == null || slots.isEmpty()) {
+                continue;
+            }
+            if (common == null) {
+                common = new HashSet<>(slots);
+            } else {
+                common.retainAll(slots);
+            }
+        }
+        return common == null ? Collections.emptySet() : common;
+    }
+
+    private boolean hasClosureReceiver(ImMethod method) {
+        for (ImClass c : prog.getClasses()) {
+            if (c.attrTrace() instanceof ExprClosure && hasConcreteDispatchImplementation(c, method)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasConcreteDispatchImplementation(ImClass receiverClass, ImMethod method) {
+        Set<String> aliases = new HashSet<>();
+        aliases.add(dispatchSlotName(method.getName()));
+        aliases.add(dispatchSlotName(imTr.dispatchSegmentOf(method)));
+        for (String alias : method.getLuaMethodDispatchAliases()) {
+            if (alias != null && !alias.isEmpty()) {
+                aliases.add(dispatchSlotName(alias));
+            }
+        }
+        String declaredName = LuaDispatchPreparation.declaredName(method);
+        String sourceName = sourceSemanticName(method);
+        for (ImMethod candidate : collectMethodsInHierarchy(receiverClass)) {
+            if (!candidate.getIsAbstract()
+                && candidate.getImplementation() != null
+                && (aliases.contains(dispatchSlotName(candidate.getName()))
+                    || aliases.contains(dispatchSlotName(imTr.dispatchSegmentOf(candidate)))
+                    || (!declaredName.isEmpty() && declaredName.equals(LuaDispatchPreparation.declaredName(candidate)))
+                    || (!sourceName.isEmpty() && sourceName.equals(sourceSemanticName(candidate))
+                        && LuaDispatchPreparation.compatibleReturnTypes(method, candidate, imTr)))) {
+                return true;
             }
         }
         return false;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -1263,6 +1263,11 @@ public class LuaTranslator {
             String methodName = dispatchSlotName(pending.method.getName());
             String segment = dispatchSlotName(imTr.dispatchSegmentOf(pending.method));
             Set<ImClass> receivers = concreteReceiversFor(pending.method);
+            if (isDestroyDispatchMethod(pending.method)
+                && emittedDispatchSlots.contains("__wurst_destroy")) {
+                setResolvedDispatchSlot(pending, "__wurst_destroy");
+                continue;
+            }
             Set<String> commonSlots = receivers.isEmpty()
                 ? Collections.emptySet()
                 : commonConcreteReceiverSlots(pending.method);
@@ -1273,11 +1278,6 @@ public class LuaTranslator {
             Set<String> resolutionSlots = receivers.isEmpty() ? emittedDispatchSlots : commonSlots;
             if (!receivers.isEmpty() && commonSlots.isEmpty()) {
                 ensureCanonicalDispatchSlot(pending);
-                continue;
-            }
-            if (isDestroyDispatchMethod(pending.method)
-                && emittedDispatchSlots.contains("__wurst_destroy")) {
-                setResolvedDispatchSlot(pending, "__wurst_destroy");
                 continue;
             }
             if (resolutionSlots.contains(methodName)) {
@@ -1452,7 +1452,7 @@ public class LuaTranslator {
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toSet());
             if (slots == null || slots.isEmpty()) {
-                continue;
+                return Collections.emptySet();
             }
             if (common == null) {
                 common = new HashSet<>(slots);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -15,6 +15,7 @@ import de.peeeq.wurstscript.utils.Lazy;
 import de.peeeq.wurstscript.utils.Utils;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static de.peeeq.wurstscript.translation.lua.translation.ExprTranslation.WURST_SUPERTYPES;
@@ -79,6 +80,7 @@ public class LuaTranslator {
     private final Set<String> usedNames = LuaReservedNames.all();
     private final Set<String> emittedDispatchSlots = new HashSet<>();
     private final Map<ImClass, Set<String>> emittedDispatchSlotsByClass = new IdentityHashMap<>();
+    private final Map<ImClass, Map<String, Set<DispatchGroupIdentity>>> emittedDispatchSlotGroupsByClass = new IdentityHashMap<>();
     private final Map<DispatchGroupIdentity, Set<ImClass>> concreteReceiverClassesByGroup = new HashMap<>();
     private final Map<ImClass, Set<ImClass>> concreteReceiverClassesByNominalType = new IdentityHashMap<>();
     private final Map<ImMethod, DispatchGroupIdentity> dispatchGroups = new IdentityHashMap<>();
@@ -1230,8 +1232,7 @@ public class LuaTranslator {
             if (impl == null || impl.getImplementation() == null) {
                 continue;
             }
-            emittedDispatchSlots.add(e.getKey());
-            emittedDispatchSlotsByClass.computeIfAbsent(c, ignored -> new HashSet<>()).add(e.getKey());
+            registerDispatchSlot(c, e.getKey(), dispatchGroupOf(impl));
             deferMainInit(LuaAst.LuaAssignment(LuaAst.LuaExprFieldAccess(
                 LuaAst.LuaExprVarAccess(classVar),
                 e.getKey()),
@@ -1239,6 +1240,17 @@ public class LuaTranslator {
             ));
         }
 
+    }
+
+    private void registerDispatchSlot(ImClass receiver, String slot, DispatchGroupIdentity group) {
+        emittedDispatchSlots.add(slot);
+        emittedDispatchSlotsByClass.computeIfAbsent(receiver, ignored -> new HashSet<>()).add(slot);
+        if (group != null) {
+            emittedDispatchSlotGroupsByClass
+                .computeIfAbsent(receiver, ignored -> new HashMap<>())
+                .computeIfAbsent(slot, ignored -> new HashSet<>())
+                .add(group);
+        }
     }
 
     /** Resolve dispatch helper targets against the slots actually registered by class descriptors. */
@@ -1344,7 +1356,7 @@ public class LuaTranslator {
             }
             Set<String> registered = emittedDispatchSlotsByClass.computeIfAbsent(receiver, ignored -> new HashSet<>());
             if (registered.add(slot)) {
-                emittedDispatchSlots.add(slot);
+                registerDispatchSlot(receiver, slot, group);
                 deferMainInit(LuaAst.LuaAssignment(
                     LuaAst.LuaExprFieldAccess(LuaAst.LuaExprVarAccess(luaClassVar.getFor(receiver)), slot),
                     LuaAst.LuaExprFuncRef(luaFunc.getFor(implementation.getImplementation()))));
@@ -1432,8 +1444,13 @@ public class LuaTranslator {
     private Set<String> commonConcreteReceiverSlots(ImMethod method) {
         Set<String> common = null;
         Set<ImClass> receivers = concreteReceiversFor(method);
+        DispatchGroupIdentity group = dispatchGroupOf(method);
         for (ImClass c : receivers) {
-            Set<String> slots = emittedDispatchSlotsByClass.get(c);
+            Map<String, Set<DispatchGroupIdentity>> slotGroups = emittedDispatchSlotGroupsByClass.get(c);
+            Set<String> slots = slotGroups == null ? Collections.emptySet() : slotGroups.entrySet().stream()
+                .filter(entry -> group != null && entry.getValue().contains(group))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
             if (slots == null || slots.isEmpty()) {
                 continue;
             }
@@ -1539,8 +1556,8 @@ public class LuaTranslator {
             }
             Set<String> slots = emittedDispatchSlotsByClass.computeIfAbsent(receiver,
                 ignored -> new HashSet<>());
-            if (slots.add("__wurst_destroy")) {
-                emittedDispatchSlots.add("__wurst_destroy");
+            if (!slots.contains("__wurst_destroy")) {
+                registerDispatchSlot(receiver, "__wurst_destroy", null);
                 deferMainInit(LuaAst.LuaAssignment(
                     LuaAst.LuaExprFieldAccess(LuaAst.LuaExprVarAccess(luaClassVar.getFor(receiver)), "__wurst_destroy"),
                     LuaAst.LuaExprFuncRef(objectDealloc)));

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -1534,6 +1534,157 @@ public class LuaBackendAuditTests extends WurstScriptTest {
         test().testLua(true).executeProg().lines(source.toArray(new String[0]));
     }
 
+    /**
+     * Differential dispatch corpus: every generated case executes the same generic interface
+     * calls through the Jass interpreter and the Lua runtime. Keeping the seed fixed makes a
+     * failure reproducible while varying specialization order, tuple shapes, nesting, and two
+     * unrelated interfaces whose method names deliberately match.
+     */
+    @Test
+    public void randomizedGenericTupleDispatchMatchesJassAndLua() {
+        Random random = new Random(0x71A9D15CL);
+        for (int caseIndex = 0; caseIndex < 8; caseIndex++) {
+            List<String> source = genericTupleDispatchCase(random, caseIndex);
+            String[] lines = source.toArray(new String[0]);
+            try {
+                test().executeProg().lines(lines);
+            } catch (Exception | Error e) {
+                throw new AssertionError("dispatch fuzz case " + caseIndex + " failed in Jass:\n"
+                    + String.join("\n", lines), e);
+            }
+            try {
+                test().testLua(true).executeProg().lines(lines);
+            } catch (Exception | Error e) {
+                throw new AssertionError("dispatch fuzz case " + caseIndex + " failed in Lua:\n"
+                    + String.join("\n", lines), e);
+            }
+        }
+    }
+
+    /** A user method beginning with {@code destroy} is ordinary virtual dispatch, not lifecycle
+     * destruction.  The lifecycle slot is identified from the generated OnDestroy function. */
+    @Test
+    public void ordinaryDestroyNamedMethodDoesNotUseLifecycleDispatchSlot() throws IOException {
+        test().testLua(true).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "interface Destroyer",
+            "    function destroyValue() returns int",
+            "class Implementation implements Destroyer",
+            "    override function destroyValue() returns int",
+            "        return 7",
+            "init",
+            "    Destroyer value = new Implementation()",
+            "    if value.destroyValue() == 7",
+            "        testSuccess()",
+            "    destroy value"
+        );
+        String compiled = compiledLua("ordinaryDestroyNamedMethodDoesNotUseLifecycleDispatchSlot");
+        int dispatchStart = compiled.indexOf("function dispatch_Destroyer_destroyValue");
+        int dispatchEnd = compiled.indexOf("\nend", dispatchStart);
+        assertTrue(dispatchStart >= 0 && dispatchEnd > dispatchStart);
+        String dispatchBody = compiled.substring(dispatchStart, dispatchEnd);
+        assertTrue(dispatchBody.contains(".Destroyer_destroyValue"));
+        assertFalse(dispatchBody.contains(".__wurst_destroy"));
+    }
+
+    private List<String> genericTupleDispatchCase(Random random, int caseIndex) {
+        List<String> source = new ArrayList<>();
+        Collections.addAll(source,
+            "package Test",
+            "native testSuccess()",
+            "tuple PairInt(int a, int b)",
+            "tuple PairText(string a, int b)",
+            "interface Predicate<T:>",
+            "    function test(T value) returns boolean",
+            "interface OtherPredicate<T:>",
+            "    function test(T value) returns boolean",
+            "class Box<T:>",
+            "    T value",
+            "    construct(T value)",
+            "        this.value = value",
+            "    function matches(Predicate<T> predicate) returns boolean",
+            "        let result = predicate.test(value)",
+            "        destroy predicate",
+            "        return result",
+            "class OtherBox<T:>",
+            "    T value",
+            "    construct(T value)",
+            "        this.value = value",
+            "    function matches(OtherPredicate<T> predicate) returns boolean",
+            "        let result = predicate.test(value)",
+            "        destroy predicate",
+            "        return result",
+            "class Nested<T:>",
+            "    Box<T> inner",
+            "    construct(T value)",
+            "        inner = new Box<T>(value)",
+            "    function matches(Predicate<T> predicate) returns boolean",
+            "        return inner.matches(predicate)",
+            "    ondestroy",
+            "        destroy inner",
+            "class Foo",
+            "class Bar",
+            "class FooPredicate implements Predicate<Foo>",
+            "    function test(Foo value) returns boolean",
+            "        return value != null",
+            "init",
+            "    int successes = 0");
+
+        int expected = 0;
+        for (int i = 0; i < 16; i++) {
+            int value = random.nextInt(100) + 1;
+            switch (random.nextInt(7)) {
+                case 0 -> {
+                    source.add("    let value" + i + " = new Box<PairInt>(PairInt(" + value + ", " + (value + 1) + "))");
+                    source.add("    if value" + i + ".matches(x -> x.a == " + value + ")");
+                    source.add("        successes++");
+                    source.add("    destroy value" + i);
+                }
+                case 1 -> {
+                    source.add("    let value" + i + " = new Box<PairText>(PairText(\"v" + value + "\", " + value + "))");
+                    source.add("    if value" + i + ".matches(x -> x.a == \"v" + value + "\")");
+                    source.add("        successes++");
+                    source.add("    destroy value" + i);
+                }
+                case 2 -> {
+                    source.add("    let value" + i + " = new Nested<PairInt>(PairInt(" + value + ", " + (value + 2) + "))");
+                    source.add("    if value" + i + ".matches(x -> x.b == " + (value + 2) + ")");
+                    source.add("        successes++");
+                    source.add("    destroy value" + i);
+                }
+                case 3 -> {
+                    source.add("    let value" + i + " = new Box<Foo>(new Foo())");
+                    source.add("    if value" + i + ".matches(x -> x != null)");
+                    source.add("        successes++");
+                    source.add("    destroy value" + i);
+                }
+                case 4 -> {
+                    source.add("    let value" + i + " = new OtherBox<Foo>(new Foo())");
+                    source.add("    if value" + i + ".matches(x -> x != null)");
+                    source.add("        successes++");
+                    source.add("    destroy value" + i);
+                }
+                case 5 -> {
+                    source.add("    let value" + i + " = new OtherBox<Bar>(new Bar())");
+                    source.add("    if value" + i + ".matches(x -> x != null)");
+                    source.add("        successes++");
+                    source.add("    destroy value" + i);
+                }
+                default -> {
+                    source.add("    let value" + i + " = new Box<Foo>(new Foo())");
+                    source.add("    if value" + i + ".matches(new FooPredicate())");
+                    source.add("        successes++");
+                    source.add("    destroy value" + i);
+                }
+            }
+            expected++;
+        }
+        source.add("    if successes == " + expected);
+        source.add("        testSuccess()");
+        return source;
+    }
+
     @Test
     public void tupleSpecializedStaticInitializerCycleDoesNotRootErasedCopy() throws IOException {
         test().testLua(true).executeProg().lines(

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -1554,6 +1554,10 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             }
             try {
                 test().testLua(true).executeProg().lines(lines);
+            } catch (org.testng.SkipException e) {
+                // Lua is optional on developer/CI hosts; preserve the framework's visible skip
+                // instead of turning it into a dispatch failure through the diagnostic wrapper.
+                throw e;
             } catch (Exception | Error e) {
                 throw new AssertionError("dispatch fuzz case " + caseIndex + " failed in Lua:\n"
                     + String.join("\n", lines), e);

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -1607,17 +1607,20 @@ public class LuaTranslationTests extends WurstScriptTest {
             "    function test(Foo value) returns boolean",
             "        return value != null",
             "init",
+            "    int successes = 0",
             "    let first = new Box<pair>(pair(1, 2))",
             "    if first.matches(x -> x.a == 1)",
-            "        testSuccess()",
+            "        successes++",
             "    let second = new Box<pair2>(pair2(\"two\", 3))",
             "    if second.matches(x -> x.a == \"two\")",
-            "        testSuccess()",
+            "        successes++",
             "    let ordinary = new Box<Foo>(new Foo())",
             "    if ordinary.matches(x -> x != null)",
-            "        testSuccess()",
+            "        successes++",
             "    let ordinaryImpl = new Box<Foo>(new Foo())",
             "    if ordinaryImpl.matches(new Impl())",
+            "        successes++",
+            "    if successes == 4",
             "        testSuccess()"
         );
         String compiled = Files.toString(new File(

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -1579,6 +1579,52 @@ public class LuaTranslationTests extends WurstScriptTest {
         assertEquals("The root-slot fixture must emit deterministic Lua across compilations.", compiled, compiledAgain);
     }
 
+    /**
+     * Generic interface dispatch must use the same normalized slot as the descriptor entries.
+     * Keeping both tuple and ordinary class instantiations in one program is important: tuple
+     * specialization is what exposes the unspecialized generic call path, while the class path
+     * proves that the specialization does not merely work by accident for one representation.
+     */
+    @Test
+    public void genericInterfaceDispatchUsesRegisteredSlotForTupleAndUnspecializedPaths() throws IOException {
+        test().testLua(true).executeProg().lines(
+            "package test",
+            "native testSuccess()",
+            "tuple pair(int a, int b)",
+            "tuple pair2(string a, int b)",
+            "interface Predicate<T:>",
+            "    function test(T t) returns boolean",
+            "class Box<T:>",
+            "    T value",
+            "    construct(T value)",
+            "        this.value = value",
+            "    function matches(Predicate<T> p) returns boolean",
+            "        let result = p.test(value)",
+            "        destroy p",
+            "        return result",
+            "class Foo",
+            "init",
+            "    let first = new Box<pair>(pair(1, 2))",
+            "    if first.matches(x -> x.a == 1)",
+            "        testSuccess()",
+            "    let second = new Box<pair2>(pair2(\"two\", 3))",
+            "    if second.matches(x -> x.a == \"two\")",
+            "        testSuccess()",
+            "    let ordinary = new Box<Foo>(new Foo())",
+            "    if ordinary.matches(x -> x != null)",
+            "        testSuccess()"
+        );
+        String compiled = Files.toString(new File(
+            "test-output/lua/LuaTranslationTests_genericInterfaceDispatchUsesRegisteredSlotForTupleAndUnspecializedPaths.lua"),
+            Charsets.UTF_8);
+        assertContainsRegex(compiled,
+            "function dispatch_Predicate_test\\([^\\)]*\\)[\\s\\S]*__wurst_objectClass\\[[^\\]]+\\]\\.test");
+        assertDoesNotContainRegex(compiled,
+            "__wurst_objectClass\\[[^\\]]+\\]\\.Predicate_test");
+        de.peeeq.wurstscript.translation.lua.translation.LuaTranslator
+            .assertDispatchSlotsHaveAssignments(compiled);
+    }
+
     @Test
     public void overloadedOverrideOnAGenericBaseIsReachedThroughTheBase() {
         test().testLua(true).executeProg().lines(
@@ -2889,6 +2935,19 @@ public class LuaTranslationTests extends WurstScriptTest {
             fail("Expected RuntimeException for missing __wurst_GetHandleId helper definition");
         } catch (RuntimeException e) {
             assertTrue(e.getMessage().contains("__wurst_GetHandleId"));
+        }
+    }
+
+    @Test
+    public void dispatchSlotAssertionRequiresAClassTableAssignment() {
+        de.peeeq.wurstscript.translation.lua.translation.LuaTranslator
+            .assertDispatchSlotsHaveAssignments("__wurst_objectClass[r].test(r)\nPredicate.test = f");
+        try {
+            de.peeeq.wurstscript.translation.lua.translation.LuaTranslator
+                .assertDispatchSlotsHaveAssignments("__wurst_objectClass[r].missing(r)");
+            fail("Expected RuntimeException for a missing descriptor dispatch slot");
+        } catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains("missing"));
         }
     }
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -1627,8 +1627,6 @@ public class LuaTranslationTests extends WurstScriptTest {
             "function dispatch_Predicate_test\\([^\\)]*\\)[\\s\\S]*__wurst_objectClass\\[[^\\]]+\\]\\.test");
         assertDoesNotContainRegex(compiled,
             "__wurst_objectClass\\[[^\\]]+\\]\\.Predicate_test");
-        de.peeeq.wurstscript.translation.lua.translation.LuaTranslator
-            .assertDispatchSlotsHaveAssignments(compiled);
     }
 
     @Test
@@ -2941,19 +2939,6 @@ public class LuaTranslationTests extends WurstScriptTest {
             fail("Expected RuntimeException for missing __wurst_GetHandleId helper definition");
         } catch (RuntimeException e) {
             assertTrue(e.getMessage().contains("__wurst_GetHandleId"));
-        }
-    }
-
-    @Test
-    public void dispatchSlotAssertionRequiresAClassTableAssignment() {
-        de.peeeq.wurstscript.translation.lua.translation.LuaTranslator
-            .assertDispatchSlotsHaveAssignments("__wurst_objectClass[r].test(r)\nPredicate.test = f");
-        try {
-            de.peeeq.wurstscript.translation.lua.translation.LuaTranslator
-                .assertDispatchSlotsHaveAssignments("__wurst_objectClass[r].missing(r)");
-            fail("Expected RuntimeException for a missing descriptor dispatch slot");
-        } catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains("missing"));
         }
     }
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -1603,6 +1603,9 @@ public class LuaTranslationTests extends WurstScriptTest {
             "        destroy p",
             "        return result",
             "class Foo",
+            "class Impl implements Predicate<Foo>",
+            "    function test(Foo value) returns boolean",
+            "        return value != null",
             "init",
             "    let first = new Box<pair>(pair(1, 2))",
             "    if first.matches(x -> x.a == 1)",
@@ -1612,6 +1615,9 @@ public class LuaTranslationTests extends WurstScriptTest {
             "        testSuccess()",
             "    let ordinary = new Box<Foo>(new Foo())",
             "    if ordinary.matches(x -> x != null)",
+            "        testSuccess()",
+            "    let ordinaryImpl = new Box<Foo>(new Foo())",
+            "    if ordinaryImpl.matches(new Impl())",
             "        testSuccess()"
         );
         String compiled = Files.toString(new File(

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -1624,7 +1624,9 @@ public class LuaTranslationTests extends WurstScriptTest {
             "test-output/lua/LuaTranslationTests_genericInterfaceDispatchUsesRegisteredSlotForTupleAndUnspecializedPaths.lua"),
             Charsets.UTF_8);
         assertContainsRegex(compiled,
-            "function dispatch_Predicate_test\\([^\\)]*\\)[\\s\\S]*__wurst_objectClass\\[[^\\]]+\\]\\.test");
+            "function dispatch_Predicate_test\\([^\\)]*\\)[\\s\\S]*__wurst_objectClass\\[[^\\]]+\\]\\.__wurst_dispatch_test");
+        assertContainsRegex(compiled, "Predicate_matches_test\\.__wurst_dispatch_test\\s*=");
+        assertContainsRegex(compiled, "Impl\\.__wurst_dispatch_test\\s*=");
         assertDoesNotContainRegex(compiled,
             "__wurst_objectClass\\[[^\\]]+\\]\\.Predicate_test");
     }


### PR DESCRIPTION
## What changed

Fix Lua generic-interface dispatch when tuple specialization and unspecialized generic calls coexist. Dispatch helpers now resolve their field key against the slots actually registered by emitted class descriptors, preserving qualified generic slots and selecting normalized aliases where required.

The Lua translator also validates that concrete dispatch groups resolve to a registered descriptor slot, so this class of missing-key failure is reported during compilation instead of at map runtime.

## Validation

- `:shadowJar` — passed
- `test --tests tests.wurstscript.tests.LuaTranslationTests` — passed
- Focused tuple/class generic dispatch regression — passed
- `git diff --check` — passed

## Acceptance criteria

- Tuple-specialized and ordinary generic interface calls dispatch successfully in Lua.
- Existing qualified generic dispatch slots remain unchanged.
- Generated Lua remains deterministic and behaviorally compatible.
