### PR TITLE
Match fuzz budgets to generator shapes and assert real invariants

### DIFF
--- a/de.peeeq.wurstscript/build.gradle
+++ b/de.peeeq.wurstscript/build.gradle
@@ -13,6 +13,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'jacoco'
+    id 'net.ltgt.errorprone' version '5.1.1'
     id 'maven-publish'
     id 'com.gradleup.shadow' version '9.2.2'
     id 'de.undercouch.download' version '5.6.0'
@@ -41,7 +42,43 @@ tasks.withType(JavaExec).configureEach {
     jvmArgs('-XX:+UnlockExperimentalVMOptions', '-XX:+UseCompactObjectHeaders')
 }
 
-tasks.withType(JavaCompile).configureEach { options.release = 25 }
+/** -------- Compilation and static analysis --------
+ * Both javac lint and Error Prone are ADVISORY: they report at warning severity and
+ * never fail the build. Unit tests and coverage remain the primary quality gate; this
+ * is a supplementary signal, not a merge blocker.
+ * Skip Error Prone entirely with: ./gradlew <task> -PskipErrorProne
+ */
+def errorProneEnabled = !project.hasProperty('skipErrorProne')
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 25
+    // 'serial'/'this-escape' are noisy against this codebase's AST and visitor style.
+    // 'auxiliaryclass' fires ~86 times purely on the multi-class-per-file layout - structural, not a defect.
+    options.compilerArgs += ['-Xlint:all', '-Xlint:-serial', '-Xlint:-this-escape',
+                             '-Xlint:-processing', '-Xlint:-auxiliaryclass']
+    // javac silently caps reporting at 100 warnings. Without this, lint noise exhausts the
+    // budget and every Error Prone finding is dropped as overflow - the analysis looks clean
+    // while reporting nothing. Do not remove.
+    options.compilerArgs += ['-Xmaxwarns', '10000']
+
+    options.errorprone {
+        enabled = errorProneEnabled
+        // src-gen holds ~700 generated AST classes - analysing them is pure noise.
+        excludedPaths = '.*src-gen.*'
+        disableWarningsInGeneratedCode = true
+        // Advisory only: demote every check to a warning so the build never fails on it.
+        // Requires the -Xmaxwarns bump above to actually be visible.
+        allErrorsAsWarnings = true
+        // Upstream bug: NonCanonicalType NPEs in SuggestedFixes.qualifyType on anonymous
+        // subclasses of nested types, which this codebase's visitors use everywhere
+        // (e.g. `new LuaModel.DefaultVisitor() {}`). A plugin crash is a hard javac error,
+        // so allErrorsAsWarnings cannot absorb it. Purely stylistic check; safe to drop.
+        disable('NonCanonicalType')
+    }
+}
+
+// Keep the test compile loop fast - tests are the primary gate, not the audit target.
+tasks.named('compileTestJava') { options.errorprone.enabled = false }
 
 jacoco {
     toolVersion = "0.8.13"
@@ -90,6 +127,8 @@ configurations {
 }
 
 dependencies {
+    errorprone 'com.google.errorprone:error_prone_core:2.50.0'
+
     implementation 'org.jetbrains:annotations:23.0.0'
 
     // Antlr

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/CompiletimeFunctionRunner.java
@@ -120,7 +120,7 @@ public class CompiletimeFunctionRunner implements AutoCloseable {
             collectCompiletimeFunctions(toExecute);
             long tCollected = System.nanoTime();
 
-            toExecute.sort(Comparator.comparing(this::getOrderIndex));
+            toExecute.sort(Comparator.comparingInt(this::getOrderIndex));
             long tSorted = System.nanoTime();
 
             execute(toExecute);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrExprType.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrExprType.java
@@ -74,7 +74,12 @@ public class AttrExprType {
             return WurstTypeUnknown.instance();
         }
         if (!(varDef instanceof OtherLink) && varDef.getDef() instanceof VarDef) {
-            if (Utils.getParentVarDef(Optional.of(term)) == Optional.of((VarDef) varDef.getDef())) {
+            // Compare the enclosing VarDef to the one this access resolves to. Both sides used
+            // to be wrapped in fresh Optionals and compared with ==, which is never true, so
+            // this check silently did nothing. getParentVarDef returns null (not empty) when
+            // there is no enclosing VarDef, hence the explicit null guard.
+            Optional<VarDef> enclosingVarDef = Utils.getParentVarDef(Optional.of(term));
+            if (enclosingVarDef != null && enclosingVarDef.orElse(null) == varDef.getDef()) {
                 term.addError("Recursive variable definition is not allowed.");
                 return WurstTypeUnknown.instance();
             }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrFuncDef.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/AttrFuncDef.java
@@ -197,9 +197,8 @@ public class AttrFuncDef {
         var raw = NameResolution.lookupMemberFuncs(node, recvT, node.getFuncName(), /*showErrors=*/false);
 
         java.util.ArrayList<FuncLink> visible = new java.util.ArrayList<>(raw.size());
-        java.util.ArrayList<FuncLink> hidden  = new java.util.ArrayList<>(raw.size());
         for (var f : raw) {
-            if (isVisible(f)) visible.add(f); else hidden.add(f);
+            if (isVisible(f)) visible.add(f);
         }
 
         if (!raw.isEmpty() && visible.isEmpty()) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/OverloadingResolver.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/OverloadingResolver.java
@@ -5,7 +5,6 @@ import de.peeeq.wurstscript.ast.*;
 import de.peeeq.wurstscript.types.WurstType;
 import de.peeeq.wurstscript.types.WurstTypeTypeParam;
 import de.peeeq.wurstscript.types.WurstTypeVararg;
-import de.peeeq.wurstscript.utils.NotNullList;
 import de.peeeq.wurstscript.utils.Utils;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -53,8 +52,6 @@ public abstract class OverloadingResolver<F extends Element, C> {
         if (size == 1) {
             return Optional.of(Utils.getFirst(alternativeFunctions));
         }
-        List<String> hints = new NotNullList<>();
-
         Map<F, Integer> numMatches = new HashMap<>();
         for (F f : alternativeFunctions) {
             if (!hasValidParameterCount(f, caller)) {
@@ -68,8 +65,6 @@ public abstract class OverloadingResolver<F extends Element, C> {
                         && expectedParamType instanceof WurstTypeTypeParam) {
                     // should be ok!
                 } else if (!getArgumentType(caller, i).isSubtypeOf(expectedParamType, f)) {
-                    hints.add("Expected " + expectedParamType
-                            + " as parameter " + i + " ,but found " + getArgumentType(caller, i) + ".");
                     continue;
                 }
                 matches++;

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/names/NameLinks.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/names/NameLinks.java
@@ -57,7 +57,9 @@ public class NameLinks {
 
     @NotNull
     private static Map<String, Map<FuncLink, OverrideCheckResult>> initOverrideMap(Multimap<String, DefLink> result) {
-        Map<String, Map<FuncLink, OverrideCheckResult>> overrideCheckResults = new Hashtable<>();
+        // LinkedHashMap, not Hashtable: nothing here is concurrent, and reportOverrideErrors
+        // iterates this map, so insertion order beats hash order for reproducible diagnostics.
+        Map<String, Map<FuncLink, OverrideCheckResult>> overrideCheckResults = new LinkedHashMap<>();
         for (DefLink link : result.values()) {
             if (link instanceof FuncLink) {
                 Map<FuncLink, OverrideCheckResult> map = overrideCheckResults.computeIfAbsent(link.getName(),

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/prettyPrint/PrettyUtils.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/prettyPrint/PrettyUtils.java
@@ -27,8 +27,11 @@ public class PrettyUtils {
             return;
         }
         String arg = args.get(0);
-        if (args.equals("...")) {
+        // Was args.equals("...") - comparing the List to a String, which is never true, so
+        // the "..." argument silently fell through to being treated as a file name below.
+        if (arg.equals("...")) {
             prettyAll(".");
+            return;
         }
         if (arg.equals("tree") && args.size() >= 2) {
             debug(args.get(1));

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/prettyPrint/PrettyUtils.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/attributes/prettyPrint/PrettyUtils.java
@@ -22,24 +22,48 @@ public class PrettyUtils {
     /**
      * @param args
      */
-    public static void pretty(List<String> args) throws IOException {
-        if (args.size() == 0) {
-            return;
+    /**
+     * What {@link #pretty(List)} does with a given argument list.
+     *
+     * <p>Split out from the dispatch so it can be asserted directly: the alternative is running the
+     * real thing, and both the directory walk and the single-file branch print to stdout while
+     * readFile swallows its own exceptions, so neither outcome is distinguishable from the other.
+     */
+    public enum PrettyAction {
+        /** No arguments; nothing to do. */
+        NONE,
+        /** "..." - format every .wurst file below the root. */
+        ALL,
+        /** "tree <file>" - dump the parse tree. */
+        TREE,
+        /** Anything else is taken as a file name. */
+        SINGLE_FILE
+    }
+
+    public static PrettyAction selectAction(List<String> args) {
+        if (args.isEmpty()) {
+            return PrettyAction.NONE;
         }
         String arg = args.get(0);
-        // Was args.equals("...") - comparing the List to a String, which is never true, so
-        // the "..." argument silently fell through to being treated as a file name below.
+        // This used to read args.equals("..."), comparing the List itself to a String, which is
+        // never true - so "..." fell through and was treated as a file name.
         if (arg.equals("...")) {
-            prettyAll(".");
-            return;
+            return PrettyAction.ALL;
         }
         if (arg.equals("tree") && args.size() >= 2) {
-            debug(args.get(1));
-            return;
+            return PrettyAction.TREE;
         }
+        return PrettyAction.SINGLE_FILE;
+    }
 
-        String clean = pretty(new File(arg));
-        System.out.println(clean);
+    public static void pretty(List<String> args) throws IOException {
+        switch (selectAction(args)) {
+            case NONE -> {
+            }
+            case ALL -> prettyAll(".");
+            case TREE -> debug(args.get(1));
+            case SINGLE_FILE -> System.out.println(pretty(new File(args.get(0))));
+        }
     }
 
     public static String pretty(String source, String ending) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/TimerMockHandler.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/intermediatelang/interpreter/TimerMockHandler.java
@@ -10,7 +10,7 @@ import java.util.PriorityQueue;
  */
 public class TimerMockHandler {
     private float virtualTime = 0;
-    private final PriorityQueue<RunTask> nextRunnable = new PriorityQueue<>(Comparator.comparing(r -> r.time));
+    private final PriorityQueue<RunTask> nextRunnable = new PriorityQueue<>(Comparator.comparingDouble(r -> r.time));
 
     public void cancelTask(RunTask runTask) {
         nextRunnable.remove(runTask);

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImToJassTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtojass/ImToJassTranslator.java
@@ -67,8 +67,8 @@ public class ImToJassTranslator {
         List<T> sorted = new ArrayList<>(list);
         sorted.sort(Comparator.comparing(JassImElementWithName::getName)
             .thenComparing(v -> v.getTrace().attrSource().getFile())
-            .thenComparing(v -> v.getTrace().attrSource().getLine())
-            .thenComparing(v -> v.getTrace().attrSource().getStartColumn()));
+            .thenComparingInt(v -> v.getTrace().attrSource().getLine())
+            .thenComparingInt(v -> v.getTrace().attrSource().getStartColumn()));
 
         Set<String> used = new HashSet<>(sorted.size() * 2);
         Map<String, Integer> nextSuffix = new HashMap<>();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateGenerics.java
@@ -1162,9 +1162,6 @@ public class EliminateGenerics {
     }
 
     private String checkDanglingMethodRefs(String phase) {
-        IdentityHashMap<ImMethod, Boolean> inProg = new IdentityHashMap<>();
-        for (ImMethod m : prog.getMethods()) inProg.put(m, Boolean.TRUE);
-
         final int[] dangling = {0};
 
         prog.accept(new Element.DefaultVisitor() {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/LuaTranslator.java
@@ -812,12 +812,10 @@ public class LuaTranslator {
             }
 
             // translate local variables
-            List<LuaVariable> functionLocals = new ArrayList<>();
             for (ImVar local : f.getLocals()) {
                 LuaVariable luaLocal = luaVar.getFor(local);
                 luaLocal.setInitialValue(defaultValue(local.getType()));
                 lf.getBody().add(luaLocal);
-                functionLocals.add(luaLocal);
             }
 
             // translate body:

--- a/de.peeeq.wurstscript/src/test/java/tests/prettyprint/PrettyUtilsArgsTest.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/prettyprint/PrettyUtilsArgsTest.java
@@ -1,0 +1,49 @@
+package tests.prettyprint;
+
+import de.peeeq.wurstscript.attributes.prettyPrint.PrettyUtils;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Argument dispatch for the -prettyPrint CLI entry point.
+ *
+ * <p>The "..." branch used to compare the argument List itself to a String, so it was never taken
+ * and "..." was treated as a file name instead; readFile then swallowed the resulting
+ * FileNotFoundException, so the mistake produced no visible failure.
+ */
+public class PrettyUtilsArgsTest {
+
+    @Test
+    public void tripleDotSelectsDirectoryFormatting() {
+        assertEquals(PrettyUtils.PrettyAction.ALL,
+            PrettyUtils.selectAction(Collections.singletonList("...")));
+    }
+
+    @Test
+    public void aFileNameIsNotTreatedAsDirectoryFormatting() {
+        assertEquals(PrettyUtils.PrettyAction.SINGLE_FILE,
+            PrettyUtils.selectAction(Collections.singletonList("some/file.wurst")));
+    }
+
+    @Test
+    public void treeWithAFileSelectsTreeDump() {
+        assertEquals(PrettyUtils.PrettyAction.TREE,
+            PrettyUtils.selectAction(Arrays.asList("tree", "some/file.wurst")));
+    }
+
+    @Test
+    public void treeWithoutAFileIsTreatedAsAFileName() {
+        assertEquals(PrettyUtils.PrettyAction.SINGLE_FILE,
+            PrettyUtils.selectAction(Collections.singletonList("tree")));
+    }
+
+    @Test
+    public void noArgumentsDoesNothing() {
+        assertEquals(PrettyUtils.PrettyAction.NONE,
+            PrettyUtils.selectAction(Collections.emptyList()));
+    }
+}

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompilerFuzzTestsSC.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompilerFuzzTestsSC.java
@@ -27,16 +27,24 @@ public class CompilerFuzzTestsSC extends WurstScriptTest {
 
     @Property(maxInvocations = 64)
     public void generatedProgramsCompileForBothBackends(@From(RandomProgram.class) Program program) {
-        assertCompilesForBothBackends(program);
+        assertCompilesForBothBackends(program, "generatedProgramsCompileForBothBackends");
     }
 
     @Test
     public void generatedCorpusCompilesForBothBackends() {
-        new RandomProgram().generate(0).forEach(this::assertCompilesForBothBackends);
+        new RandomProgram().generate(0)
+            .forEach(p -> assertCompilesForBothBackends(p, "generatedCorpusCompilesForBothBackends"));
     }
 
-    private void assertCompilesForBothBackends(Program program) {
-        CompilationResult result = test()
+    /**
+     * Both callers used to let test() name the output after this helper, so they shared one file
+     * under ./test-output/. They run in different Gradle forks - the @Test under TestNG, the
+     * @Property under SmallCheckViaJUnitCoreTestNG - so the two JVMs raced on that file and pjass
+     * intermittently parsed a spliced result, reporting word fragments as undefined types. Naming
+     * the output after the calling test keeps them apart.
+     */
+    private void assertCompilesForBothBackends(Program program, String testName) {
+        CompilationResult result = testNamed(testName)
             .setStopOnFirstError(false)
             .executeProg(false)
             .testLua(true)

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompilerFuzzTestsSC.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/CompilerFuzzTestsSC.java
@@ -8,6 +8,10 @@ import smallcheck.annotations.From;
 import smallcheck.annotations.Property;
 import smallcheck.generators.SeriesGen;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +21,18 @@ import java.util.stream.Stream;
 @RunWith(SmallCheckRunner.class)
 public class CompilerFuzzTestsSC extends WurstScriptTest {
 
-    @Property(maxInvocations = 320)
+    /**
+     * How many structurally distinct programs each generator can actually produce.
+     *
+     * <p>buildRandomSingleProgram varies its shape with six bits of the seed - indent style,
+     * tuple, interface, module, loop, callback - so there are 2^6 shapes; the rest of the seed
+     * only renames packages and changes integer literals, which reaches no new compiler path.
+     * Budgets above these counts recompile the same shapes under different names.
+     */
+    private static final int SINGLE_PROGRAM_SHAPES = 64;
+    private static final int CROSS_PACKAGE_SHAPES = 24;
+
+    @Property(maxInvocations = SINGLE_PROGRAM_SHAPES)
     public void generatedProgramsAreCrashFree(@From(RandomProgram.class) Program program) {
         CompilationResult result = runProgram(program);
 
@@ -25,7 +40,7 @@ public class CompilerFuzzTestsSC extends WurstScriptTest {
         Assert.assertNotNull(result.getGui());
     }
 
-    @Property(maxInvocations = 64)
+    @Property(maxInvocations = SINGLE_PROGRAM_SHAPES)
     public void generatedProgramsCompileForBothBackends(@From(RandomProgram.class) Program program) {
         assertCompilesForBothBackends(program, "generatedProgramsCompileForBothBackends");
     }
@@ -56,16 +71,58 @@ public class CompilerFuzzTestsSC extends WurstScriptTest {
                 + "\nsource:\n" + String.join("\n---\n", program.sources));
     }
 
-    @Property(maxInvocations = 180)
-    public void mixedNewlineStylesAreCrashFree(@From(RandomProgram.class) Program program) {
+    /**
+     * Line endings are a lexer detail: the same source written with LF and with CRLF has to emit
+     * byte-identical Jass. This previously only asserted that compiling the CRLF variant returned
+     * non-null, which no realistic bug would violate.
+     */
+    @Property(maxInvocations = SINGLE_PROGRAM_SHAPES)
+    public void newlineStyleDoesNotAffectEmittedCode(@From(RandomProgram.class) Program program) {
         String alternateNewline = "\n".equals(program.newline) ? "\r\n" : "\n";
-        CompilationResult result = runProgram(program.withNewline(alternateNewline));
 
-        Assert.assertNotNull(result);
-        Assert.assertNotNull(result.getGui());
+        String fromOriginal = compileAndReadJass(program, "newlineOriginal");
+        String fromAlternate = compileAndReadJass(program.withNewline(alternateNewline), "newlineAlternate");
+
+        Assert.assertEquals(fromAlternate, fromOriginal,
+            "line ending style changed the emitted Jass\nsource:\n" + String.join("\n---\n", program.sources));
     }
 
-    @Property(maxInvocations = 120)
+    /**
+     * The same source compiled twice in one process has to emit the same script. DeterministicChecks
+     * pins this for a few hand-written programs; this runs it across every generated shape.
+     */
+    @Property(maxInvocations = SINGLE_PROGRAM_SHAPES)
+    public void compilingTwiceEmitsIdenticalCode(@From(RandomProgram.class) Program program) {
+        String first = compileAndReadJass(program, "determinismFirst");
+        String second = compileAndReadJass(program, "determinismSecond");
+
+        Assert.assertEquals(second, first,
+            "recompiling the same source emitted different Jass\nsource:\n" + String.join("\n---\n", program.sources));
+    }
+
+    /**
+     * Compiles {@code program} and returns the unoptimised Jass it emitted. The output name is
+     * explicit so two compilations inside one property do not overwrite each other's file.
+     */
+    private String compileAndReadJass(Program program, String outputName) {
+        CompilationResult result = testNamed(outputName)
+            .setStopOnFirstError(false)
+            .executeProg(false)
+            .compilationUnits(asCompilationUnits(program));
+
+        Assert.assertTrue(result.getGui().getErrorList().isEmpty(),
+            "generated program produced compiler diagnostics: " + result.getGui().getErrorList()
+                + "\nsource:\n" + String.join("\n---\n", program.sources));
+
+        File emitted = new File(TEST_OUTPUT_PATH + getClass().getSimpleName() + "_" + outputName + "_no_opts.j");
+        try {
+            return Files.readString(emitted.toPath(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new AssertionError("could not read emitted script " + emitted, e);
+        }
+    }
+
+    @Property(maxInvocations = CROSS_PACKAGE_SHAPES)
     public void crossPackageProgramsAreCrashFree(@From(CrossPackageProgram.class) Program program) {
         CompilationResult result = runProgram(program);
 

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ScopingTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/ScopingTests.java
@@ -95,5 +95,31 @@ public class ScopingTests extends WurstScriptTest {
                 "endpackage");
     }
 
+    /**
+     * A class field whose initializer refers to itself must be rejected.
+     * Globals are caught earlier by "must be declared before it is used" and locals by
+     * flow analysis, so class fields are the only shape that reaches the check in
+     * AttrExprType.calculate(ExprVarAccess). That check compared two freshly allocated
+     * Optionals with ==, so it was unreachable and this compiled silently.
+     */
+    @Test
+    public void test_recursive_class_field_def() {
+        testAssertErrorsLines(false, "Recursive variable definition is not allowed",
+                "package test",
+                "	class C",
+                "		int x = x + 1",
+                "endpackage");
+    }
+
+    /** Guard against the check over-triggering: a field initialized from another field is fine. */
+    @Test
+    public void test_non_recursive_class_field_def_ok() {
+        testAssertOkLines(false,
+                "package test",
+                "	class C",
+                "		int a = 1",
+                "		int b = a + 1",
+                "endpackage");
+    }
 
 }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstScriptTest.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstScriptTest.java
@@ -1169,7 +1169,10 @@ public class WurstScriptTest {
         if (!pJassResult.isOk() && !pJassResult.getMessage().equals("IO Exception")) {
             throw new Error(pJassResult.getMessage() + pJassResult.getErrors());
         }
-        if (digest != null) {
+        // Only a real pass may be recorded. An "IO Exception" result is deliberately not fatal, but
+        // it means pjass never validated this script - caching it would make every later identical
+        // script skip validation too, after a failure that may well have been transient.
+        if (digest != null && pJassResult.isOk()) {
             pjassCheckedScripts.add(digest);
         }
     }

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstScriptTest.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/WurstScriptTest.java
@@ -40,6 +40,9 @@ import java.nio.file.StandardCopyOption;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.Map.Entry;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -430,6 +433,24 @@ public class WurstScriptTest {
         String name = UtilsIO.getMethodName(WurstScriptTest.class.getName());
         name = this.getClass().getSimpleName() + "_" + name;
         return new TestConfig(name);
+    }
+
+    /**
+     * Like {@link #test()} but with an explicit name for the files written under
+     * {@link #TEST_OUTPUT_PATH}.
+     *
+     * <p>{@link #test()} names those files after the first frame outside WurstScriptTest, which is
+     * the *helper* whenever a test reaches it through one of its own methods. That is deliberate -
+     * DeterministicChecks relies on one test method producing several differently named outputs -
+     * but it means two test methods sharing a helper get the same name, and therefore the same
+     * file. Gradle runs test classes in parallel forks, so when those two methods live in
+     * different suites the JVMs race on one .j file and pjass parses a spliced result.
+     *
+     * <p>Pass an explicit name in that situation. {@code name} is prefixed with the test class,
+     * exactly as {@link #test()} does.
+     */
+    public TestConfig testNamed(String name) {
+        return new TestConfig(this.getClass().getSimpleName() + "_" + name);
     }
 
     void testAssertOk(boolean excuteProg, boolean withStdLib, CU... units) {
@@ -1122,11 +1143,44 @@ public class WurstScriptTest {
     }
 
 
+    /**
+     * Scripts already checked by pjass in this JVM, by content hash.
+     *
+     * <p>pjass parses every file it is given as one program, so independent test scripts cannot be
+     * batched into a single invocation - each one costs a process spawn plus a re-parse of
+     * common.j and blizzard.j (~15k lines). About a third of the scripts this suite emits are
+     * byte-identical to one already checked (the same source compiled under several optimisation
+     * levels, and near-identical fixtures within a test class), and pjass is a pure function of its
+     * input, so checking those again cannot tell us anything new. Spawning is the dominant cost on
+     * Windows, where CreateProcess is an order of magnitude dearer than fork/exec.
+     *
+     * <p>Only successes are recorded: a failure re-runs so the reported message names the file the
+     * caller actually passed.
+     */
+    private static final Set<String> pjassCheckedScripts = ConcurrentHashMap.newKeySet();
+
     private void runPjass(File outputFile) throws Error {
+        String digest = scriptDigest(outputFile);
+        if (digest != null && pjassCheckedScripts.contains(digest)) {
+            return;
+        }
         Result pJassResult = Pjass.runPjass(outputFile);
         WLogger.info(pJassResult.getMessage());
         if (!pJassResult.isOk() && !pJassResult.getMessage().equals("IO Exception")) {
             throw new Error(pJassResult.getMessage() + pJassResult.getErrors());
+        }
+        if (digest != null) {
+            pjassCheckedScripts.add(digest);
+        }
+    }
+
+    /** Content hash of a generated script, or null if it cannot be read - in which case pjass runs. */
+    private static String scriptDigest(File file) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(md.digest(java.nio.file.Files.readAllBytes(file.toPath())));
+        } catch (IOException | NoSuchAlgorithmException e) {
+            return null;
         }
     }
 


### PR DESCRIPTION
The compiler fuzz generator varies program structure with six bits of the seed (indent style, tuple, interface, module, loop, callback), giving 64 distinct shapes for single programs and 24 for cross-package ones; the rest of the seed only renames packages and changes integer literals, which reaches no new compiler path. The invocation budgets were 320/180/120 against those counts, so most invocations recompiled shapes already covered, and three of the four properties asserted only that the result was non-null.

Budgets now derive from named constants tied to what each generator can actually produce, and the weakest property is replaced by two that assert real invariants:

- `newlineStyleDoesNotAffectEmittedCode` - the same source written with LF and CRLF must emit byte-identical Jass (was: compiling the CRLF variant returns non-null).
- `compilingTwiceEmitsIdenticalCode` - recompiling the same source in one process must emit byte-identical Jass, across every generated shape rather than the handful `DeterministicChecks` pins.

Compilations drop from 684 to 408. `SmallCheckViaJUnitCoreTestNG` falls from 360.4s to 42.0s in isolation and 129.8s under full parallel load, and is no longer the suite's slowest class.

Checks: full suite green locally, 1941 tests, 0 failures, 6m34s (was 7m17s on the base branch).

Stacked on #1294 - `compileAndReadJass` uses `testNamed`, which is added there. Retarget to master once that merges.
