### PR TITLE
Deduplicate Lua callback adapters

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
@@ -53,42 +53,7 @@ public class ExprTranslation {
     }
 
     public static LuaExpr translate(ImFuncRef e, LuaTranslator tr) {
-//        return LuaAst.LuaExprFuncRef(tr.luaFunc.getFor(e.getFunc()));
-//         alternative: use xpcall to get stacktraces (did not work)
-        boolean returnsValue = !(e.getFunc().getReturnType() instanceof ImVoid);
-        LuaVariable dots = LuaAst.LuaVariable("...", LuaAst.LuaNoExpr());
-        LuaStatements callbackBody = LuaAst.LuaStatements();
-        if (returnsValue) {
-            LuaVariable tempRes = LuaAst.LuaVariable("tempRes", LuaAst.LuaExprNull());
-            callbackBody.add(tempRes);
-            callbackBody.add(LuaAst.LuaExprFunctionCallByName("xpcall",
-                LuaAst.LuaExprlist(
-                    LuaAst.LuaExprFunctionAbstraction(
-                        LuaAst.LuaParams(dots.copy()),
-                        LuaAst.LuaStatements(
-                            LuaAst.LuaAssignment(LuaAst.LuaExprVarAccess(tempRes),
-                                LuaAst.LuaExprFunctionCall(tr.luaFunc.getFor(e.getFunc()), LuaAst.LuaExprlist(LuaAst.LuaExprVarAccess(dots.copy())))))
-                    ),
-                    LuaAst.LuaLiteral("function(err) if err == \"" + WURST_ABORT_THREAD_SENTINEL + "\" then return end BJDebugMsg(\"lua callback error: \" .. tostring(err)) xpcall(function() " + callErrorFunc(tr, "tostring(err)", "in lua callback error handler") + " end, function(err2) if err2 == \"" + WURST_ABORT_THREAD_SENTINEL + "\" then return end BJDebugMsg(\"error reporting error: \" .. tostring(err2)) BJDebugMsg(\"while reporting: \" .. tostring(err))  end) end"),
-                    LuaAst.LuaExprVarAccess(dots.copy())
-                )
-            ));
-            callbackBody.add(LuaAst.LuaReturn(LuaAst.LuaExprVarAccess(tempRes)));
-        } else {
-            callbackBody.add(LuaAst.LuaExprFunctionCallByName("xpcall",
-                LuaAst.LuaExprlist(
-                    LuaAst.LuaExprFunctionAbstraction(
-                        LuaAst.LuaParams(dots.copy()),
-                        LuaAst.LuaStatements(
-                            LuaAst.LuaExprFunctionCall(tr.luaFunc.getFor(e.getFunc()), LuaAst.LuaExprlist(LuaAst.LuaExprVarAccess(dots.copy())))
-                        )
-                    ),
-                    LuaAst.LuaLiteral("function(err) if err == \"" + WURST_ABORT_THREAD_SENTINEL + "\" then return end BJDebugMsg(\"lua callback error: \" .. tostring(err)) xpcall(function() " + callErrorFunc(tr, "tostring(err)", "in lua callback error handler") + " end, function(err2) if err2 == \"" + WURST_ABORT_THREAD_SENTINEL + "\" then return end BJDebugMsg(\"error reporting error: \" .. tostring(err2)) BJDebugMsg(\"while reporting: \" .. tostring(err))  end) end"),
-                    LuaAst.LuaExprVarAccess(dots.copy())
-                )
-            ));
-        }
-        return LuaAst.LuaExprFunctionAbstraction(LuaAst.LuaParams(dots), callbackBody);
+        return LuaAst.LuaExprFuncRef(tr.callbackAdapterFor(e.getFunc()));
     }
 
     static String callErrorFunc(LuaTranslator tr, String msg) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -406,14 +406,23 @@ public class LuaTranslator {
         callbackAdapters.put(target, adapter);
 
         LuaFunction errorHandler = callbackErrorHandler();
-        String xpcall = "xpcall(" + targetLua.getName() + ", " + errorHandler.getName() + ", ...)";
+        LuaExprFunctionCallByName xpcall = LuaAst.LuaExprFunctionCallByName("xpcall",
+            LuaAst.LuaExprlist(
+                LuaAst.LuaExprFuncRef(targetLua),
+                LuaAst.LuaExprFuncRef(errorHandler),
+                LuaAst.LuaExprVarAccess(dots.copy())));
         if (target.getReturnType() instanceof ImVoid) {
-            adapter.getBody().add(LuaAst.LuaLiteral(xpcall));
+            adapter.getBody().add(xpcall);
         } else {
             // Keep exactly the first callback result. Returning select(2, xpcall(...)) directly
             // could leak additional Lua return values into a surrounding argument list.
-            adapter.getBody().add(LuaAst.LuaLiteral("local _, result = " + xpcall));
-            adapter.getBody().add(LuaAst.LuaLiteral("return result"));
+            LuaVariable ignored = LuaAst.LuaVariable("_", LuaAst.LuaNoExpr());
+            LuaVariable result = LuaAst.LuaVariable("result", LuaAst.LuaNoExpr());
+            adapter.getBody().add(ignored);
+            adapter.getBody().add(result);
+            adapter.getBody().add(LuaAst.LuaAssignment(
+                LuaAst.LuaLiteral("_, result"), xpcall));
+            adapter.getBody().add(LuaAst.LuaReturn(LuaAst.LuaExprVarAccess(result)));
         }
         luaModel.add(adapter);
         return adapter;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -137,6 +137,8 @@ public class LuaTranslator {
 
     List<ExprTranslation.TupleFunc> tupleEqualsFuncs = new ArrayList<>();
     List<ExprTranslation.TupleFunc> tupleCopyFuncs = new ArrayList<>();
+    private final Map<ImFunction, LuaFunction> callbackAdapters = new IdentityHashMap<>();
+    private LuaFunction callbackErrorHandler;
 
     // Array-default infrastructure (metatables/helper functions) shared across
     // every array of a given entry type, instead of allocated per array
@@ -383,6 +385,59 @@ public class LuaTranslator {
         enforceLuaLocalLimits();
 
         return luaModel;
+    }
+
+    /**
+     * Function references need an xpcall boundary, but the boundary is a property of the referenced
+     * function rather than of each expression which names it. Emit one reusable adapter per target
+     * so evaluating a function reference performs no closure allocation.
+     */
+    LuaFunction callbackAdapterFor(ImFunction target) {
+        LuaFunction existing = callbackAdapters.get(target);
+        if (existing != null) {
+            return existing;
+        }
+
+        LuaFunction targetLua = luaFunc.getFor(target);
+        LuaVariable dots = LuaAst.LuaVariable("...", LuaAst.LuaNoExpr());
+        LuaFunction adapter = LuaAst.LuaFunction(
+            uniqueName("__wurst_callback_" + targetLua.getName()),
+            LuaAst.LuaParams(dots), LuaAst.LuaStatements());
+        callbackAdapters.put(target, adapter);
+
+        LuaFunction errorHandler = callbackErrorHandler();
+        String xpcall = "xpcall(" + targetLua.getName() + ", " + errorHandler.getName() + ", ...)";
+        if (target.getReturnType() instanceof ImVoid) {
+            adapter.getBody().add(LuaAst.LuaLiteral(xpcall));
+        } else {
+            // Keep exactly the first callback result. Returning select(2, xpcall(...)) directly
+            // could leak additional Lua return values into a surrounding argument list.
+            adapter.getBody().add(LuaAst.LuaLiteral("local _, result = " + xpcall));
+            adapter.getBody().add(LuaAst.LuaLiteral("return result"));
+        }
+        luaModel.add(adapter);
+        return adapter;
+    }
+
+    private LuaFunction callbackErrorHandler() {
+        if (callbackErrorHandler != null) {
+            return callbackErrorHandler;
+        }
+        LuaVariable err = LuaAst.LuaVariable("err", LuaAst.LuaNoExpr());
+        callbackErrorHandler = LuaAst.LuaFunction(uniqueName("__wurst_callback_error"),
+            LuaAst.LuaParams(err), LuaAst.LuaStatements());
+        callbackErrorHandler.getBody().add(LuaAst.LuaLiteral(
+            "if err == \"" + ExprTranslation.WURST_ABORT_THREAD_SENTINEL + "\" then return end"));
+        callbackErrorHandler.getBody().add(LuaAst.LuaLiteral(
+            "BJDebugMsg(\"lua callback error: \" .. tostring(err))"));
+        callbackErrorHandler.getBody().add(LuaAst.LuaLiteral(
+            "xpcall(function() " + ExprTranslation.callErrorFunc(this, "tostring(err)",
+                "in lua callback error handler")
+                + " end, function(err2) if err2 == \"" + ExprTranslation.WURST_ABORT_THREAD_SENTINEL
+                + "\" then return end BJDebugMsg(\"error reporting error: \" .. tostring(err2))"
+                + " BJDebugMsg(\"while reporting: \" .. tostring(err)) end)"));
+        luaModel.add(callbackErrorHandler);
+        return callbackErrorHandler;
     }
 
     /**

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -128,6 +128,15 @@ public class LuaTranslationTests extends WurstScriptTest {
         return result;
     }
 
+    private int countMatches(String output, String regex) {
+        Matcher matcher = Pattern.compile(regex).matcher(output);
+        int result = 0;
+        while (matcher.find()) {
+            result++;
+        }
+        return result;
+    }
+
     private String singleMatch(String output, String regex, int group) {
         Matcher matcher = Pattern.compile(regex).matcher(output);
         assertTrue("Expected pattern to occur: " + regex, matcher.find());
@@ -173,6 +182,11 @@ public class LuaTranslationTests extends WurstScriptTest {
 
     private String compileLuaWithCUs(String testName, boolean withStdLib, List<CU> extraCUs, String... lines) {
         RunArgs runArgs = new RunArgs().with("-lua", "-inline", "-localOptimizations", "-stacktraces");
+        return compileLuaWithCUs(testName, withStdLib, extraCUs, runArgs, lines);
+    }
+
+    private String compileLuaWithCUs(String testName, boolean withStdLib, List<CU> extraCUs,
+                                     RunArgs runArgs, String... lines) {
         WurstGui gui = new WurstGuiCliImpl();
         WurstCompilerJassImpl compiler = new WurstCompilerJassImpl(null, gui, null, runArgs);
         List<CU> inputs = new ArrayList<>();
@@ -2475,10 +2489,43 @@ public class LuaTranslationTests extends WurstScriptTest {
             "    ForForce(f, () -> skip)"
         );
         String compiled = Files.toString(new File("test-output/lua/LuaTranslationTests_luaFunctionRefWrapperForwardsVarargs.lua"), Charsets.UTF_8);
-        assertTrue(compiled.contains("xpcall(function (...)"));
+        assertContainsRegex(compiled, "function\\s+__wurst_callback_[A-Za-z0-9_]+\\(\\.\\.\\.\\)");
+        assertFalse(compiled.contains("xpcall(function (...)"));
+        assertContainsRegex(compiled,
+            "xpcall\\([A-Za-z0-9_]+, __wurst_callback_error[A-Za-z0-9_]*, \\.\\.\\.\\)");
         assertTrue(compiled.contains(", ...)"));
         assertFalse(compiled.contains("local temp = ..."));
         assertFalse(compiled.contains("ForForce(f, function (...) \n\t\t\tlocal tempRes"));
+    }
+
+    @Test
+    public void luaFunctionRefsReuseOneAdapterAndPreserveSingleReturn() {
+        String compiled = compileLuaWithCUs(
+            "LuaTranslationTests_luaFunctionRefsReuseOneAdapterAndPreserveSingleReturn",
+            false,
+            Collections.emptyList(),
+            new RunArgs().with("-lua", "-inline", "-localOptimizations"),
+            "type boolexpr extends handle",
+            "package Test",
+            "@extern native Condition(code callback) returns boolexpr",
+            "function predicate() returns boolean",
+            "    return true",
+            "init",
+            "    let first = Condition(function predicate)",
+            "    let second = Condition(function predicate)"
+        );
+
+        List<String> adapters = uniqueMatches(compiled,
+            "function\\s+(__wurst_callback_predicate[A-Za-z0-9_]*)\\(\\.\\.\\.\\)", 1);
+        assertEquals("one adapter must serve every reference to the same function:\n" + compiled,
+            1, adapters.size());
+        String adapter = adapters.get(0);
+        assertEquals("both Condition calls must reference the cached adapter", 2,
+            countMatches(compiled, "Condition\\(" + Pattern.quote(adapter) + "\\)"));
+        String adapterBody = getFunctionBody(compiled, adapter);
+        assertTrue(adapterBody.contains("local _, result = xpcall(predicate,"));
+        assertTrue(adapterBody.contains("return result"));
+        assertFalse("callback sites must not allocate anonymous wrappers", compiled.contains("Condition(function ("));
     }
 
     @Test

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -2523,9 +2523,36 @@ public class LuaTranslationTests extends WurstScriptTest {
         assertEquals("both Condition calls must reference the cached adapter", 2,
             countMatches(compiled, "Condition\\(" + Pattern.quote(adapter) + "\\)"));
         String adapterBody = getFunctionBody(compiled, adapter);
-        assertTrue(adapterBody.contains("local _, result = xpcall(predicate,"));
+        assertTrue(adapterBody.contains("_, result = xpcall(predicate,"));
         assertTrue(adapterBody.contains("return result"));
         assertFalse("callback sites must not allocate anonymous wrappers", compiled.contains("Condition(function ("));
+    }
+
+    @Test
+    public void luaFunctionRefAdapterTracksLateClassFunctionRename() {
+        String compiled = compileLuaWithCUs(
+            "LuaTranslationTests_luaFunctionRefAdapterTracksLateClassFunctionRename",
+            false,
+            Collections.emptyList(),
+            new RunArgs().with("-lua"),
+            "package Test",
+            "@extern native consume(code callback)",
+            "@extern native CallbackOwner_staticCallback()",
+            "class CallbackOwner",
+            "    function start()",
+            "        consume(function staticCallback)",
+            "    private static function staticCallback()",
+            "        consume(function staticCallback)",
+            "init",
+            "    CallbackOwner_staticCallback()",
+            "    new CallbackOwner().start()"
+        );
+
+        String callbackName = singleMatch(compiled,
+            "function\\s+(CallbackOwner_[A-Za-z0-9_]*staticCallback[A-Za-z0-9_]*)\\(\\)", 1);
+        assertTrue("adapter must track the class callback's final name:\n" + compiled,
+            compiled.contains("xpcall(" + callbackName + ","));
+        assertFalse(compiled.contains("xpcall(staticCallback,"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- emit one reusable Lua callback adapter per referenced IM function
- share callback error handling instead of allocating nested wrappers on every function-reference evaluation
- preserve exactly one callback return value and retain per-call-site stack positions in stacktrace builds

## Verification

- `./gradlew.bat test --tests tests.wurstscript.tests.LuaTranslationTests --tests tests.wurstscript.tests.LuaBackendAuditTests --tests tests.wurstscript.tests.OptimizerTests`
- `./gradlew.bat test`
- `git diff --check`

Targets `big-lua-opt-update` as the final high-priority Lua hot-path follow-up.
