### PR TITLE
Fix dangling Lua enum helper calls

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaNatives.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaNatives.java
@@ -179,7 +179,7 @@ public class LuaNatives {
             f.getBody().add(LuaAst.LuaLiteral("local prev = __wurst_enumPlayer_override"));
             f.getBody().add(LuaAst.LuaLiteral("ForForce(whichForce, function()"));
             f.getBody().add(LuaAst.LuaLiteral("    count = count + 1"));
-            f.getBody().add(LuaAst.LuaLiteral("    players[count] = __wurst_GetEnumPlayer()"));
+            f.getBody().add(LuaAst.LuaLiteral("    players[count] = GetEnumPlayer()"));
             f.getBody().add(LuaAst.LuaLiteral("end)"));
             f.getBody().add(LuaAst.LuaLiteral("for i = 1, count do"));
             f.getBody().add(LuaAst.LuaLiteral("    __wurst_enumPlayer_override = players[i]"));
@@ -206,7 +206,7 @@ public class LuaNatives {
             f.getBody().add(LuaAst.LuaLiteral("local prev = __wurst_enumUnit_override"));
             f.getBody().add(LuaAst.LuaLiteral("ForGroup(whichGroup, function()"));
             f.getBody().add(LuaAst.LuaLiteral("    count = count + 1"));
-            f.getBody().add(LuaAst.LuaLiteral("    units[count] = __wurst_GetEnumUnit()"));
+            f.getBody().add(LuaAst.LuaLiteral("    units[count] = GetEnumUnit()"));
             f.getBody().add(LuaAst.LuaLiteral("end)"));
             f.getBody().add(LuaAst.LuaLiteral("for i = 1, count do"));
             f.getBody().add(LuaAst.LuaLiteral("    __wurst_enumUnit_override = units[i]"));
@@ -234,7 +234,7 @@ public class LuaNatives {
             f.getBody().add(LuaAst.LuaLiteral("local prev = __wurst_enumItem_override"));
             f.getBody().add(LuaAst.LuaLiteral("EnumItemsInRect(r, filter, function()"));
             f.getBody().add(LuaAst.LuaLiteral("    count = count + 1"));
-            f.getBody().add(LuaAst.LuaLiteral("    items[count] = __wurst_GetEnumItem()"));
+            f.getBody().add(LuaAst.LuaLiteral("    items[count] = GetEnumItem()"));
             f.getBody().add(LuaAst.LuaLiteral("end)"));
             f.getBody().add(LuaAst.LuaLiteral("for i = 1, count do"));
             f.getBody().add(LuaAst.LuaLiteral("    __wurst_enumItem_override = items[i]"));
@@ -262,7 +262,7 @@ public class LuaNatives {
             f.getBody().add(LuaAst.LuaLiteral("local prev = __wurst_enumDestructable_override"));
             f.getBody().add(LuaAst.LuaLiteral("EnumDestructablesInRect(r, filter, function()"));
             f.getBody().add(LuaAst.LuaLiteral("    count = count + 1"));
-            f.getBody().add(LuaAst.LuaLiteral("    dests[count] = __wurst_GetEnumDestructable()"));
+            f.getBody().add(LuaAst.LuaLiteral("    dests[count] = GetEnumDestructable()"));
             f.getBody().add(LuaAst.LuaLiteral("end)"));
             f.getBody().add(LuaAst.LuaLiteral("for i = 1, count do"));
             f.getBody().add(LuaAst.LuaLiteral("    __wurst_enumDestructable_override = dests[i]"));

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaTranslationTests.java
@@ -2763,6 +2763,20 @@ public class LuaTranslationTests extends WurstScriptTest {
     }
 
     @Test
+    public void forForceCollectorUsesNativeEnumAccessorInLua() throws IOException {
+        test().testLua(true).withStdLib().lines(
+            "package Test",
+            "init",
+            "    let f = CreateForce()",
+            "    ForForce(f, () -> skip)"
+        );
+        String compiled = Files.toString(new File("test-output/lua/LuaTranslationTests_forForceCollectorUsesNativeEnumAccessorInLua.lua"), Charsets.UTF_8);
+        assertTrue(compiled.contains("players[count] = GetEnumPlayer()"));
+        assertFalse(compiled.contains("players[count] = __wurst_GetEnumPlayer()"));
+        assertFalse(compiled.contains("function __wurst_GetEnumPlayer("));
+    }
+
+    @Test
     public void luaFunctionRefsReuseOneAdapterAndPreserveSingleReturn() {
         String compiled = compileLuaWithCUs(
             "LuaTranslationTests_luaFunctionRefsReuseOneAdapterAndPreserveSingleReturn",
@@ -2951,6 +2965,12 @@ public class LuaTranslationTests extends WurstScriptTest {
         assertContainsRegex(compiled, "\\bfunction\\s+__wurst_ForGroup\\s*\\(");
         assertContainsRegex(compiled, "\\bfunction\\s+__wurst_EnumItemsInRect\\s*\\(");
         assertContainsRegex(compiled, "\\bfunction\\s+__wurst_EnumDestructablesInRect\\s*\\(");
+        assertTrue(compiled.contains("units[count] = GetEnumUnit()"));
+        assertTrue(compiled.contains("items[count] = GetEnumItem()"));
+        assertTrue(compiled.contains("dests[count] = GetEnumDestructable()"));
+        assertFalse(compiled.contains("units[count] = __wurst_GetEnumUnit()"));
+        assertFalse(compiled.contains("items[count] = __wurst_GetEnumItem()"));
+        assertFalse(compiled.contains("dests[count] = __wurst_GetEnumDestructable()"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- use WC3's native enum accessors while Lua context collectors are executing inside native callbacks
- avoid dangling references to separately garbage-collected `__wurst_GetEnum*` helpers
- cover force, group, item, and destructable collector output

## Acceptance criteria

- `ForForce` works when user code does not otherwise reference `GetEnumPlayer`
- generated context collectors contain no hidden dependency on separately emitted helper functions
- override-aware helpers remain available for replayed callbacks that call `GetEnum*`

## Checks

- focused Lua callback-helper regression set: passed
- `LuaTranslationTests`: passed
- full `test` suite: passed (completed before the request to leave the full suite to CI)
- `git diff --check`: passed

## Known gaps

- no Warcraft III client run; generated Lua and Lua runtime tests cover this compiler-emission defect
