### PR TITLE
Preserve externally visible names during optimization

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/WurstChecker.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/WurstChecker.java
@@ -7,7 +7,6 @@ import de.peeeq.wurstscript.attributes.ErrorHandler;
 import de.peeeq.wurstscript.attributes.names.DesugarArrayLength;
 import de.peeeq.wurstscript.gui.WurstGui;
 import de.peeeq.wurstscript.validation.GlobalCaches;
-import de.peeeq.wurstscript.validation.TRVEHelper;
 import de.peeeq.wurstscript.validation.WurstValidator;
 
 import java.util.ArrayList;
@@ -36,7 +35,6 @@ public class WurstChecker {
         if (root.isEmpty()) {
             return;
         }
-        TRVEHelper.protectedVariables.clear();
         new DesugarArrayLength().run(root);
         gui.sendProgress("Checking Files");
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/GlobalsInliner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/GlobalsInliner.java
@@ -6,7 +6,7 @@ import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.translation.imtranslation.ImHelper;
 import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
 import de.peeeq.wurstscript.utils.Utils;
-import de.peeeq.wurstscript.validation.TRVEHelper;
+import de.peeeq.wurstscript.validation.NamePreservation;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -47,8 +47,8 @@ public class GlobalsInliner implements OptimizerPass {
                 // cannot optimize arrays yet
                 continue;
             }
-            if (TRVEHelper.protectedVariables.contains(v.getName())) {
-                // keep TRVE vars
+            if (NamePreservation.isPreserved(v)) {
+                // keep names which are part of the external Warcraft III API
                 continue;
             }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImCompressor.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImCompressor.java
@@ -5,7 +5,7 @@ import de.peeeq.wurstscript.jassIm.ImProg;
 import de.peeeq.wurstscript.jassIm.ImVar;
 import de.peeeq.wurstscript.translation.imtranslation.ImHelper;
 import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
-import de.peeeq.wurstscript.validation.TRVEHelper;
+import de.peeeq.wurstscript.validation.NamePreservation;
 
 public class ImCompressor {
 
@@ -27,9 +27,8 @@ public class ImCompressor {
 
     public void compressGlobals() {
         for (final ImVar global : prog.getGlobals()) {
-            if (global.getIsBJ() || TRVEHelper.protectedVariables.contains(global.getName())) {
-                // do not rename bj constants
-                // do not rename TRVE vars
+            if (global.getIsBJ() || NamePreservation.isPreserved(global)) {
+                // do not rename bj constants or names exposed to Warcraft III
                 continue;
             }
 
@@ -41,7 +40,8 @@ public class ImCompressor {
 
     public void compressFunctions() {
         for (ImFunction func : ImHelper.calculateFunctionsOfProg(prog)) {
-            if (func.isNative() || func.isBj() || func.isCompiletime() || func.isExtern()) {
+            if (func.isNative() || func.isBj() || func.isCompiletime() || func.isExtern()
+                || NamePreservation.isPreserved(func)) {
                 // do not rename builtin an bj functions
                 continue;
             }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImCompressor.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImCompressor.java
@@ -7,16 +7,30 @@ import de.peeeq.wurstscript.translation.imtranslation.ImHelper;
 import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
 import de.peeeq.wurstscript.validation.NamePreservation;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class ImCompressor {
 
     private final ImTranslator trans;
     private final ImProg prog;
     private final NameGenerator ng;
+    private final Set<String> preservedNames = new HashSet<>();
 
     public ImCompressor(ImTranslator translator) {
         this.trans = translator;
         this.prog = translator.getImProg();
         ng = new NameGenerator();
+        for (ImVar global : prog.getGlobals()) {
+            if (NamePreservation.isPreserved(global)) {
+                preservedNames.add(global.getName());
+            }
+        }
+        for (ImFunction function : ImHelper.calculateFunctionsOfProg(prog)) {
+            if (NamePreservation.isPreserved(function)) {
+                preservedNames.add(function.getName());
+            }
+        }
     }
 
     public void compressNames() {
@@ -32,7 +46,7 @@ public class ImCompressor {
                 continue;
             }
 
-            String replacement = ng.getUniqueToken();
+            String replacement = nextCompressedName();
 
             global.setName(replacement);
         }
@@ -50,10 +64,18 @@ public class ImCompressor {
                 // do not rename main and config functions
                 continue;
             }
-            String rname = ng.getUniqueToken();
+            String rname = nextCompressedName();
             func.setName(rname);
         }
 
+    }
+
+    private String nextCompressedName() {
+        String replacement;
+        do {
+            replacement = ng.getUniqueToken();
+        } while (preservedNames.contains(replacement));
+        return replacement;
     }
 
     private void compressLocals(ImFunction func) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImOptimizer.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imoptimizer/ImOptimizer.java
@@ -17,7 +17,7 @@ import de.peeeq.wurstscript.translation.imtranslation.ImHelper;
 import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
 import de.peeeq.wurstscript.types.TypesHelper;
 import de.peeeq.wurstscript.utils.Pair;
-import de.peeeq.wurstscript.validation.TRVEHelper;
+import de.peeeq.wurstscript.validation.NamePreservation;
 
 import java.util.stream.Collectors;
 
@@ -174,13 +174,13 @@ public class ImOptimizer {
                         super.visit(e);
                         if (e.getLeft() instanceof ImVarAccess) {
                             ImVarAccess va = (ImVarAccess) e.getLeft();
-                            if (!readVars.contains(va.getVar()) && !TRVEHelper.protectedVariables.contains(va.getVar().getName())) {
+                            if (!readVars.contains(va.getVar()) && !NamePreservation.isPreserved(va.getVar())) {
                                 List<ImExpr> sideEffects = collectSideEffects(e.getRight(), sideEffectAnalyzer);
                                 replacements.add(Pair.create(e, sideEffects));
                             }
                         } else if (e.getLeft() instanceof ImVarArrayAccess) {
                             ImVarArrayAccess va = (ImVarArrayAccess) e.getLeft();
-                            if (!readVars.contains(va.getVar()) && !TRVEHelper.protectedVariables.contains(va.getVar().getName())) {
+                            if (!readVars.contains(va.getVar()) && !NamePreservation.isPreserved(va.getVar())) {
                                 List<ImExpr> exprs = new ArrayList<>();
                                 for (ImExpr index : va.getIndexes()) {
                                     exprs.addAll(collectSideEffects(index, sideEffectAnalyzer));
@@ -190,13 +190,13 @@ public class ImOptimizer {
                             }
                         } else if (e.getLeft() instanceof ImTupleSelection) {
                             ImVar var = TypesHelper.getTupleVar((ImTupleSelection) e.getLeft());
-                            if(var != null && !readVars.contains(var) && !TRVEHelper.protectedVariables.contains(var.getName())) {
+                            if(var != null && !readVars.contains(var) && !NamePreservation.isPreserved(var)) {
                                 List<ImExpr> sideEffects = collectSideEffects(e.getRight(), sideEffectAnalyzer);
                                 replacements.add(Pair.create(e, sideEffects));
                             }
                         } else if(e.getLeft() instanceof ImMemberAccess) {
                             ImMemberAccess va = ((ImMemberAccess) e.getLeft());
-                            if (!readVars.contains(va.getVar()) && !TRVEHelper.protectedVariables.contains(va.getVar().getName())) {
+                            if (!readVars.contains(va.getVar()) && !NamePreservation.isPreserved(va.getVar())) {
                                 List<ImExpr> sideEffects = collectSideEffects(e.getRight(), sideEffectAnalyzer);
                                 replacements.add(Pair.create(e, sideEffects));
                             }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImToJassTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImToJassTranslator.java
@@ -9,6 +9,7 @@ import de.peeeq.wurstscript.parser.WPos;
 import de.peeeq.wurstscript.translation.imoptimizer.RestrictedCompressedNames;
 import de.peeeq.wurstscript.translation.imtranslation.FunctionFlagEnum;
 import de.peeeq.wurstscript.translation.imtranslation.ImHelper;
+import de.peeeq.wurstscript.validation.NamePreservation;
 import de.peeeq.wurstscript.utils.Utils;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -50,6 +51,11 @@ public class ImToJassTranslator {
 
         translateFunctionTransitive(mainFunc);
         translateFunctionTransitive(confFunction);
+        for (ImFunction function : ImHelper.calculateFunctionsOfProg(imProg)) {
+            if (NamePreservation.isPreserved(function)) {
+                translateFunctionTransitive(function);
+            }
+        }
 
         return prog;
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ExprTranslation.java
@@ -14,6 +14,7 @@ import de.peeeq.wurstscript.attributes.names.NameLink;
 import de.peeeq.wurstscript.attributes.names.OtherLink;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.types.*;
+import de.peeeq.wurstscript.validation.NamePreservation;
 import de.peeeq.wurstscript.utils.Utils;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
@@ -588,6 +589,7 @@ public class ExprTranslation {
             String exFunc = s.getValS();
             NameLink func = Utils.getFirst(e.lookupFuncs(exFunc));
             ImFunction executedFunc = t.getFuncFor((TranslatedToImFunction) func.getDef());
+            NamePreservation.preserve(executedFunc);
             return ImFunctionCall(e, executedFunc, ImTypeArguments(), JassIm.ImExprs(), true, CallType.EXECUTE);
         }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/FunctionFlagEnum.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/FunctionFlagEnum.java
@@ -6,6 +6,7 @@ public enum FunctionFlagEnum implements FunctionFlag {
     IS_TEST,
     IS_COMPILETIME_NATIVE,
     IS_EXTERN,
-    IS_VARARG
+    IS_VARARG,
+    PRESERVE_NAME
 
 }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
@@ -19,7 +19,7 @@ import de.peeeq.wurstscript.parser.WPos;
 import de.peeeq.wurstscript.types.*;
 import de.peeeq.wurstscript.utils.Pair;
 import de.peeeq.wurstscript.utils.Utils;
-import de.peeeq.wurstscript.validation.TRVEHelper;
+import de.peeeq.wurstscript.validation.NamePreservation;
 import de.peeeq.wurstscript.validation.WurstValidator;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
@@ -1067,6 +1067,9 @@ private void callInitFunc(Set<WPackage> calledInitializers, WPackage p, @Nullabl
                 if (m instanceof Annotation) {
                     Annotation annotation = (Annotation) m;
                     flags.add(new FunctionFlagAnnotation(annotation.getAnnotationType()));
+                    if (NamePreservation.isPreserveAnnotation(annotation.getAnnotationType())) {
+                        flags.add(PRESERVE_NAME);
+                    }
                 }
             }
         }
@@ -1462,12 +1465,9 @@ private void callInitFunc(Set<WPackage> calledInitializers, WPackage p, @Nullabl
         final ImFunction conf = getConfFunc();
         if (conf != null && conf != main) calculateCallRelations(conf, includeUsedVariables);
 
-        // mark protected globals as read
-        // TRVEHelper.protectedVariables is presumably a HashSet<String> (O(1) contains)
+        // Mark externally visible globals as read so they survive garbage collection.
         for (ImVar global : imProg.getGlobals()) {
-            if (TRVEHelper.protectedVariables.contains(global.getName())) {
-                readVariables.add(global);
-            }
+            if (NamePreservation.isPreserved(global)) readVariables.add(global);
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImTranslator.java
@@ -1465,6 +1465,14 @@ private void callInitFunc(Set<WPackage> calledInitializers, WPackage p, @Nullabl
         final ImFunction conf = getConfFunc();
         if (conf != null && conf != main) calculateCallRelations(conf, includeUsedVariables);
 
+        // Preserved functions are externally visible entry points even when no Wurst code calls
+        // them. Keep their bodies and everything they call reachable for both backends.
+        for (ImFunction function : ImHelper.calculateFunctionsOfProg(imProg)) {
+            if (NamePreservation.isPreserved(function)) {
+                calculateCallRelations(function, includeUsedVariables);
+            }
+        }
+
         // Mark externally visible globals as read so they survive garbage collection.
         for (ImVar global : imProg.getGlobals()) {
             if (NamePreservation.isPreserved(global)) readVariables.add(global);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -1047,7 +1047,9 @@ public class LuaTranslator {
         // translate functions
         for (ImFunction f : c.getFunctions()) {
             translateFunc(f);
-            luaFunc.getFor(f).setName(uniqueName(c.getName() + "_" + f.getName()));
+            if (!NamePreservation.isPreserved(f)) {
+                luaFunc.getFor(f).setName(uniqueName(c.getName() + "_" + f.getName()));
+            }
         }
 
         createClassInitFunction(c, classVar, initMethod);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -503,15 +503,6 @@ public class LuaTranslator {
             }
         }
 
-        for (ImClass clazz : prog.getClasses()) {
-            for (ImFunction function : clazz.getFunctions()) {
-                if (NamePreservation.isPreserved(function)) {
-                    LuaFunction luaFunction = luaFunc.getFor(function);
-                    usedNames.add(luaFunction.getName());
-                }
-            }
-        }
-
         for (ImVar global : prog.getGlobals()) {
             if (global.getIsBJ()) {
                 setNameFromTrace(global);
@@ -1056,9 +1047,7 @@ public class LuaTranslator {
         // translate functions
         for (ImFunction f : c.getFunctions()) {
             translateFunc(f);
-            if (!NamePreservation.isPreserved(f)) {
-                luaFunc.getFor(f).setName(uniqueName(c.getName() + "_" + f.getName()));
-            }
+            luaFunc.getFor(f).setName(uniqueName(c.getName() + "_" + f.getName()));
         }
 
         createClassInitFunction(c, classVar, initMethod);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -492,7 +492,8 @@ public class LuaTranslator {
 
     private void collectPredefinedNames() {
         for (ImFunction function : prog.getFunctions()) {
-            if (function.isBj() || function.isExtern() || function.isNative()) {
+            if (function.isBj() || function.isExtern() || function.isNative()
+                || NamePreservation.isPreserved(function)) {
                 // Don't rename Wurst-internal stubs (names starting with __wurst_)
                 // since their names are intentionally different from their trace's source name.
                 if (!function.getName().startsWith("__wurst_")) {
@@ -505,6 +506,8 @@ public class LuaTranslator {
         for (ImVar global : prog.getGlobals()) {
             if (global.getIsBJ()) {
                 setNameFromTrace(global);
+                usedNames.add(global.getName());
+            } else if (NamePreservation.isPreserved(global)) {
                 usedNames.add(global.getName());
             }
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -14,6 +14,7 @@ import de.peeeq.wurstscript.translation.imtranslation.LuaNativeLowering;
 import de.peeeq.wurstscript.types.TypesHelper;
 import de.peeeq.wurstscript.utils.Lazy;
 import de.peeeq.wurstscript.utils.Utils;
+import de.peeeq.wurstscript.validation.NamePreservation;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -156,8 +157,10 @@ public class LuaTranslator {
         @Override
         public LuaVariable initFor(ImVar a) {
             String name = a.getName();
-            if (!a.getIsBJ()) {
+            if (!a.getIsBJ() && !NamePreservation.isPreserved(a)) {
                 name = uniqueName(name);
+            } else {
+                usedNames.add(name);
             }
             return LuaAst.LuaVariable(name, LuaAst.LuaNoExpr());
         }
@@ -168,9 +171,10 @@ public class LuaTranslator {
         @Override
         public LuaFunction initFor(ImFunction a) {
             String name = a.getName();
-            if (!a.isExtern() && !a.isBj() && !a.isNative() && !isFixedEntryPoint(a)) {
+            if (!a.isExtern() && !a.isBj() && !a.isNative()
+                && !isFixedEntryPoint(a) && !NamePreservation.isPreserved(a)) {
                 name = uniqueName(name);
-            } else if (isFixedEntryPoint(a)) {
+            } else if (isFixedEntryPoint(a) || NamePreservation.isPreserved(a)) {
                 usedNames.add(name);
             }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -331,8 +331,8 @@ public class LuaTranslator {
     }
 
     public LuaCompilationUnit translate() {
-        assertNoDanglingFunctionReferences(prog);
         collectPredefinedNames();
+        assertNoDanglingFunctionReferences(prog);
 
         normalizeFieldNames();
 
@@ -500,6 +500,15 @@ public class LuaTranslator {
                     setNameFromTrace(function);
                 }
                 usedNames.add(function.getName());
+            }
+        }
+
+        for (ImClass clazz : prog.getClasses()) {
+            for (ImFunction function : clazz.getFunctions()) {
+                if (NamePreservation.isPreserved(function)) {
+                    LuaFunction luaFunction = luaFunc.getFor(function);
+                    usedNames.add(luaFunction.getName());
+                }
             }
         }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
@@ -222,12 +222,6 @@ public class RemoveGarbage {
             return;
         }
         used.addFunction(f);
-        if (f.getParent() != null && f.getParent().getParent() instanceof ImClass owner) {
-            // A preserved static method has no receiver type to retain its owner. Keep the class
-            // because Lua emits class methods together with their class table.
-            visitClass(owner, used, false);
-        }
-
         visitType(f.getReturnType(), used);
         f.accept(new Element.DefaultVisitor() {
             @Override

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
@@ -222,6 +222,11 @@ public class RemoveGarbage {
             return;
         }
         used.addFunction(f);
+        if (f.getParent() != null && f.getParent().getParent() instanceof ImClass owner) {
+            // A preserved static method has no receiver type to retain its owner. Keep the class
+            // because Lua emits class methods together with their class table.
+            visitClass(owner, used, false);
+        }
 
         visitType(f.getReturnType(), used);
         f.accept(new Element.DefaultVisitor() {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
@@ -5,7 +5,7 @@ import com.google.common.collect.Multimap;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.translation.imtranslation.ImHelper;
 import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
-import de.peeeq.wurstscript.validation.TRVEHelper;
+import de.peeeq.wurstscript.validation.NamePreservation;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -122,7 +122,7 @@ public class RemoveGarbage {
         Used used = collectUsed(prog, translator);
 
         prog.getClasses().removeIf(c -> !used.getClasses().contains(c));
-        prog.getGlobals().removeIf(g -> !used.getVars().contains(g) && !TRVEHelper.protectedVariables.contains(g.getName()));
+        prog.getGlobals().removeIf(g -> !used.getVars().contains(g) && !NamePreservation.isPreserved(g));
         prog.getFunctions().removeIf(f -> !used.getFunctions().contains(f));
         prog.getMethods().removeIf(m -> !used.getMethods().contains(m));
         for (ImMethod m : prog.getMethods()) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
@@ -153,7 +153,8 @@ public class RemoveGarbage {
         Used used = new Used(translator, ignoredInitializers);
         for (ImFunction f : ImHelper.calculateFunctionsOfProg(prog)) {
             if (f.getName().equals("main")
-                || f.getName().equals("config")) {
+                || f.getName().equals("config")
+                || NamePreservation.isPreserved(f)) {
                 visitFunction(f, used);
             }
         }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/NamePreservation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/NamePreservation.java
@@ -9,9 +9,12 @@ import de.peeeq.wurstscript.types.WurstTypeArray;
 import de.peeeq.wurstscript.types.WurstTypeTuple;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Metadata for names which are part of the Warcraft III-facing API. */
 public final class NamePreservation {
@@ -65,7 +68,8 @@ public final class NamePreservation {
                 super.visit(variable);
                 String name = runtimeName(variable);
                 result.add(name, variable);
-                addTupleComponentNames(result, name, variable.attrTyp(), variable);
+                addTupleComponentNames(result, name, variable.attrTyp(), variable,
+                    Collections.newSetFromMap(new IdentityHashMap<>()));
             }
         });
         return result;
@@ -87,17 +91,20 @@ public final class NamePreservation {
     }
 
     private static void addTupleComponentNames(RuntimeNameIndex index, String name, WurstType type,
-                                               GlobalVarDef variable) {
+                                               GlobalVarDef variable, Set<TupleDef> expandedTuples) {
         if (type instanceof WurstTypeArray array) {
             type = array.getBaseType();
         }
         if (!(type instanceof WurstTypeTuple tuple)) {
             return;
         }
+        if (!expandedTuples.add(tuple.getTupleDef())) {
+            return;
+        }
         for (WParameter parameter : tuple.getTupleDef().getParameters()) {
             String componentName = name + "_" + parameter.getName();
             index.add(componentName, variable);
-            addTupleComponentNames(index, componentName, parameter.attrTyp(), variable);
+            addTupleComponentNames(index, componentName, parameter.attrTyp(), variable, expandedTuples);
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/NamePreservation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/NamePreservation.java
@@ -4,6 +4,15 @@ import de.peeeq.wurstscript.ast.*;
 import de.peeeq.wurstscript.jassIm.ImFunction;
 import de.peeeq.wurstscript.jassIm.ImVar;
 import de.peeeq.wurstscript.translation.imtranslation.FunctionFlagEnum;
+import de.peeeq.wurstscript.types.WurstType;
+import de.peeeq.wurstscript.types.WurstTypeArray;
+import de.peeeq.wurstscript.types.WurstTypeTuple;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /** Metadata for names which are part of the Warcraft III-facing API. */
 public final class NamePreservation {
@@ -33,29 +42,73 @@ public final class NamePreservation {
      * name-based side table. The marker remains attached to the AST definition and is copied to
      * the corresponding IM variable through its trace.
      */
-    public static void preserve(GlobalVarDef variable) {
-        if (!variable.hasAnnotation(ANNOTATION)) {
-            Annotation marker = Ast.Annotation(variable.getSource(),
-                Ast.Identifier(variable.getSource(), ANNOTATION.substring(1)), Ast.Arguments());
-            variable.getModifiers().add(marker);
+    public static @Nullable Annotation preserve(GlobalVarDef variable) {
+        if (variable.hasAnnotation(ANNOTATION)) {
+            return null;
         }
+        Annotation marker = Ast.Annotation(variable.getSource(),
+            Ast.Identifier(variable.getSource(), ANNOTATION.substring(1)), Ast.Arguments());
+        variable.getModifiers().add(marker);
+        return marker;
     }
 
     /**
-     * Finds globals by their emitted runtime name, without consulting lexical name resolution.
-     * This is needed for native APIs such as TriggerRegisterVariableEvent whose string argument
-     * refers to the generated global name rather than a source-level variable access.
+     * Resolves globals by their emitted runtime name, without consulting lexical name resolution.
+     * The index is scoped to one validation run; the preservation marker itself remains attached to
+     * the AST definition and is copied to the corresponding IM variables through their trace.
      */
-    public static void preserveGlobalWithRuntimeName(WurstModel model, String runtimeName) {
+    public static RuntimeNameIndex indexGlobals(WurstModel model) {
+        RuntimeNameIndex result = new RuntimeNameIndex();
         model.accept(new Element.DefaultVisitor() {
             @Override
             public void visit(GlobalVarDef variable) {
                 super.visit(variable);
-                if (runtimeName(variable).equals(runtimeName)) {
-                    preserve(variable);
-                }
+                String name = runtimeName(variable);
+                result.add(name, variable);
+                addTupleComponentNames(result, name, variable.attrTyp(), variable);
             }
         });
+        return result;
+    }
+
+    private static void addTupleComponentNames(RuntimeNameIndex index, String name, WurstType type,
+                                               GlobalVarDef variable) {
+        if (type instanceof WurstTypeArray array) {
+            type = array.getBaseType();
+        }
+        if (!(type instanceof WurstTypeTuple tuple)) {
+            return;
+        }
+        for (WParameter parameter : tuple.getTupleDef().getParameters()) {
+            String componentName = name + "_" + parameter.getName();
+            index.add(componentName, variable);
+            addTupleComponentNames(index, componentName, parameter.attrTyp(), variable);
+        }
+    }
+
+    public static final class RuntimeNameIndex {
+        private final Map<String, List<GlobalVarDef>> globalsByName = new LinkedHashMap<>();
+        private final Map<GlobalVarDef, Annotation> syntheticMarkers = new LinkedHashMap<>();
+
+        private void add(String name, GlobalVarDef variable) {
+            globalsByName.computeIfAbsent(name, ignored -> new ArrayList<>()).add(variable);
+        }
+
+        public void preserve(String runtimeName) {
+            for (GlobalVarDef variable : globalsByName.getOrDefault(runtimeName, List.of())) {
+                Annotation marker = NamePreservation.preserve(variable);
+                if (marker != null) {
+                    syntheticMarkers.put(variable, marker);
+                }
+            }
+        }
+
+        public void clearSyntheticMarkers() {
+            for (Map.Entry<GlobalVarDef, Annotation> entry : syntheticMarkers.entrySet()) {
+                entry.getKey().getModifiers().remove(entry.getValue());
+            }
+            syntheticMarkers.clear();
+        }
     }
 
     private static String runtimeName(GlobalVarDef variable) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/NamePreservation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/NamePreservation.java
@@ -1,0 +1,50 @@
+package de.peeeq.wurstscript.validation;
+
+import de.peeeq.wurstscript.ast.Annotation;
+import de.peeeq.wurstscript.ast.Ast;
+import de.peeeq.wurstscript.ast.GlobalVarDef;
+import de.peeeq.wurstscript.ast.NameDef;
+import de.peeeq.wurstscript.jassIm.ImFunction;
+import de.peeeq.wurstscript.jassIm.ImVar;
+import de.peeeq.wurstscript.translation.imtranslation.FunctionFlagEnum;
+
+/** Metadata for names which are part of the Warcraft III-facing API. */
+public final class NamePreservation {
+
+    public static final String ANNOTATION = "@preserveName";
+
+    private NamePreservation() {
+    }
+
+    public static boolean isPreserved(ImFunction function) {
+        return function.hasFlag(FunctionFlagEnum.PRESERVE_NAME);
+    }
+
+    public static boolean isPreserved(ImVar variable) {
+        return variable.getTrace() instanceof NameDef
+            && ((NameDef) variable.getTrace()).hasAnnotation(ANNOTATION);
+    }
+
+    public static void preserve(ImFunction function) {
+        if (!isPreserved(function)) {
+            function.getFlags().add(FunctionFlagEnum.PRESERVE_NAME);
+        }
+    }
+
+    /**
+     * Marks a resolved global used by TriggerRegisterVariableEvent without maintaining a
+     * name-based side table. The marker remains attached to the AST definition and is copied to
+     * the corresponding IM variable through its trace.
+     */
+    public static void preserve(GlobalVarDef variable) {
+        if (!variable.hasAnnotation(ANNOTATION)) {
+            Annotation marker = Ast.Annotation(variable.getSource(),
+                Ast.Identifier(variable.getSource(), ANNOTATION.substring(1)), Ast.Arguments());
+            variable.getModifiers().add(marker);
+        }
+    }
+
+    public static boolean isPreserveAnnotation(String annotation) {
+        return annotation.equalsIgnoreCase(ANNOTATION);
+    }
+}

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/NamePreservation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/NamePreservation.java
@@ -7,7 +7,6 @@ import de.peeeq.wurstscript.translation.imtranslation.FunctionFlagEnum;
 import de.peeeq.wurstscript.types.WurstType;
 import de.peeeq.wurstscript.types.WurstTypeArray;
 import de.peeeq.wurstscript.types.WurstTypeTuple;
-import org.eclipse.jdt.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -18,6 +17,7 @@ import java.util.Map;
 public final class NamePreservation {
 
     public static final String ANNOTATION = "@preserveName";
+    private static final String SYNTHETIC_MARKER = "__wurst_trve_preserve_name";
 
     private NamePreservation() {
     }
@@ -42,14 +42,14 @@ public final class NamePreservation {
      * name-based side table. The marker remains attached to the AST definition and is copied to
      * the corresponding IM variable through its trace.
      */
-    public static @Nullable Annotation preserve(GlobalVarDef variable) {
+    public static void preserve(GlobalVarDef variable) {
         if (variable.hasAnnotation(ANNOTATION)) {
-            return null;
+            return;
         }
         Annotation marker = Ast.Annotation(variable.getSource(),
-            Ast.Identifier(variable.getSource(), ANNOTATION.substring(1)), Ast.Arguments());
+            Ast.Identifier(variable.getSource(), ANNOTATION.substring(1)),
+            Ast.Arguments(Ast.ExprStringVal(variable.getSource(), SYNTHETIC_MARKER)));
         variable.getModifiers().add(marker);
-        return marker;
     }
 
     /**
@@ -71,6 +71,21 @@ public final class NamePreservation {
         return result;
     }
 
+    /** Removes markers synthesized for TRVE during an earlier validation run. */
+    public static void clearSyntheticMarkers(WurstModel model) {
+        model.accept(new Element.DefaultVisitor() {
+            @Override
+            public void visit(GlobalVarDef variable) {
+                super.visit(variable);
+                variable.getModifiers().removeIf(modifier -> modifier instanceof Annotation annotation
+                    && annotation.getAnnotationType().equalsIgnoreCase(ANNOTATION)
+                    && annotation.getArgs().size() == 1
+                    && annotation.getArgs().get(0) instanceof ExprStringVal value
+                    && value.getValS().equals(SYNTHETIC_MARKER));
+            }
+        });
+    }
+
     private static void addTupleComponentNames(RuntimeNameIndex index, String name, WurstType type,
                                                GlobalVarDef variable) {
         if (type instanceof WurstTypeArray array) {
@@ -88,7 +103,6 @@ public final class NamePreservation {
 
     public static final class RuntimeNameIndex {
         private final Map<String, List<GlobalVarDef>> globalsByName = new LinkedHashMap<>();
-        private final Map<GlobalVarDef, Annotation> syntheticMarkers = new LinkedHashMap<>();
 
         private void add(String name, GlobalVarDef variable) {
             globalsByName.computeIfAbsent(name, ignored -> new ArrayList<>()).add(variable);
@@ -96,18 +110,8 @@ public final class NamePreservation {
 
         public void preserve(String runtimeName) {
             for (GlobalVarDef variable : globalsByName.getOrDefault(runtimeName, List.of())) {
-                Annotation marker = NamePreservation.preserve(variable);
-                if (marker != null) {
-                    syntheticMarkers.put(variable, marker);
-                }
+                NamePreservation.preserve(variable);
             }
-        }
-
-        public void clearSyntheticMarkers() {
-            for (Map.Entry<GlobalVarDef, Annotation> entry : syntheticMarkers.entrySet()) {
-                entry.getKey().getModifiers().remove(entry.getValue());
-            }
-            syntheticMarkers.clear();
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/NamePreservation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/NamePreservation.java
@@ -1,9 +1,6 @@
 package de.peeeq.wurstscript.validation;
 
-import de.peeeq.wurstscript.ast.Annotation;
-import de.peeeq.wurstscript.ast.Ast;
-import de.peeeq.wurstscript.ast.GlobalVarDef;
-import de.peeeq.wurstscript.ast.NameDef;
+import de.peeeq.wurstscript.ast.*;
 import de.peeeq.wurstscript.jassIm.ImFunction;
 import de.peeeq.wurstscript.jassIm.ImVar;
 import de.peeeq.wurstscript.translation.imtranslation.FunctionFlagEnum;
@@ -42,6 +39,37 @@ public final class NamePreservation {
                 Ast.Identifier(variable.getSource(), ANNOTATION.substring(1)), Ast.Arguments());
             variable.getModifiers().add(marker);
         }
+    }
+
+    /**
+     * Finds globals by their emitted runtime name, without consulting lexical name resolution.
+     * This is needed for native APIs such as TriggerRegisterVariableEvent whose string argument
+     * refers to the generated global name rather than a source-level variable access.
+     */
+    public static void preserveGlobalWithRuntimeName(WurstModel model, String runtimeName) {
+        model.accept(new Element.DefaultVisitor() {
+            @Override
+            public void visit(GlobalVarDef variable) {
+                super.visit(variable);
+                if (runtimeName(variable).equals(runtimeName)) {
+                    preserve(variable);
+                }
+            }
+        });
+    }
+
+    private static String runtimeName(GlobalVarDef variable) {
+        if (variable.getParent() != null && variable.getParent().getParent() instanceof NamedScope scope) {
+            return runtimeName(scope) + "_" + variable.getName();
+        }
+        return variable.getName();
+    }
+
+    private static String runtimeName(NamedScope scope) {
+        if (scope instanceof ModuleInstanciation instantiation) {
+            return runtimeName(instantiation.getParent().attrNearestNamedScope()) + "_" + instantiation.getName();
+        }
+        return scope.getName();
     }
 
     public static boolean isPreserveAnnotation(String annotation) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/TRVEHelper.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/TRVEHelper.java
@@ -1,7 +1,0 @@
-package de.peeeq.wurstscript.validation;
-
-import java.util.HashSet;
-
-public class TRVEHelper {
-    public static final HashSet<String> protectedVariables = new HashSet<>();
-}

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -90,9 +90,6 @@ public class WurstValidator {
             guaranteedClassFieldInitCache.clear();
             moduleFieldCopiesCache.clear();
             moduleFieldCopiesIndexed = false;
-            if (runtimeNameIndex != null) {
-                runtimeNameIndex.clearSyntheticMarkers();
-            }
             trveWrapperFuncs.clear();
             wrapperCalls.clear();
             NamePreservation.clearSyntheticMarkers(prog);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -93,6 +93,7 @@ public class WurstValidator {
             if (runtimeNameIndex != null) {
                 runtimeNameIndex.clearSyntheticMarkers();
             }
+            NamePreservation.clearSyntheticMarkers(prog);
             runtimeNameIndex = NamePreservation.indexGlobals(prog);
 
             lightValidation(toCheck);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -93,8 +93,11 @@ public class WurstValidator {
             if (runtimeNameIndex != null) {
                 runtimeNameIndex.clearSyntheticMarkers();
             }
+            trveWrapperFuncs.clear();
+            wrapperCalls.clear();
             NamePreservation.clearSyntheticMarkers(prog);
             runtimeNameIndex = NamePreservation.indexGlobals(prog);
+            recomputeTrvePreservation();
 
             lightValidation(toCheck);
 
@@ -3681,19 +3684,11 @@ public class WurstValidator {
                     return;
                 } else if (e.getArgs().get(1) instanceof ExprVarAccess) {
                     // Check if this is a two line hook... thanks Bribe
-                    ExprVarAccess varAccess = (ExprVarAccess) e.getArgs().get(1);
-                    @Nullable FunctionImplementation nearestFunc = e.attrNearestFuncDef();
-                    WStatements fbody = nearestFunc.getBody();
-                    if (e.getParent() instanceof StmtReturn && fbody.size() <= 4 && fbody.get(fbody.size() - 2).structuralEquals(e.getParent())) {
-                        WParameters params = nearestFunc.getParameters();
-                        if (params.size() == 4 && ((TypeExprSimple) params.get(0).getTyp()).getTypeName().equals("trigger")
-                            && ((TypeExprSimple) params.get(1).getTyp()).getTypeName().equals("string")
-                            && ((TypeExprSimple) params.get(2).getTyp()).getTypeName().equals("limitop")
-                            && ((TypeExprSimple) params.get(3).getTyp()).getTypeName().equals("real")) {
-                            trveWrapperFuncs.add(nearestFunc.getName());
-                            WLogger.info("found wrapper: " + nearestFunc.getName());
-                            return;
-                        }
+                    String wrapper = trveWrapperName(e);
+                    if (wrapper != null) {
+                        trveWrapperFuncs.add(wrapper);
+                        WLogger.info("found wrapper: " + wrapper);
+                        return;
                     }
                 }
             } else {
@@ -3732,6 +3727,66 @@ public class WurstValidator {
                 e.addError("Wurst does only support ExecuteFunc with a single string as argument.");
             }
         }
+    }
+
+    private void recomputeTrvePreservation() {
+        prog.accept(new Element.DefaultVisitor() {
+            @Override
+            public void visit(ExprFunctionCall call) {
+                super.visit(call);
+                if (call.getFuncName().equals("TriggerRegisterVariableEvent") && call.getArgs().size() > 1) {
+                    if (call.getArgs().get(1) instanceof ExprStringVal varName) {
+                        preserveVariableName(varName.getValS());
+                    } else if (call.getArgs().get(1) instanceof ExprVarAccess) {
+                        String wrapper = trveWrapperName(call);
+                        if (wrapper != null) {
+                            trveWrapperFuncs.add(wrapper);
+                        }
+                    }
+                }
+            }
+
+        });
+
+        // Repeat the cheap call pass so calls which precede their wrapper declaration are covered.
+        prog.accept(new Element.DefaultVisitor() {
+            @Override
+            public void visit(ExprFunctionCall call) {
+                super.visit(call);
+                if (trveWrapperFuncs.contains(call.getFuncName())
+                    && call.getArgs().size() > 1
+                    && call.getArgs().get(1) instanceof ExprStringVal varName) {
+                    preserveVariableName(varName.getValS());
+                }
+            }
+        });
+    }
+
+    private @Nullable String trveWrapperName(ExprFunctionCall e) {
+        @Nullable FunctionImplementation nearestFunc = e.attrNearestFuncDef();
+        if (nearestFunc == null) {
+            return null;
+        }
+        WStatements fbody = nearestFunc.getBody();
+        if (!(e.getParent() instanceof StmtReturn)
+            || fbody.size() < 2
+            || fbody.size() > 4
+            || !fbody.get(fbody.size() - 2).structuralEquals(e.getParent())) {
+            return null;
+        }
+        WParameters params = nearestFunc.getParameters();
+        if (params.size() != 4
+            || !(params.get(0).getTyp() instanceof TypeExprSimple triggerType)
+            || !(params.get(1).getTyp() instanceof TypeExprSimple stringType)
+            || !(params.get(2).getTyp() instanceof TypeExprSimple limitopType)
+            || !(params.get(3).getTyp() instanceof TypeExprSimple realType)
+            || !triggerType.getTypeName().equals("trigger")
+            || !stringType.getTypeName().equals("string")
+            || !limitopType.getTypeName().equals("limitop")
+            || !realType.getTypeName().equals("real")) {
+            return null;
+        }
+        return nearestFunc.getName();
     }
 
     private void preserveVariableName(String variableName) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -177,7 +177,7 @@ public class WurstValidator {
                 for (FunctionCall call : wrapperCalls.get(wrapper)) {
                     if (call.getArgs().size() > 1 && call.getArgs().get(1) instanceof ExprStringVal) {
                         ExprStringVal varName = (ExprStringVal) call.getArgs().get(1);
-                        TRVEHelper.protectedVariables.add(varName.getValS());
+                        preserveVariableName(call, varName.getValS());
                         WLogger.info("keep: " + varName.getValS());
                     } else {
                         call.addError("Map contains TriggerRegisterVariableEvent with non-constant arguments. Can't be optimized.");
@@ -3670,7 +3670,7 @@ public class WurstValidator {
             if (e.getArgs().size() > 1) {
                 if (e.getArgs().get(1) instanceof ExprStringVal) {
                     ExprStringVal varName = (ExprStringVal) e.getArgs().get(1);
-                    TRVEHelper.protectedVariables.add(varName.getValS());
+                    preserveVariableName(e, varName.getValS());
                     WLogger.info("keep: " + varName.getValS());
                     return;
                 } else if (e.getArgs().get(1) instanceof ExprVarAccess) {
@@ -3725,6 +3725,14 @@ public class WurstValidator {
             } else {
                 e.addError("Wurst does only support ExecuteFunc with a single string as argument.");
             }
+        }
+    }
+
+    private void preserveVariableName(Element useSite, String variableName) {
+        NameLink variable = de.peeeq.wurstscript.attributes.names.NameResolution
+            .lookupVarNoConfig(useSite, variableName, false);
+        if (variable != null && variable.getDef() instanceof GlobalVarDef) {
+            NamePreservation.preserve((GlobalVarDef) variable.getDef());
         }
     }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -62,6 +62,7 @@ public class WurstValidator {
     private final Map<ClassDef, Map<GlobalVarDef, Integer>> classVarInitOrderCache = new HashMap<>();
     private final Map<GlobalVarDef, Boolean> guaranteedClassFieldInitCache = new IdentityHashMap<>();
     private final Map<GlobalVarDef, List<GlobalVarDef>> moduleFieldCopiesCache = new IdentityHashMap<>();
+    private NamePreservation.RuntimeNameIndex runtimeNameIndex;
     private boolean moduleFieldCopiesIndexed;
 
     /**
@@ -89,6 +90,10 @@ public class WurstValidator {
             guaranteedClassFieldInitCache.clear();
             moduleFieldCopiesCache.clear();
             moduleFieldCopiesIndexed = false;
+            if (runtimeNameIndex != null) {
+                runtimeNameIndex.clearSyntheticMarkers();
+            }
+            runtimeNameIndex = NamePreservation.indexGlobals(prog);
 
             lightValidation(toCheck);
 
@@ -177,7 +182,7 @@ public class WurstValidator {
                 for (FunctionCall call : wrapperCalls.get(wrapper)) {
                     if (call.getArgs().size() > 1 && call.getArgs().get(1) instanceof ExprStringVal) {
                         ExprStringVal varName = (ExprStringVal) call.getArgs().get(1);
-                        preserveVariableName(call, varName.getValS());
+                        preserveVariableName(varName.getValS());
                         WLogger.info("keep: " + varName.getValS());
                     } else {
                         call.addError("Map contains TriggerRegisterVariableEvent with non-constant arguments. Can't be optimized.");
@@ -3670,7 +3675,7 @@ public class WurstValidator {
             if (e.getArgs().size() > 1) {
                 if (e.getArgs().get(1) instanceof ExprStringVal) {
                     ExprStringVal varName = (ExprStringVal) e.getArgs().get(1);
-                    preserveVariableName(e, varName.getValS());
+                    preserveVariableName(varName.getValS());
                     WLogger.info("keep: " + varName.getValS());
                     return;
                 } else if (e.getArgs().get(1) instanceof ExprVarAccess) {
@@ -3728,8 +3733,8 @@ public class WurstValidator {
         }
     }
 
-    private void preserveVariableName(Element useSite, String variableName) {
-        NamePreservation.preserveGlobalWithRuntimeName(prog, variableName);
+    private void preserveVariableName(String variableName) {
+        runtimeNameIndex.preserve(variableName);
     }
 
     private boolean isViableSwitchtype(Expr expr) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/validation/WurstValidator.java
@@ -3729,11 +3729,7 @@ public class WurstValidator {
     }
 
     private void preserveVariableName(Element useSite, String variableName) {
-        NameLink variable = de.peeeq.wurstscript.attributes.names.NameResolution
-            .lookupVarNoConfig(useSite, variableName, false);
-        if (variable != null && variable.getDef() instanceof GlobalVarDef) {
-            NamePreservation.preserve((GlobalVarDef) variable.getDef());
-        }
+        NamePreservation.preserveGlobalWithRuntimeName(prog, variableName);
     }
 
     private boolean isViableSwitchtype(Expr expr) {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
@@ -588,6 +588,27 @@ public class OptimizerTests extends WurstScriptTest {
     }
 
     @Test
+    public void preservedClassFunctionReservesItsLuaNameBeforeClassVariables() throws IOException {
+        test().testLua(true).luaOnly(true).executeProg(false).lines(
+            "package test",
+            "    class Foo",
+            "        @preserveName function bar()",
+            "            skip",
+            "    class Foo_bar",
+            "    init",
+            "        new Foo_bar",
+            "endpackage");
+
+        String output = Files.toString(
+            new File("./test-output/lua/OptimizerTests_preservedClassFunctionReservesItsLuaNameBeforeClassVariables.lua"),
+            Charsets.UTF_8);
+        assertTrue(output.contains("function Foo_bar("),
+            "Expected the preserved class function to keep its Lua name.\n" + output);
+        assertTrue(output.contains("Foo_bar1 = ({})"),
+            "Expected the colliding class variable to be uniqued around the preserved function.\n" + output);
+    }
+
+    @Test
     public void test_tempVarRemover() throws IOException {
         test().lines(
             "package test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
@@ -551,6 +551,43 @@ public class OptimizerTests extends WurstScriptTest {
     }
 
     @Test
+    public void trvePreservesLoweredTupleComponent() throws IOException {
+        test().optimize().lines(
+            "type trigger extends handle",
+            "type event extends handle",
+            "type limitop extends handle",
+            "package test",
+            "    tuple pair(real x, real y)",
+            "    pair value = pair(0., 0.)",
+            "    @extern native TriggerRegisterVariableEvent(trigger whichTrigger, string varName, limitop opcode, real limitval) returns event",
+            "    init",
+            "        TriggerRegisterVariableEvent(null, \"test_value_x\", null, 0.0)",
+            "endpackage");
+
+        String output = Files.toString(
+            new File("./test-output/OptimizerTests_trvePreservesLoweredTupleComponent_opt.j"),
+            Charsets.UTF_8);
+        assertTrue(output.contains("real test_value_x"),
+            "Expected TRVE to preserve the lowered tuple component.\n" + output);
+    }
+
+    @Test
+    public void preserveNameAnnotationKeepsClassFunctionNameInLua() throws IOException {
+        test().testLua(true).luaOnly(true).executeProg(false).lines(
+            "package test",
+            "    class ExternalApi",
+            "        @preserveName function callback()",
+            "            skip",
+            "endpackage");
+
+        String output = Files.toString(
+            new File("./test-output/lua/OptimizerTests_preserveNameAnnotationKeepsClassFunctionNameInLua.lua"),
+            Charsets.UTF_8);
+        assertTrue(output.contains("function ExternalApi_callback"),
+            "Expected a preserved class function to keep its emitted name.\n" + output);
+    }
+
+    @Test
     public void test_tempVarRemover() throws IOException {
         test().lines(
             "package test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
@@ -505,6 +505,29 @@ public class OptimizerTests extends WurstScriptTest {
     }
 
     @Test
+    public void preservedNamesAreReservedBeforeCompression() throws IOException {
+        test().optimize().lines(
+            "package test",
+            "    native testSuccess()",
+            "    function ordinary()",
+            "        testSuccess()",
+            "    @preserveName function w()",
+            "        testSuccess()",
+            "    init",
+            "        ordinary()",
+            "        w()",
+            "endpackage");
+
+        String output = Files.toString(
+            new File("./test-output/OptimizerTests_preservedNamesAreReservedBeforeCompression_opt.j"),
+            Charsets.UTF_8);
+        assertTrue(output.contains("function w"),
+            "Expected the preserved function name to remain available.\n" + output);
+        assertFalse(output.contains("function w_1"),
+            "Expected compression to reserve the preserved name.\n" + output);
+    }
+
+    @Test
     public void trvePreservesGlobalDespiteLexicalShadow() throws IOException {
         test().optimize().lines(
             "type trigger extends handle",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
@@ -572,59 +572,6 @@ public class OptimizerTests extends WurstScriptTest {
     }
 
     @Test
-    public void preserveNameAnnotationKeepsClassFunctionNameInLua() throws IOException {
-        test().testLua(true).luaOnly(true).executeProg(false).lines(
-            "package test",
-            "    class ExternalApi",
-            "        @preserveName function callback()",
-            "            skip",
-            "endpackage");
-
-        String output = Files.toString(
-            new File("./test-output/lua/OptimizerTests_preserveNameAnnotationKeepsClassFunctionNameInLua.lua"),
-            Charsets.UTF_8);
-        assertTrue(output.contains("function ExternalApi_callback"),
-            "Expected a preserved class function to keep its emitted name.\n" + output);
-    }
-
-    @Test
-    public void preserveNameAnnotationKeepsStaticClassFunctionReachableInLua() throws IOException {
-        test().testLua(true).luaOnly(true).executeProg(false).lines(
-            "package test",
-            "    class ExternalApi",
-            "        @preserveName static function callback()",
-            "            skip",
-            "endpackage");
-
-        String output = Files.toString(
-            new File("./test-output/lua/OptimizerTests_preserveNameAnnotationKeepsStaticClassFunctionReachableInLua.lua"),
-            Charsets.UTF_8);
-        assertTrue(output.contains("function callback("),
-            "Expected a preserved static class function to keep its emitted name.\n" + output);
-    }
-
-    @Test
-    public void preservedClassFunctionReservesItsLuaNameBeforeClassVariables() throws IOException {
-        test().testLua(true).luaOnly(true).executeProg(false).lines(
-            "package test",
-            "    class Foo",
-            "        @preserveName function bar()",
-            "            skip",
-            "    class Foo_bar",
-            "    init",
-            "        new Foo_bar",
-            "endpackage");
-
-        String output = Files.toString(
-            new File("./test-output/lua/OptimizerTests_preservedClassFunctionReservesItsLuaNameBeforeClassVariables.lua"),
-            Charsets.UTF_8);
-        assertTrue(output.contains("function Foo_bar("),
-            "Expected the preserved class function to keep its Lua name.\n" + output);
-        assertTrue(output.contains("Foo_bar1 = ({})"),
-            "Expected the colliding class variable to be uniqued around the preserved function.\n" + output);
-    }
-
-    @Test
     public void test_tempVarRemover() throws IOException {
         test().lines(
             "package test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
@@ -588,6 +588,22 @@ public class OptimizerTests extends WurstScriptTest {
     }
 
     @Test
+    public void preserveNameAnnotationKeepsStaticClassFunctionReachableInLua() throws IOException {
+        test().testLua(true).luaOnly(true).executeProg(false).lines(
+            "package test",
+            "    class ExternalApi",
+            "        @preserveName static function callback()",
+            "            skip",
+            "endpackage");
+
+        String output = Files.toString(
+            new File("./test-output/lua/OptimizerTests_preserveNameAnnotationKeepsStaticClassFunctionReachableInLua.lua"),
+            Charsets.UTF_8);
+        assertTrue(output.contains("function callback("),
+            "Expected a preserved static class function to keep its emitted name.\n" + output);
+    }
+
+    @Test
     public void preservedClassFunctionReservesItsLuaNameBeforeClassVariables() throws IOException {
         test().testLua(true).luaOnly(true).executeProg(false).lines(
             "package test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
@@ -445,6 +445,50 @@ public class OptimizerTests extends WurstScriptTest {
     }
 
     @Test
+    public void preserveNameAnnotationExemptsFunctionFromCompression() throws IOException {
+        test().optimize().lines(
+            "package test",
+            "    native testSuccess()",
+            "    @preserveName function externallyCalled()",
+            "        testSuccess()",
+            "    function normallyCompressed()",
+            "        testSuccess()",
+            "    init",
+            "        externallyCalled()",
+            "        normallyCompressed()",
+            "endpackage");
+
+        String output = Files.toString(
+            new File("./test-output/OptimizerTests_preserveNameAnnotationExemptsFunctionFromCompression_opt.j"),
+            Charsets.UTF_8);
+        assertTrue(output.contains("function externallyCalled"),
+            "Expected @preserveName function to retain its source name.\n" + output);
+        assertFalse(output.contains("function normallyCompressed"),
+            "Expected an unannotated function to remain eligible for compression.\n" + output);
+    }
+
+    @Test
+    public void executeFuncPreservesResolvedFunctionNameDuringCompression() throws IOException {
+        test().optimize().lines(
+            "package test",
+            "    @extern native ExecuteFunc(string name)",
+            "    native testSuccess()",
+            "    function callback()",
+            "        testSuccess()",
+            "    init",
+            "        ExecuteFunc(\"callback\")",
+            "endpackage");
+
+        String output = Files.toString(
+            new File("./test-output/OptimizerTests_executeFuncPreservesResolvedFunctionNameDuringCompression_opt.j"),
+            Charsets.UTF_8);
+        assertTrue(output.contains("function callback"),
+            "Expected ExecuteFunc target to retain its source name.\n" + output);
+        assertTrue(output.contains("ExecuteFunc(\"callback\")"),
+            "Expected ExecuteFunc to receive the preserved source name.\n" + output);
+    }
+
+    @Test
     public void test_tempVarRemover() throws IOException {
         test().lines(
             "package test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/OptimizerTests.java
@@ -489,6 +489,45 @@ public class OptimizerTests extends WurstScriptTest {
     }
 
     @Test
+    public void preserveNameAnnotationKeepsExternallyCalledFunctionReachable() throws IOException {
+        test().optimize().lines(
+            "package test",
+            "    native testSuccess()",
+            "    @preserveName function externallyCalled()",
+            "        testSuccess()",
+            "endpackage");
+
+        String output = Files.toString(
+            new File("./test-output/OptimizerTests_preserveNameAnnotationKeepsExternallyCalledFunctionReachable_opt.j"),
+            Charsets.UTF_8);
+        assertTrue(output.contains("function externallyCalled"),
+            "Expected an externally-called @preserveName function to survive garbage collection.\n" + output);
+    }
+
+    @Test
+    public void trvePreservesGlobalDespiteLexicalShadow() throws IOException {
+        test().optimize().lines(
+            "type trigger extends handle",
+            "type event extends handle",
+            "type limitop extends handle",
+            "package test",
+            "    int myVar = 0",
+            "    @extern native TriggerRegisterVariableEvent(trigger whichTrigger, string varName, limitop opcode, real limitval) returns event",
+            "    function registerVariableEvent()",
+            "        string myVar = \"local\"",
+            "        TriggerRegisterVariableEvent(null, \"test_myVar\", null, 0.0)",
+            "    init",
+            "        registerVariableEvent()",
+            "endpackage");
+
+        String output = Files.toString(
+            new File("./test-output/OptimizerTests_trvePreservesGlobalDespiteLexicalShadow_opt.j"),
+            Charsets.UTF_8);
+        assertTrue(output.contains("integer test_myVar"),
+            "Expected TRVE to preserve the global despite a local shadow.\n" + output);
+    }
+
+    @Test
     public void test_tempVarRemover() throws IOException {
         test().lines(
             "package test",

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstScriptTest.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstScriptTest.java
@@ -113,6 +113,7 @@ public class WurstScriptTest {
         private final List<CU> additionalCompilationUnits = new ArrayList<>();
         private boolean stopOnFirstError = true;
         private boolean runCompiletimeFunctions;
+        private boolean optimize;
         private boolean testLua = false;
         private boolean luaOnly = false;
         private boolean uncheckedDispatch = false;
@@ -154,6 +155,11 @@ public class WurstScriptTest {
 
         public TestConfig executeTests(boolean b) {
             this.executeTests = b;
+            return this;
+        }
+
+        TestConfig optimize() {
+            this.optimize = true;
             return this;
         }
 
@@ -268,6 +274,9 @@ public class WurstScriptTest {
             }
             if (runCompiletimeFunctions) {
                 runArgs = runArgs.with("-runcompiletimefunctions");
+            }
+            if (optimize) {
+                runArgs = runArgs.with("-opt");
             }
             if (legacyJassTypeChecks) {
                 runArgs.setLegacyJassTypeChecks(true);


### PR DESCRIPTION
## Summary

- Add `@preserveName` support for functions when `-opt` compresses identifiers.
- Carry preservation through IM metadata and reuse it for ExecuteFunc targets.
- Replace TRVE's global name-based protection set with metadata attached to the resolved AST global.
- Keep preserved globals alive through garbage collection, inlining, and optimization.

## Acceptance criteria

- An annotated function retains its source name under `-opt`.
- ExecuteFunc targets retain their source names and receive the preserved name.
- Existing direct and hooked TriggerRegisterVariableEvent behavior remains intact.
- No global name-based protection map remains.

## Checks

- `./gradlew test` — passed on this branch (`BUILD SUCCESSFUL in 5m 11s`).
