### PR TITLE
Reduce transient allocations in hot compiler passes

### DIFF
--- a/de.peeeq.wurstscript/build.gradle
+++ b/de.peeeq.wurstscript/build.gradle
@@ -98,8 +98,8 @@ dependencies {
     implementation "org.antlr:antlr4-runtime:4.13.1"
 
     // abstractsyntaxgen (available to IDE via compileOnly; used at runtime via astgen)
-    compileOnly 'com.github.peterzeller:abstractsyntaxgen:623da1c60f'
-    astgen 'com.github.peterzeller:abstractsyntaxgen:623da1c60f'
+    compileOnly 'com.github.peterzeller:abstractsyntaxgen:2b3d742e8a'
+    astgen 'com.github.peterzeller:abstractsyntaxgen:2b3d742e8a'
 
 
     // Tests

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/LocalMerger.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/LocalMerger.java
@@ -22,12 +22,21 @@ public class LocalMerger implements LocalPlayerAwareOptimizerPass {
         ImProg prog = trans.getImProg();
         localPlayerContextAnalyzer = analyzer;
         totalLocalsMerged = 0;
-        for (ImFunction func : de.peeeq.wurstscript.translation.imtranslation.ImHelper.calculateFunctionsOfProg(prog)) {
+        optimizeFunctions(prog.getFunctions());
+        List<ImClass> classes = prog.getClasses();
+        for (int i = 0; i < classes.size(); i++) {
+            optimizeFunctions(classes.get(i).getFunctions());
+        }
+        return totalLocalsMerged;
+    }
+
+    private void optimizeFunctions(List<ImFunction> functions) {
+        for (int i = 0; i < functions.size(); i++) {
+            ImFunction func = functions.get(i);
             if (!func.isNative() && !func.isBj()) {
                 optimizeFunc(func);
             }
         }
-        return totalLocalsMerged;
     }
 
     @Override
@@ -54,13 +63,12 @@ public class LocalMerger implements LocalPlayerAwareOptimizerPass {
         );
         queue.addAll(interference.keySet());
 
-        List<ImVar> params = new ArrayList<>(func.getParameters());
-        if (func.hasFlag(de.peeeq.wurstscript.translation.imtranslation.FunctionFlagEnum.IS_VARARG) && !params.isEmpty()) {
-            params.remove(params.size() - 1);
+        List<ImVar> colors = new ArrayList<>(func.getParameters());
+        if (func.hasFlag(de.peeeq.wurstscript.translation.imtranslation.FunctionFlagEnum.IS_VARARG) && !colors.isEmpty()) {
+            colors.remove(colors.size() - 1);
         }
         queue.removeAll(func.getParameters());
 
-        List<ImVar> colors = new ArrayList<>(params);
         Map<ImVar, ImVar> merges = new LinkedHashMap<>();
 
         while (!queue.isEmpty()) {
@@ -137,7 +145,7 @@ public class LocalMerger implements LocalPlayerAwareOptimizerPass {
                 }
             }
         });
-        List<ImVar> locals = new ArrayList<>(f.getLocals());
+        List<ImVar> locals = f.getLocals();
         int before = locals.size();
         List<ImVar> kept = new ArrayList<>(locals.size());
         for (int i = 0; i < locals.size(); i++) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/LocalMerger.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/LocalMerger.java
@@ -67,8 +67,11 @@ public class LocalMerger implements LocalPlayerAwareOptimizerPass {
             ImVar v = queue.poll();
             boolean merged = false;
 
-            for (ImVar color : colors) {
-                if (!canMerge(color.getType(), v.getType())) continue;
+            for (int colorIndex = 0; colorIndex < colors.size(); colorIndex++) {
+                ImVar color = colors.get(colorIndex);
+                if (!canMerge(color.getType(), v.getType())) {
+                    continue;
+                }
                 if (localPlayerContextAnalyzer != null
                     && (localPlayerContextAnalyzer.isLocalPlayerDependent(v)
                     || localPlayerContextAnalyzer.isLocalPlayerDependent(color))) {
@@ -110,7 +113,9 @@ public class LocalMerger implements LocalPlayerAwareOptimizerPass {
             }
             @Override public void visit(ImVarargLoop varargLoop) {
                 super.visit(varargLoop);
-                for (ImVarargLoopVar loopVar : varargLoop.getLoopVars()) {
+                List<ImVarargLoopVar> loopVars = varargLoop.getLoopVars();
+                for (int i = 0; i < loopVars.size(); i++) {
+                    ImVarargLoopVar loopVar = loopVars.get(i);
                     ImVar m = merges.get(loopVar.getVar());
                     if (m != null) loopVar.setVar(m);
                 }
@@ -127,13 +132,20 @@ public class LocalMerger implements LocalPlayerAwareOptimizerPass {
             @Override public void visit(ImVarArrayAccess vaa) { super.visit(vaa); used.add(vaa.getVar()); }
             @Override public void visit(ImVarargLoop loop) {
                 super.visit(loop);
-                loop.getLoopVars().forEach(v -> used.add(v.getVar()));
+                for (int i = 0; i < loop.getLoopVars().size(); i++) {
+                    used.add(loop.getLoopVars().get(i).getVar());
+                }
             }
         });
         List<ImVar> locals = new ArrayList<>(f.getLocals());
         int before = locals.size();
         List<ImVar> kept = new ArrayList<>(locals.size());
-        for (ImVar v : locals) if (used.contains(v)) kept.add(v);
+        for (int i = 0; i < locals.size(); i++) {
+            ImVar v = locals.get(i);
+            if (used.contains(v)) {
+                kept.add(v);
+            }
+        }
         if (kept.size() != locals.size()) { f.getLocals().clear(); f.getLocals().addAll(kept); }
         return before - kept.size();
     }
@@ -183,7 +195,8 @@ public class LocalMerger implements LocalPlayerAwareOptimizerPass {
                     AstEdits.deleteStmt(s);  // remove the dead assignment entirely
                 } else {
                     ImStmts block = JassIm.ImStmts();
-                    for (ImExpr e : raw) {
+                    for (int i = 0; i < raw.size(); i++) {
+                        ImExpr e = raw.get(i);
                         // wrap expression as a statement; add a *copy* to avoid re-parenting conflicts
                         block.add(ImHelper.statementExprVoid(e.copy()));
                     }
@@ -195,10 +208,22 @@ public class LocalMerger implements LocalPlayerAwareOptimizerPass {
 
     private static void collectLhsSideEffects(ImLExpr lhs, List<ImExpr> out) {
         if (lhs instanceof ImVarArrayAccess a) {
-            for (ImExpr idx : a.getIndexes()) if (hasSideEffects(idx)) out.add(idx);
+            ImExprs indexes = a.getIndexes();
+            for (int i = 0; i < indexes.size(); i++) {
+                ImExpr idx = indexes.get(i);
+                if (hasSideEffects(idx)) {
+                    out.add(idx);
+                }
+            }
         } else if (lhs instanceof ImMemberAccess m) {
             if (hasSideEffects(m.getReceiver())) out.add(m.getReceiver());
-            for (ImExpr idx : m.getIndexes()) if (hasSideEffects(idx)) out.add(idx);
+            ImExprs indexes = m.getIndexes();
+            for (int i = 0; i < indexes.size(); i++) {
+                ImExpr idx = indexes.get(i);
+                if (hasSideEffects(idx)) {
+                    out.add(idx);
+                }
+            }
         } else if (lhs instanceof ImTupleSelection ts) {
             Element t = ts.getTupleExpr();
             if (hasSideEffects(t)) out.add((ImExpr) t);
@@ -255,7 +280,12 @@ public class LocalMerger implements LocalPlayerAwareOptimizerPass {
                         @Override public void case_ImVarArrayAccess(ImVarArrayAccess e) { e.getIndexes().accept(me); }
                         @Override public void case_ImMemberAccess(ImMemberAccess e) { e.getReceiver().accept(me); e.getIndexes().accept(me); }
                         @Override public void case_ImStatementExpr(ImStatementExpr e) { e.getStatements().accept(me); ((ImLExpr) e.getExpr()).match(this); }
-                        @Override public void case_ImTupleExpr(ImTupleExpr e) { for (ImExpr ex : e.getExprs()) ((ImLExpr) ex).match(this); }
+                        @Override public void case_ImTupleExpr(ImTupleExpr e) {
+                            ImExprs exprs = e.getExprs();
+                            for (int i = 0; i < exprs.size(); i++) {
+                                ((ImLExpr) exprs.get(i)).match(this);
+                            }
+                        }
                     });
                 }
             });
@@ -291,14 +321,16 @@ public class LocalMerger implements LocalPlayerAwareOptimizerPass {
         for (int i = 0; i < N; i++) { in[i] = new ObjectOpenHashSet<>(); out[i] = new ObjectOpenHashSet<>(); }
 
         // 5. Iterate over SCCs in reverse topological order
-        for (List<Node> scc : sccs) {
+        for (int sccIndex = 0; sccIndex < sccs.size(); sccIndex++) {
+            List<Node> scc = sccs.get(sccIndex);
             if (scc.isEmpty()) continue;
 
             // Iterate within this SCC until a fixed point is reached for all its nodes.
             boolean changedInScc = true;
             while (changedInScc) {
                 changedInScc = false;
-                for (Node u_node : scc) {
+                for (int uIndex = 0; uIndex < scc.size(); uIndex++) {
+                    Node u_node = scc.get(uIndex);
                     int u_idx = idx.getInt(u_node);
 
                     // Recalculate OUT[u] from the IN sets of its successors.

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/LocalPlayerContextAnalyzer.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/LocalPlayerContextAnalyzer.java
@@ -1,7 +1,6 @@
 package de.peeeq.wurstscript.intermediatelang.optimizer;
 
 import de.peeeq.wurstscript.jassIm.*;
-import de.peeeq.wurstscript.translation.imtranslation.ImHelper;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -161,7 +160,17 @@ public final class LocalPlayerContextAnalyzer {
 
     private void analyze(ImProg prog) {
         sourceFacts.add(unknownDispatchSource);
-        for (ImFunction function : ImHelper.calculateFunctionsOfProg(prog)) {
+        analyzeFunctions(prog.getFunctions());
+        List<ImClass> classes = prog.getClasses();
+        for (int i = 0; i < classes.size(); i++) {
+            analyzeFunctions(classes.get(i).getFunctions());
+        }
+        propagateFacts();
+    }
+
+    private void analyzeFunctions(List<ImFunction> functions) {
+        for (int i = 0; i < functions.size(); i++) {
+            ImFunction function = functions.get(i);
             returnFact(function);
             useFact(function);
             if (isClientLocalValueSource(function)) {
@@ -171,7 +180,6 @@ public final class LocalPlayerContextAnalyzer {
                 addDependency(function.getBody(), useFact(function));
             }
         }
-        propagateFacts();
     }
 
     private boolean methodReturnsLocalPlayerDependentValue(ImMethod method) {
@@ -554,8 +562,11 @@ public final class LocalPlayerContextAnalyzer {
         }
         while (!worklist.isEmpty()) {
             Object fact = worklist.removeFirst();
-            for (Object dependent : dependents.getOrDefault(fact, Collections.emptyList())) {
-                activateFact(dependent, worklist);
+            List<Object> factDependents = dependents.get(fact);
+            if (factDependents != null) {
+                for (int i = 0; i < factDependents.size(); i++) {
+                    activateFact(factDependents.get(i), worklist);
+                }
             }
         }
     }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/LocalPlayerContextAnalyzer.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/optimizer/LocalPlayerContextAnalyzer.java
@@ -181,8 +181,9 @@ public final class LocalPlayerContextAnalyzer {
         if (localPlayerDependentReturns.contains(method.getImplementation())) {
             return true;
         }
-        for (ImMethod subMethod : method.getSubMethods()) {
-            if (methodReturnsLocalPlayerDependentValue(subMethod)) {
+        List<ImMethod> subMethods = method.getSubMethods();
+        for (int i = 0; i < subMethods.size(); i++) {
+            if (methodReturnsLocalPlayerDependentValue(subMethods.get(i))) {
                 return true;
             }
         }
@@ -259,9 +260,12 @@ public final class LocalPlayerContextAnalyzer {
         } else if (element instanceof ImMemberAccess) {
             addDependency(variableFact(((ImMemberAccess) element).getVar()), element);
         } else if (element instanceof ImVarargLoop) {
+            ImVarargLoop loop = (ImVarargLoop) element;
             ImVar varargParameter = varargParameter(owner);
             if (varargParameter != null) {
-                for (ImVarargLoopVar loopVar : ((ImVarargLoop) element).getLoopVars()) {
+                List<ImVarargLoopVar> loopVars = loop.getLoopVars();
+                for (int i = 0; i < loopVars.size(); i++) {
+                    ImVarargLoopVar loopVar = loopVars.get(i);
                     addDependency(variableFact(varargParameter), variableFact(loopVar.getVar()));
                 }
             }
@@ -292,7 +296,8 @@ public final class LocalPlayerContextAnalyzer {
                                            Deque<IndexTask> work) {
         List<IndexTask> tasks = new ArrayList<>(statements.size());
         Object continuationControl = controlContext;
-        for (ImStmt statement : statements) {
+        for (int i = 0; i < statements.size(); i++) {
+            ImStmt statement = statements.get(i);
             addDependency(statement, statements);
             tasks.add(new IndexTask(statement, continuationControl, false));
 
@@ -380,6 +385,8 @@ public final class LocalPlayerContextAnalyzer {
         ImFunction called = call.getFunc();
         addDependency(returnFact(called), call);
         addDependency(useFact(called), useFact(owner));
+        List<ImExpr> arguments = call.getArguments();
+        List<ImVar> calledParameters = called.getParameters();
         if (!called.isNative()) {
             addEnclosingControlDependency(controlContext, entryControlFact(called));
         }
@@ -388,19 +395,20 @@ public final class LocalPlayerContextAnalyzer {
             addLocalPlayerSource(called);
         }
 
-        int fixedParameterCount = called.getParameters().size();
+        int fixedParameterCount = calledParameters.size();
         if (called.hasFlag(IS_VARARG) && fixedParameterCount > 0) {
             fixedParameterCount--;
         }
-        int positionalCount = Math.min(call.getArguments().size(), fixedParameterCount);
+        int argumentCount = arguments.size();
+        int positionalCount = Math.min(argumentCount, fixedParameterCount);
         for (int i = 0; i < positionalCount; i++) {
-            addDependency(call.getArguments().get(i),
-                variableFact(called.getParameters().get(i)));
+            addDependency(arguments.get(i),
+                variableFact(calledParameters.get(i)));
         }
         ImVar varargParameter = varargParameter(called);
         if (varargParameter != null) {
-            for (int i = fixedParameterCount; i < call.getArguments().size(); i++) {
-                addDependency(call.getArguments().get(i),
+            for (int i = fixedParameterCount; i < argumentCount; i++) {
+                addDependency(arguments.get(i),
                     variableFact(varargParameter));
             }
         }
@@ -425,14 +433,18 @@ public final class LocalPlayerContextAnalyzer {
             addDependency(unknownDispatchSource, useFact(owner));
         }
 
+        List<ImExpr> arguments = call.getArguments();
         for (ImFunction implementation : implementations) {
             addDependency(returnFact(implementation), call);
             addDependency(useFact(implementation), useFact(owner));
             addEnclosingControlDependency(controlContext, entryControlFact(implementation));
-            for (ImVar parameter : implementation.getParameters()) {
-                addDependency(call.getReceiver(), variableFact(parameter));
-                for (ImExpr argument : call.getArguments()) {
-                    addDependency(argument, variableFact(parameter));
+            Element receiver = call.getReceiver();
+            List<ImVar> parameters = implementation.getParameters();
+            for (int i = 0; i < parameters.size(); i++) {
+                ImVar parameter = parameters.get(i);
+                addDependency(receiver, variableFact(parameter));
+                for (int j = 0; j < arguments.size(); j++) {
+                    addDependency(arguments.get(j), variableFact(parameter));
                 }
             }
         }
@@ -487,8 +499,9 @@ public final class LocalPlayerContextAnalyzer {
             return method != null && method.getImplementation() != null;
         }
         implementations.add(method.getImplementation());
-        for (ImMethod subMethod : method.getSubMethods()) {
-            if (!collectMethodImplementations(subMethod, implementations, visited)) {
+        List<ImMethod> subMethods = method.getSubMethods();
+        for (int i = 0; i < subMethods.size(); i++) {
+            if (!collectMethodImplementations(subMethods.get(i), implementations, visited)) {
                 return false;
             }
         }
@@ -508,9 +521,11 @@ public final class LocalPlayerContextAnalyzer {
                 forEachAssignedVariable((ImLExpr) tupleExpr, consumer);
             }
         } else if (left instanceof ImTupleExpr) {
-            for (ImExpr expr : ((ImTupleExpr) left).getExprs()) {
-                if (expr instanceof ImLExpr) {
-                    forEachAssignedVariable((ImLExpr) expr, consumer);
+            ImExprs exprs = ((ImTupleExpr) left).getExprs();
+            for (int i = 0; i < exprs.size(); i++) {
+                ImExpr expr = exprs.get(i);
+                if (expr instanceof ImLExpr lExpr) {
+                    forEachAssignedVariable(lExpr, consumer);
                 }
             }
         } else if (left instanceof ImStatementExpr) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/Flatten.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/Flatten.java
@@ -501,9 +501,15 @@ public class Flatten {
             if (total >= PARALLEL_THRESHOLD) {
                 // Collect once for parallel traversal.
                 List<ImFunction> allFunctions = new ArrayList<>(total);
-                allFunctions.addAll(imProg.getFunctions());
+                List<ImFunction> functions = imProg.getFunctions();
+                for (int i = 0; i < functions.size(); i++) {
+                    allFunctions.add(functions.get(i));
+                }
                 for (int i = 0; i < classes.size(); i++) {
-                    allFunctions.addAll(classes.get(i).getFunctions());
+                    List<ImFunction> classFunctions = classes.get(i).getFunctions();
+                    for (int j = 0; j < classFunctions.size(); j++) {
+                        allFunctions.add(classFunctions.get(j));
+                    }
                 }
                 allFunctions.parallelStream().forEach(f -> f.flatten(translator));
             } else {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/Flatten.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/Flatten.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static de.peeeq.wurstscript.jassIm.JassIm.*;
 
@@ -136,7 +135,8 @@ public class Flatten {
         public Result(List<ImStmt> stmts, ImExpr expr) {
             Preconditions.checkArgument(expr.getParent() == null, "expression must not have a parent");
             boolean b = true;
-            for (ImStmt s : stmts) {
+            for (int i = 0; i < stmts.size(); i++) {
+                ImStmt s = stmts.get(i);
                 if (s.getParent() != null) {
                     b = false;
                     break;
@@ -286,8 +286,8 @@ public class Flatten {
     }
 
     private static void flattenStatementsInto(List<ImStmt> result, ImStmts statements, ImTranslator t, ImFunction f) {
-        for (ImStmt s : statements) {
-            s.flatten(t, f).intoStatements(result, t, f);
+        for (int i = 0; i < statements.size(); i++) {
+            statements.get(i).flatten(t, f).intoStatements(result, t, f);
         }
     }
 
@@ -494,35 +494,48 @@ public class Flatten {
         // Choose execution strategy based on flags and size
         if (USE_PARALLEL_EXECUTION) {
             int total = imProg.getFunctions().size();
-            for (ImClass c : imProg.getClasses()) {
-                total += c.getFunctions().size();
+            List<ImClass> classes = imProg.getClasses();
+            for (int i = 0; i < classes.size(); i++) {
+                total += classes.get(i).getFunctions().size();
             }
             if (total >= PARALLEL_THRESHOLD) {
                 // Collect once for parallel traversal.
                 List<ImFunction> allFunctions = new ArrayList<>(total);
                 allFunctions.addAll(imProg.getFunctions());
-                for (ImClass c : imProg.getClasses()) {
-                    allFunctions.addAll(c.getFunctions());
+                for (int i = 0; i < classes.size(); i++) {
+                    allFunctions.addAll(classes.get(i).getFunctions());
                 }
                 allFunctions.parallelStream().forEach(f -> f.flatten(translator));
             } else {
-                for (ImFunction f : imProg.getFunctions()) {
-                    f.flatten(translator);
+                List<ImFunction> functions = imProg.getFunctions();
+                for (int i = 0; i < functions.size(); i++) {
+                    ImFunction function = functions.get(i);
+                    function.flatten(translator);
                 }
-                for (ImClass c : imProg.getClasses()) {
-                    for (ImFunction f : c.getFunctions()) {
-                        f.flatten(translator);
+                List<ImClass> classes = imProg.getClasses();
+                for (int i = 0; i < classes.size(); i++) {
+                    ImClass c = classes.get(i);
+                    List<ImFunction> classFunctions = c.getFunctions();
+                    for (int j = 0; j < classFunctions.size(); j++) {
+                        ImFunction function = classFunctions.get(j);
+                        function.flatten(translator);
                     }
                 }
             }
         } else {
             // Sequential processing avoids intermediate list/lambda overhead.
-            for (ImFunction f : imProg.getFunctions()) {
-                f.flatten(translator);
+            List<ImFunction> functions = imProg.getFunctions();
+            for (int i = 0; i < functions.size(); i++) {
+                ImFunction function = functions.get(i);
+                function.flatten(translator);
             }
-            for (ImClass c : imProg.getClasses()) {
-                for (ImFunction f : c.getFunctions()) {
-                    f.flatten(translator);
+            List<ImClass> classes = imProg.getClasses();
+            for (int i = 0; i < classes.size(); i++) {
+                ImClass c = classes.get(i);
+                List<ImFunction> classFunctions = c.getFunctions();
+                for (int j = 0; j < classFunctions.size(); j++) {
+                    ImFunction function = classFunctions.get(j);
+                    function.flatten(translator);
                 }
             }
         }
@@ -665,9 +678,12 @@ public class Flatten {
     }
 
     private static ImVarargLoopVars copyVarargLoopVars(ImVarargLoopVars loopVars) {
-        return JassIm.ImVarargLoopVars(loopVars.stream()
-            .map(v -> JassIm.ImVarargLoopVar(v.getVar()))
-            .collect(Collectors.toList()));
+        int n = loopVars.size();
+        List<ImVarargLoopVar> copiedVars = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            copiedVars.add(JassIm.ImVarargLoopVar(loopVars.get(i).getVar()));
+        }
+        return JassIm.ImVarargLoopVars(copiedVars);
     }
 
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/Flatten.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/Flatten.java
@@ -492,9 +492,9 @@ public class Flatten {
 
     public static void flattenProg(ImProg imProg, ImTranslator translator) {
         // Choose execution strategy based on flags and size
+        List<ImClass> classes = imProg.getClasses();
         if (USE_PARALLEL_EXECUTION) {
             int total = imProg.getFunctions().size();
-            List<ImClass> classes = imProg.getClasses();
             for (int i = 0; i < classes.size(); i++) {
                 total += classes.get(i).getFunctions().size();
             }
@@ -512,7 +512,6 @@ public class Flatten {
                     ImFunction function = functions.get(i);
                     function.flatten(translator);
                 }
-                List<ImClass> classes = imProg.getClasses();
                 for (int i = 0; i < classes.size(); i++) {
                     ImClass c = classes.get(i);
                     List<ImFunction> classFunctions = c.getFunctions();
@@ -529,7 +528,6 @@ public class Flatten {
                 ImFunction function = functions.get(i);
                 function.flatten(translator);
             }
-            List<ImClass> classes = imProg.getClasses();
             for (int i = 0; i < classes.size(); i++) {
                 ImClass c = classes.get(i);
                 List<ImFunction> classFunctions = c.getFunctions();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImHelper.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/ImHelper.java
@@ -21,25 +21,40 @@ public class ImHelper {
      * rather than counting parameters.
      */
     public static int flattenedJassArity(ImType type) {
-        if (type instanceof ImTupleType) {
-            return ((ImTupleType) type).getTypes().stream()
-                .mapToInt(ImHelper::flattenedJassArity)
-                .sum();
+        if (type instanceof ImTupleType tupleType) {
+            int result = 0;
+            List<ImType> types = tupleType.getTypes();
+            for (int i = 0; i < types.size(); i++) {
+                result += flattenedJassArity(types.get(i));
+            }
+            return result;
         }
         return 1;
     }
 
     public static Set<ImFunction> calculateFunctionsOfProg(ImProg prog) {
-        Set<ImFunction> allFunctions = new HashSet<>(prog.getFunctions());
-        for(ImClass c : prog.getClasses()) {
-            allFunctions.addAll(c.getFunctions());
+        ImFunctions functions = prog.getFunctions();
+        ImClasses classes = prog.getClasses();
+        int functionCount = functions.size();
+        for (int i = 0; i < classes.size(); i++) {
+            functionCount += classes.get(i).getFunctions().size();
+        }
+        Set<ImFunction> allFunctions = HashSet.newHashSet(functionCount);
+        for (int i = 0; i < functions.size(); i++) {
+            allFunctions.add(functions.get(i));
+        }
+        for (int i = 0; i < classes.size(); i++) {
+            ImFunctions classFunctions = classes.get(i).getFunctions();
+            for (int j = 0; j < classFunctions.size(); j++) {
+                allFunctions.add(classFunctions.get(j));
+            }
         }
         return allFunctions;
     }
 
     static void translateParameters(WParameters params, ImVars result, ImTranslator t) {
-        for (WParameter p : params) {
-            result.add(t.getVarFor(p));
+        for (int i = 0; i < params.size(); i++) {
+            result.add(t.getVarFor(params.get(i)));
         }
     }
 
@@ -58,8 +73,8 @@ public class ImHelper {
     }
 
     public static void replaceVar(List<ImStmt> stmts, final ImVar oldVar, final ImVar newVar) {
-        for (ImStmt s : stmts) {
-            replaceVar(s, oldVar, newVar);
+        for (int i = 0; i < stmts.size(); i++) {
+            replaceVar(stmts.get(i), oldVar, newVar);
         }
     }
 
@@ -164,8 +179,9 @@ public class ImHelper {
             @Override
             public ImExpr case_ImTupleType(ImTupleType tt) {
                 ImExprs res = JassIm.ImExprs();
-                for (ImType it : tt.getTypes()) {
-                    res.add(defaultValueForComplexType(it));
+                List<ImType> types = tt.getTypes();
+                for (int i = 0; i < types.size(); i++) {
+                    res.add(defaultValueForComplexType(types.get(i)));
                 }
                 return JassIm.ImTupleExpr(res);
             }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/LuaDispatchPreparation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/LuaDispatchPreparation.java
@@ -49,14 +49,20 @@ public final class LuaDispatchPreparation {
         List<ImClass> classes = prog.getClasses();
         for (int i = 0; i < classes.size(); i++) {
             ImClass c = classes.get(i);
-            methods.addAll(c.getMethods());
+            List<ImMethod> classMethods = c.getMethods();
+            for (int j = 0; j < classMethods.size(); j++) {
+                methods.add(classMethods.get(j));
+            }
         }
         methods.sort(Comparator.comparing(LuaDispatchPreparation::methodSortKey));
         return methods;
     }
 
     private static void assignDispatchGroupKeys(List<ImMethod> allMethods) {
-        Set<ImMethod> knownMethods = new HashSet<>(allMethods);
+        Set<ImMethod> knownMethods = HashSet.newHashSet(allMethods.size());
+        for (int i = 0; i < allMethods.size(); i++) {
+            knownMethods.add(allMethods.get(i));
+        }
         UnionFind<ImMethod> unions = new UnionFind<>();
         for (int i = 0; i < allMethods.size(); i++) {
             ImMethod method = allMethods.get(i);
@@ -77,18 +83,14 @@ public final class LuaDispatchPreparation {
             grouped.computeIfAbsent(root, ignored -> new ArrayList<>()).add(method);
         }
 
-        List<List<ImMethod>> groups = new ArrayList<>(grouped.values());
-        for (int i = 0; i < groups.size(); i++) {
-            List<ImMethod> group = groups.get(i);
+        for (List<ImMethod> group : grouped.values()) {
             Map<String, List<ImMethod>> partitions = new LinkedHashMap<>();
             group.sort(Comparator.comparing(LuaDispatchPreparation::methodSortKey));
             for (int j = 0; j < group.size(); j++) {
                 ImMethod method = group.get(j);
                 partitions.computeIfAbsent(dispatchSignatureKey(method), ignored -> new ArrayList<>()).add(method);
             }
-            List<List<ImMethod>> partitionGroups = new ArrayList<>(partitions.values());
-            for (int j = 0; j < partitionGroups.size(); j++) {
-                List<ImMethod> partition = partitionGroups.get(j);
+            for (List<ImMethod> partition : partitions.values()) {
                 partition.sort(Comparator.comparing(LuaDispatchPreparation::methodSortKey));
                 if (partition.isEmpty()) {
                     continue;
@@ -161,9 +163,9 @@ public final class LuaDispatchPreparation {
                 usedNames.add(function.getName());
             }
         }
-        ImVar[] globals = prog.getGlobals().toArray(new ImVar[0]);
-        for (int i = 0; i < globals.length; i++) {
-            ImVar global = globals[i];
+        List<ImVar> globals = prog.getGlobals();
+        for (int i = 0; i < globals.size(); i++) {
+            ImVar global = globals.get(i);
             if (global.getIsBJ()) {
                 usedNames.add(global.getName());
             }
@@ -306,9 +308,7 @@ public final class LuaDispatchPreparation {
             return;
         }
         String runtimeKey = closureRuntimeDispatchKey(method);
-        List<ImClass> anchors = new ArrayList<>(closureFamilyAnchors(owner, closureFamilyAnchorsCache));
-        for (int i = 0; i < anchors.size(); i++) {
-            ImClass anchor = anchors.get(i);
+        for (ImClass anchor : closureFamilyAnchors(owner, closureFamilyAnchorsCache)) {
             List<ImClass> candidateClasses = closureFamilyClassesForAnchor(prog, anchor, closureFamilyClassesByAnchor);
             for (int j = 0; j < candidateClasses.size(); j++) {
                 ImClass candidateClass = candidateClasses.get(j);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/LuaDispatchPreparation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/LuaDispatchPreparation.java
@@ -45,7 +45,9 @@ public final class LuaDispatchPreparation {
 
     private static List<ImMethod> collectAllMethods(ImProg prog) {
         List<ImMethod> methods = new ArrayList<>();
-        for (ImClass c : prog.getClasses()) {
+        List<ImClass> classes = prog.getClasses();
+        for (int i = 0; i < classes.size(); i++) {
+            ImClass c = classes.get(i);
             methods.addAll(c.getMethods());
         }
         methods.sort(Comparator.comparing(LuaDispatchPreparation::methodSortKey));
@@ -55,9 +57,12 @@ public final class LuaDispatchPreparation {
     private static void assignDispatchGroupKeys(List<ImMethod> allMethods) {
         Set<ImMethod> knownMethods = new HashSet<>(allMethods);
         UnionFind<ImMethod> unions = new UnionFind<>();
-        for (ImMethod method : allMethods) {
+        for (int i = 0; i < allMethods.size(); i++) {
+            ImMethod method = allMethods.get(i);
             unions.find(method);
-            for (ImMethod subMethod : method.getSubMethods()) {
+            List<ImMethod> subMethods = method.getSubMethods();
+            for (int j = 0; j < subMethods.size(); j++) {
+                ImMethod subMethod = subMethods.get(j);
                 if (knownMethods.contains(subMethod)) {
                     unions.union(method, subMethod);
                 }
@@ -65,24 +70,31 @@ public final class LuaDispatchPreparation {
         }
 
         Map<ImMethod, List<ImMethod>> grouped = new LinkedHashMap<>();
-        for (ImMethod method : allMethods) {
+        for (int i = 0; i < allMethods.size(); i++) {
+            ImMethod method = allMethods.get(i);
             ImMethod root = unions.find(method);
             grouped.computeIfAbsent(root, ignored -> new ArrayList<>()).add(method);
         }
 
-        for (List<ImMethod> group : grouped.values()) {
+        List<List<ImMethod>> groups = new ArrayList<>(grouped.values());
+        for (int i = 0; i < groups.size(); i++) {
+            List<ImMethod> group = groups.get(i);
             Map<String, List<ImMethod>> partitions = new LinkedHashMap<>();
             group.sort(Comparator.comparing(LuaDispatchPreparation::methodSortKey));
-            for (ImMethod method : group) {
+            for (int j = 0; j < group.size(); j++) {
+                ImMethod method = group.get(j);
                 partitions.computeIfAbsent(dispatchSignatureKey(method), ignored -> new ArrayList<>()).add(method);
             }
-            for (List<ImMethod> partition : partitions.values()) {
+            List<List<ImMethod>> partitionGroups = new ArrayList<>(partitions.values());
+            for (int j = 0; j < partitionGroups.size(); j++) {
+                List<ImMethod> partition = partitionGroups.get(j);
                 partition.sort(Comparator.comparing(LuaDispatchPreparation::methodSortKey));
                 if (partition.isEmpty()) {
                     continue;
                 }
                 String key = methodSortKey(partition.get(0)) + "|" + dispatchSignatureKey(partition.get(0));
-                for (ImMethod method : partition) {
+                for (int k = 0; k < partition.size(); k++) {
+                    ImMethod method = partition.get(k);
                     method.setLuaDispatchGroupKey(key);
                 }
             }
@@ -94,12 +106,14 @@ public final class LuaDispatchPreparation {
         collectPredefinedNames(prog, usedNames);
 
         Map<String, List<ImMethod>> groupedMethods = new TreeMap<>();
-        for (ImMethod method : allMethods) {
+        for (int i = 0; i < allMethods.size(); i++) {
+            ImMethod method = allMethods.get(i);
             groupedMethods.computeIfAbsent(method.getLuaDispatchGroupKey(), ignored -> new ArrayList<>()).add(method);
         }
         List<List<ImMethod>> groups = new ArrayList<>(groupedMethods.values());
         groups.sort(Comparator.comparing(g -> g.isEmpty() ? "" : methodSortKey(g.get(0))));
-        for (List<ImMethod> group : groups) {
+        for (int i = 0; i < groups.size(); i++) {
+            List<ImMethod> group = groups.get(i);
             if (group.isEmpty()) {
                 continue;
             }
@@ -113,7 +127,8 @@ public final class LuaDispatchPreparation {
             // whose own name appears nowhere in it - which is why no method can work this out for
             // itself afterwards.
             String segment = segmentOf(name, group.get(0));
-            for (ImMethod method : group) {
+            for (int j = 0; j < group.size(); j++) {
+                ImMethod method = group.get(j);
                 method.setName(name);
                 tr.recordDispatchSegment(method, segment);
             }
@@ -127,7 +142,8 @@ public final class LuaDispatchPreparation {
 
         Set<String> ambiguousDirectAliases = ambiguousDirectAliases(allMethods, tr);
 
-        for (ImMethod method : allMethods) {
+        for (int i = 0; i < allMethods.size(); i++) {
+            ImMethod method = allMethods.get(i);
             TreeSet<String> aliases = new TreeSet<>();
             addDirectAliases(method, aliases, ambiguousDirectAliases, tr);
             addHierarchyAliases(method, aliases, sortedMethodsByClass, tr);
@@ -137,16 +153,20 @@ public final class LuaDispatchPreparation {
     }
 
     private static void collectPredefinedNames(ImProg prog, Set<String> usedNames) {
-        prog.getFunctions().forEach(function -> {
+        List<ImFunction> functions = prog.getFunctions();
+        for (int i = 0; i < functions.size(); i++) {
+            ImFunction function = functions.get(i);
             if (function.isBj() || function.isExtern() || function.isNative()) {
                 usedNames.add(function.getName());
             }
-        });
-        prog.getGlobals().forEach(global -> {
+        }
+        List<ImVar> globals = prog.getGlobals();
+        for (int i = 0; i < globals.size(); i++) {
+            ImVar global = globals.get(i);
             if (global.getIsBJ()) {
                 usedNames.add(global.getName());
             }
-        });
+        }
     }
 
     private static String uniqueName(String name, Set<String> usedNames) {
@@ -172,7 +192,8 @@ public final class LuaDispatchPreparation {
     private static Set<String> ambiguousDirectAliases(List<ImMethod> allMethods, ImTranslator tr) {
         Map<String, String> claimedBy = new LinkedHashMap<>();
         Set<String> ambiguous = new HashSet<>();
-        for (ImMethod method : allMethods) {
+        for (int i = 0; i < allMethods.size(); i++) {
+            ImMethod method = allMethods.get(i);
             String composed = directAliasFor(method, tr);
             if (composed == null) {
                 continue;
@@ -246,7 +267,9 @@ public final class LuaDispatchPreparation {
         if (c == null || !visited.add(c)) {
             return;
         }
-        for (ImMethod candidate : sortedMethodsForClass(c, sortedMethodsByClass)) {
+        List<ImMethod> candidates = sortedMethodsForClass(c, sortedMethodsByClass);
+        for (int i = 0; i < candidates.size(); i++) {
+            ImMethod candidate = candidates.get(i);
             if (!dispatchKey.equals(dispatchParameterSignatureKey(candidate))) {
                 continue;
             }
@@ -262,7 +285,9 @@ public final class LuaDispatchPreparation {
                 aliases.add(c.getName() + "_" + candidateName);
             }
         }
-        for (ImClassType sc : c.getSuperClasses()) {
+        List<ImClassType> superClasses = c.getSuperClasses();
+        for (int i = 0; i < superClasses.size(); i++) {
+            ImClassType sc = superClasses.get(i);
             collectHierarchyAliases(sc.getClassDef(), method, dispatchKey, semanticNames, aliases, sortedMethodsByClass, visited, tr);
         }
     }
@@ -280,9 +305,15 @@ public final class LuaDispatchPreparation {
             return;
         }
         String runtimeKey = closureRuntimeDispatchKey(method);
-        for (ImClass anchor : closureFamilyAnchors(owner, closureFamilyAnchorsCache)) {
-            for (ImClass candidateClass : closureFamilyClassesForAnchor(prog, anchor, closureFamilyClassesByAnchor)) {
-                for (ImMethod candidate : sortedMethodsForClass(candidateClass, sortedMethodsByClass)) {
+        List<ImClass> anchors = new ArrayList<>(closureFamilyAnchors(owner, closureFamilyAnchorsCache));
+        for (int i = 0; i < anchors.size(); i++) {
+            ImClass anchor = anchors.get(i);
+            List<ImClass> candidateClasses = closureFamilyClassesForAnchor(prog, anchor, closureFamilyClassesByAnchor);
+            for (int j = 0; j < candidateClasses.size(); j++) {
+                ImClass candidateClass = candidateClasses.get(j);
+                List<ImMethod> candidates = sortedMethodsForClass(candidateClass, sortedMethodsByClass);
+                for (int k = 0; k < candidates.size(); k++) {
+                    ImMethod candidate = candidates.get(k);
                     if (!runtimeKey.equals(closureRuntimeDispatchKey(candidate))) {
                         continue;
                     }
@@ -377,7 +408,9 @@ public final class LuaDispatchPreparation {
         if (!isClosureGeneratedClass(c)) {
             anchors.add(c);
         }
-        for (ImClassType sc : c.getSuperClasses()) {
+        List<ImClassType> superClasses = c.getSuperClasses();
+        for (int i = 0; i < superClasses.size(); i++) {
+            ImClassType sc = superClasses.get(i);
             collectClosureFamilyAnchors(sc.getClassDef(), anchors, visited);
         }
     }
@@ -385,7 +418,9 @@ public final class LuaDispatchPreparation {
     private static List<ImClass> closureFamilyClassesForAnchor(ImProg prog, ImClass anchor, Map<ImClass, List<ImClass>> cache) {
         return cache.computeIfAbsent(anchor, a -> {
             List<ImClass> result = new ArrayList<>();
-            for (ImClass candidate : prog.getClasses()) {
+            List<ImClass> classes = prog.getClasses();
+            for (int i = 0; i < classes.size(); i++) {
+                ImClass candidate = classes.get(i);
                 if (sharesClosureFamilyAnchor(candidate, a, new HashSet<>())) {
                     result.add(candidate);
                 }
@@ -402,7 +437,9 @@ public final class LuaDispatchPreparation {
         if (c == anchor) {
             return true;
         }
-        for (ImClassType sc : c.getSuperClasses()) {
+        List<ImClassType> superClasses = c.getSuperClasses();
+        for (int i = 0; i < superClasses.size(); i++) {
+            ImClassType sc = superClasses.get(i);
             if (sharesClosureFamilyAnchor(sc.getClassDef(), anchor, visited)) {
                 return true;
             }
@@ -517,7 +554,9 @@ public final class LuaDispatchPreparation {
         if (current == target) {
             return true;
         }
-        for (ImMethod subMethod : current.getSubMethods()) {
+        List<ImMethod> subMethods = current.getSubMethods();
+        for (int i = 0; i < subMethods.size(); i++) {
+            ImMethod subMethod = subMethods.get(i);
             if (reaches(subMethod, target, visited)) {
                 return true;
             }
@@ -558,7 +597,8 @@ public final class LuaDispatchPreparation {
         }
         List<ImMethod> subMethods = new ArrayList<>(method.getSubMethods());
         subMethods.sort(Comparator.comparing(LuaDispatchPreparation::methodSortKey));
-        for (ImMethod subMethod : subMethods) {
+        for (int i = 0; i < subMethods.size(); i++) {
+            ImMethod subMethod = subMethods.get(i);
             ImFunction resolved = resolveDispatchSignatureImplementation(subMethod, visited);
             if (resolved != null) {
                 return resolved;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/LuaDispatchPreparation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/LuaDispatchPreparation.java
@@ -10,6 +10,7 @@ import de.peeeq.wurstscript.jassIm.ImClassType;
 import de.peeeq.wurstscript.jassIm.ImFunction;
 import de.peeeq.wurstscript.jassIm.ImMethod;
 import de.peeeq.wurstscript.jassIm.ImProg;
+import de.peeeq.wurstscript.jassIm.ImVar;
 import de.peeeq.wurstscript.jassIm.ImType;
 import de.peeeq.wurstscript.jassIm.ImTypeVarRef;
 import de.peeeq.wurstscript.jassIm.ImVars;
@@ -160,9 +161,9 @@ public final class LuaDispatchPreparation {
                 usedNames.add(function.getName());
             }
         }
-        List<ImVar> globals = prog.getGlobals();
-        for (int i = 0; i < globals.size(); i++) {
-            ImVar global = globals.get(i);
+        ImVar[] globals = prog.getGlobals().toArray(new ImVar[0]);
+        for (int i = 0; i < globals.length; i++) {
+            ImVar global = globals[i];
             if (global.getIsBJ()) {
                 usedNames.add(global.getName());
             }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -98,11 +97,13 @@ public class RemoveGarbage {
             }
             if (newDispatchClass) {
                 Collection<ImMethod> imMethods = waitingMethods.get(c);
-                Iterator<ImMethod> it = imMethods.iterator();
-                while (it.hasNext()) {
-                    ImMethod m = it.next();
-                    visitMethod(m, this);
-                    it.remove();
+                if (!imMethods.isEmpty()) {
+                    Object[] pendingMethods = imMethods.toArray();
+                    for (int i = 0; i < pendingMethods.length; i++) {
+                        ImMethod m = (ImMethod) pendingMethods[i];
+                        visitMethod(m, this);
+                        waitingMethods.remove(c, m);
+                    }
                 }
             }
             return newClass || newDispatchClass;
@@ -112,8 +113,9 @@ public class RemoveGarbage {
             if (!instantiatedClasses.add(c)) {
                 return;
             }
-            for (ImClassType superClass : c.getSuperClasses()) {
-                addInstantiatedClass(superClass.getClassDef());
+            List<ImClassType> superClasses = c.getSuperClasses();
+            for (int i = 0; i < superClasses.size(); i++) {
+                addInstantiatedClass(superClasses.get(i).getClassDef());
             }
         }
     }
@@ -125,20 +127,24 @@ public class RemoveGarbage {
         prog.getGlobals().removeIf(g -> !used.getVars().contains(g) && !NamePreservation.isPreserved(g));
         prog.getFunctions().removeIf(f -> !used.getFunctions().contains(f));
         prog.getMethods().removeIf(m -> !used.getMethods().contains(m));
-        for (ImMethod m : prog.getMethods()) {
-            m.getSubMethods().removeIf(sm -> !used.getMethods().contains(sm));
+        List<ImMethod> methods = prog.getMethods();
+        for (int i = 0; i < methods.size(); i++) {
+            methods.get(i).getSubMethods().removeIf(sm -> !used.getMethods().contains(sm));
         }
         // A field of a specialised class is a copy which nothing refers to, an access made before
         // specialisation still naming the original's variable. It is live exactly when the field it
         // was copied from is; dropping it leaves an instance of the specialised class allocated with
         // no fields at all while the emitted code goes on reading them.
-        for (ImClass c : prog.getClasses()) {
+        List<ImClass> classes = prog.getClasses();
+        for (int i = 0; i < classes.size(); i++) {
+            ImClass c = classes.get(i);
             c.getFields().removeIf(g -> !used.getVars().contains(g)
                 && !used.getVars().contains(translator.canonical(g)));
             c.getFunctions().removeIf(f -> !used.getFunctions().contains(f));
             c.getMethods().removeIf(m -> !used.getMethods().contains(m));
-            for (ImMethod m : c.getMethods()) {
-                m.getSubMethods().removeIf(sm -> !used.getMethods().contains(sm));
+            List<ImMethod> classMethods = c.getMethods();
+            for (int j = 0; j < classMethods.size(); j++) {
+                classMethods.get(j).getSubMethods().removeIf(sm -> !used.getMethods().contains(sm));
             }
         }
 
@@ -151,7 +157,9 @@ public class RemoveGarbage {
     private static Used collectUsed(ImProg prog, ImTranslator translator,
                                     Set<ImSet> ignoredInitializers) {
         Used used = new Used(translator, ignoredInitializers);
-        for (ImFunction f : ImHelper.calculateFunctionsOfProg(prog)) {
+        List<ImFunction> programFunctions = ImHelper.calculateFunctionsOfProg(prog);
+        for (int i = 0; i < programFunctions.size(); i++) {
+            ImFunction f = programFunctions.get(i);
             if (f.getName().equals("main")
                 || f.getName().equals("config")
                 || NamePreservation.isPreserved(f)) {
@@ -163,7 +171,9 @@ public class RemoveGarbage {
 
     public static void removePhantomGenericStaticInitializers(ImProg prog, ImTranslator translator) {
         Map<ImVar, List<ImSet>> candidates = new LinkedHashMap<>();
-        for (ImVar global : prog.getGlobals()) {
+        List<ImVar> globals = prog.getGlobals();
+        for (int i = 0; i < globals.size(); i++) {
+            ImVar global = globals.get(i);
             ImTranslator.Specialisation specialization = translator.specialisationOf(global);
             if (specialization != null && specialization.original() instanceof ImVar original
                 && translator.genericStaticOwnerOf(original) != null) {
@@ -182,14 +192,20 @@ public class RemoveGarbage {
         boolean changed;
         do {
             Set<ImSet> ignored = Collections.newSetFromMap(new IdentityHashMap<>());
-            for (Map.Entry<ImVar, List<ImSet>> candidate : candidates.entrySet()) {
+            Object[] candidateEntries = candidates.entrySet().toArray();
+            for (int i = 0; i < candidateEntries.length; i++) {
+                @SuppressWarnings("unchecked")
+                Map.Entry<ImVar, List<ImSet>> candidate
+                    = (Map.Entry<ImVar, List<ImSet>>) candidateEntries[i];
                 if (!liveOriginals.contains(candidate.getKey())) {
                     ignored.addAll(candidate.getValue());
                 }
             }
             Used used = collectUsed(prog, translator, ignored);
             changed = false;
-            for (ImVar original : candidates.keySet()) {
+            Object[] candidateKeys = candidates.keySet().toArray();
+            for (int i = 0; i < candidateKeys.length; i++) {
+                ImVar original = (ImVar) candidateKeys[i];
                 ImClass owner = translator.genericStaticOwnerOf(original);
                 boolean erasedInstantiationNeedsOriginal = used.getInstantiatedClasses().contains(owner)
                     && translator.hasErasedAllocationWithoutStaticSpecialization(owner, original);
@@ -200,12 +216,18 @@ public class RemoveGarbage {
             }
         } while (changed);
 
-        for (Map.Entry<ImVar, List<ImSet>> candidate : candidates.entrySet()) {
+        Object[] finalCandidateEntries = candidates.entrySet().toArray();
+        for (int i = 0; i < finalCandidateEntries.length; i++) {
+            @SuppressWarnings("unchecked")
+            Map.Entry<ImVar, List<ImSet>> candidate
+                = (Map.Entry<ImVar, List<ImSet>>) finalCandidateEntries[i];
             if (liveOriginals.contains(candidate.getKey())) {
                 continue;
             }
             prog.getGlobalInits().remove(candidate.getKey());
-            for (ImSet initializer : candidate.getValue()) {
+            List<ImSet> initSetters = candidate.getValue();
+            for (int j = 0; j < initSetters.size(); j++) {
+                ImSet initializer = initSetters.get(j);
                 if (initializer.getParent() == null) {
                     continue;
                 }
@@ -322,8 +344,9 @@ public class RemoveGarbage {
             // abstract methods can have no implementation
             visitFunction(m.getImplementation(), used);
         }
-        for (ImMethod subMethod : m.getSubMethods()) {
-            used.maybeVisitMethod(subMethod);
+        List<ImMethod> subMethods = m.getSubMethods();
+        for (int i = 0; i < subMethods.size(); i++) {
+            used.maybeVisitMethod(subMethods.get(i));
         }
     }
 
@@ -335,8 +358,9 @@ public class RemoveGarbage {
         if (!used.addClass(c, dispatchReachable)) {
             return;
         }
-        for (ImClassType superClass : c.getSuperClasses()) {
-            visitClass(superClass.getClassDef(), used, dispatchReachable);
+        List<ImClassType> superClasses = c.getSuperClasses();
+        for (int i = 0; i < superClasses.size(); i++) {
+            visitClass(superClasses.get(i).getClassDef(), used, dispatchReachable);
         }
     }
 
@@ -350,8 +374,9 @@ public class RemoveGarbage {
 
             @Override
             public void case_ImTupleType(ImTupleType tt) {
-                for (ImType type : tt.getTypes()) {
-                    visitType(type, used);
+                List<ImType> types = tt.getTypes();
+                for (int i = 0; i < types.size(); i++) {
+                    visitType(types.get(i), used);
                 }
             }
 
@@ -378,8 +403,9 @@ public class RemoveGarbage {
             @Override
             public void case_ImClassType(ImClassType tt) {
                 visitClass(tt.getClassDef(), used, false);
-                for (ImTypeArgument ta : tt.getTypeArguments()) {
-                    visitType(ta.getType(), used);
+                List<ImTypeArgument> tArgs = tt.getTypeArguments();
+                for (int i = 0; i < tArgs.size(); i++) {
+                    visitType(tArgs.get(i).getType(), used);
                 }
             }
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
@@ -3,7 +3,6 @@ package de.peeeq.wurstscript.translation.lua.translation;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import de.peeeq.wurstscript.jassIm.*;
-import de.peeeq.wurstscript.translation.imtranslation.ImHelper;
 import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
 import de.peeeq.wurstscript.validation.NamePreservation;
 
@@ -11,6 +10,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -97,13 +97,13 @@ public class RemoveGarbage {
             }
             if (newDispatchClass) {
                 Collection<ImMethod> imMethods = waitingMethods.get(c);
-                if (!imMethods.isEmpty()) {
-                    Object[] pendingMethods = imMethods.toArray();
-                    for (int i = 0; i < pendingMethods.length; i++) {
-                        ImMethod m = (ImMethod) pendingMethods[i];
-                        visitMethod(m, this);
-                        waitingMethods.remove(c, m);
-                    }
+                // This is a HashMultimap set view, not an indexed list. Keep the one iterator:
+                // taking an array snapshot here allocates one entry for every waiting method.
+                Iterator<ImMethod> iterator = imMethods.iterator();
+                while (iterator.hasNext()) {
+                    ImMethod method = iterator.next();
+                    visitMethod(method, this);
+                    iterator.remove();
                 }
             }
             return newClass || newDispatchClass;
@@ -157,16 +157,23 @@ public class RemoveGarbage {
     private static Used collectUsed(ImProg prog, ImTranslator translator,
                                     Set<ImSet> ignoredInitializers) {
         Used used = new Used(translator, ignoredInitializers);
-        ImFunction[] programFunctions = ImHelper.calculateFunctionsOfProg(prog).toArray(new ImFunction[0]);
-        for (int i = 0; i < programFunctions.length; i++) {
-            ImFunction f = programFunctions[i];
+        visitRootFunctions(prog.getFunctions(), used);
+        List<ImClass> classes = prog.getClasses();
+        for (int i = 0; i < classes.size(); i++) {
+            visitRootFunctions(classes.get(i).getFunctions(), used);
+        }
+        return used;
+    }
+
+    private static void visitRootFunctions(List<ImFunction> functions, Used used) {
+        for (int i = 0; i < functions.size(); i++) {
+            ImFunction f = functions.get(i);
             if (f.getName().equals("main")
                 || f.getName().equals("config")
                 || NamePreservation.isPreserved(f)) {
                 visitFunction(f, used);
             }
         }
-        return used;
     }
 
     public static void removePhantomGenericStaticInitializers(ImProg prog, ImTranslator translator) {
@@ -192,20 +199,17 @@ public class RemoveGarbage {
         boolean changed;
         do {
             Set<ImSet> ignored = Collections.newSetFromMap(new IdentityHashMap<>());
-            Object[] candidateEntries = candidates.entrySet().toArray();
-            for (int i = 0; i < candidateEntries.length; i++) {
-                @SuppressWarnings("unchecked")
-                Map.Entry<ImVar, List<ImSet>> candidate
-                    = (Map.Entry<ImVar, List<ImSet>>) candidateEntries[i];
+            for (Map.Entry<ImVar, List<ImSet>> candidate : candidates.entrySet()) {
                 if (!liveOriginals.contains(candidate.getKey())) {
-                    ignored.addAll(candidate.getValue());
+                    List<ImSet> initializers = candidate.getValue();
+                    for (int i = 0; i < initializers.size(); i++) {
+                        ignored.add(initializers.get(i));
+                    }
                 }
             }
             Used used = collectUsed(prog, translator, ignored);
             changed = false;
-            Object[] candidateKeys = candidates.keySet().toArray();
-            for (int i = 0; i < candidateKeys.length; i++) {
-                ImVar original = (ImVar) candidateKeys[i];
+            for (ImVar original : candidates.keySet()) {
                 ImClass owner = translator.genericStaticOwnerOf(original);
                 boolean erasedInstantiationNeedsOriginal = used.getInstantiatedClasses().contains(owner)
                     && translator.hasErasedAllocationWithoutStaticSpecialization(owner, original);
@@ -216,11 +220,7 @@ public class RemoveGarbage {
             }
         } while (changed);
 
-        Object[] finalCandidateEntries = candidates.entrySet().toArray();
-        for (int i = 0; i < finalCandidateEntries.length; i++) {
-            @SuppressWarnings("unchecked")
-            Map.Entry<ImVar, List<ImSet>> candidate
-                = (Map.Entry<ImVar, List<ImSet>>) finalCandidateEntries[i];
+        for (Map.Entry<ImVar, List<ImSet>> candidate : candidates.entrySet()) {
             if (liveOriginals.contains(candidate.getKey())) {
                 continue;
             }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/RemoveGarbage.java
@@ -157,9 +157,9 @@ public class RemoveGarbage {
     private static Used collectUsed(ImProg prog, ImTranslator translator,
                                     Set<ImSet> ignoredInitializers) {
         Used used = new Used(translator, ignoredInitializers);
-        List<ImFunction> programFunctions = ImHelper.calculateFunctionsOfProg(prog);
-        for (int i = 0; i < programFunctions.size(); i++) {
-            ImFunction f = programFunctions.get(i);
+        ImFunction[] programFunctions = ImHelper.calculateFunctionsOfProg(prog).toArray(new ImFunction[0]);
+        for (int i = 0; i < programFunctions.length; i++) {
+            ImFunction f = programFunctions[i];
             if (f.getName().equals("main")
                 || f.getName().equals("config")
                 || NamePreservation.isPreserved(f)) {


### PR DESCRIPTION
## Summary

- bump `abstractsyntaxgen` from `623da1c60f` to `2b3d742e8a` on both the compiler and AST-generation classpaths
- replace allocation-producing iterator, stream, lambda, and collection-copy traversals with indexed access across frequently repeated IM passes
- avoid materializing combined function collections when flattening, merging locals, analyzing local-player context, and tracing Lua reachability
- preserve the required iterator for the `HashMultimap` removal view, where indexed traversal is not available and taking a snapshot would allocate more

## Affected compiler paths

- IM flattening and helper traversal
- local-variable liveness and merging
- local-player dependency analysis
- Lua dispatch preparation
- Lua garbage collection and generic-static initializer cleanup

## Motivation

These passes repeatedly traverse generated AST/IM list types across the whole program. Using their indexed access directly removes avoidable transient iterators, streams, snapshots, and aggregate sets without changing traversal order or compiler semantics.

## Validation

- Gradle build and test CI passed
- published test results passed
- Codex reviewed head `51456777b3` and reported no major issues

No source-language or backend behavior change is intended.
