### PR TITLE
Fix tuple member-array index capture in Lua

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/UsedVariables.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/UsedVariables.java
@@ -66,7 +66,9 @@ public class UsedVariables {
             if (expr instanceof ImVarAccess) {
                 // Write only, skip
             } else if (expr instanceof ImMemberAccess) {
-                ((ImMemberAccess) expr).getReceiver().accept(this);
+                ImMemberAccess memberAccess = (ImMemberAccess) expr;
+                memberAccess.getReceiver().accept(this);
+                memberAccess.getIndexes().accept(this);
             } else if (expr instanceof ImVarArrayAccess) {
                 ((ImVarArrayAccess) expr).getIndexes().accept(this);
             } else if (expr instanceof ImTupleSelection) {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -200,6 +200,33 @@ public class LuaBackendAuditTests extends WurstScriptTest {
     }
 
     @Test
+    public void tupleMemberArrayAssignmentCapturesIndex() throws IOException {
+        test().testLua(true).luaOnly(false).executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "tuple pair(int first, int second)",
+            "constant SIZE = 10",
+            "class Container",
+            "    pair array[SIZE] values",
+            "    int used",
+            "    function add(pair value)",
+            "        values[used] = value",
+            "        used++",
+            "init",
+            "    let container = new Container()",
+            "    container.add(pair(1, 2))",
+            "    if container.used == 1 and container.values[0] == pair(1, 2)",
+            "        testSuccess()"
+        );
+
+        String compiled = compiledLua("tupleMemberArrayAssignmentCapturesIndex");
+        assertTrue("tuple member-array index must be captured into a declared Lua local",
+            compiled.contains("local tuple_lvalue_index = 0"));
+        assertTrue("tuple member-array index capture must survive dead-store elimination",
+            compiled.contains("tuple_lvalue_index = Container_used_storage[this]"));
+    }
+
+    @Test
     public void optimizedTupleCommonPathIsOnlyScalarCode() {
         String compiled = compileOptimizedLua(
             "optimizedTupleCommonPathIsOnlyScalarCode",


### PR DESCRIPTION
## Summary

- treat member-array index expressions as reads during IM read-variable analysis
- preserve tuple l-value index captures through dead-store elimination
- add a regression covering the reported class-field tuple-array assignment in Jass and Lua

## Acceptance criteria

- generated Lua declares and initializes tuple l-value index temporaries before use
- the reported tuple-array assignment executes without a nil-index failure
- Jass transform modes and Lua execution produce the expected stored tuple and slot count

## Verification

- `./gradlew test --tests "tests.wurstscript.tests.LuaBackendAuditTests.tupleMemberArrayAssignmentCapturesIndex"` — passed
- `./gradlew test --tests "tests.wurstscript.tests.LuaBackendAuditTests"` — passed
- `./gradlew test --tests "tests.wurstscript.tests.TupleTests"` — passed
- `./gradlew test` — passed (6m 13s)
- `git diff --check` — passed

## Known gaps

None.
