### PR TITLE
Inline monomorphic methods in optimized Lua

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
@@ -905,13 +905,6 @@ public class WurstCompilerJassImpl implements WurstCompiler {
         imTranslator.assertProperties();
         timeTaker.endPhase();
 
-        // Expose calls which cannot dispatch anywhere else to the ordinary function inliner.
-        // The Lua emitter already applies this exact direct-call rule when optimization is off.
-        beginPhase(4, "lower monomorphic Lua method calls");
-        LuaMethodCallLowering.transform(imProg);
-        imTranslator.assertProperties();
-        timeTaker.endPhase();
-
         ImTranslator imTranslator2 = getImTranslator();
         ImOptimizer optimizer = new ImOptimizer(timeTaker, imTranslator2);
 
@@ -924,6 +917,13 @@ public class WurstCompilerJassImpl implements WurstCompiler {
         // inliner
         stage = 5;
         if (runArgs.isInline()) {
+            // Expose hot loop calls which cannot dispatch anywhere else to the ordinary inliner.
+            // Calls outside loops keep their established method/slot representation.
+            beginPhase(5, "lower monomorphic Lua method calls");
+            LuaMethodCallLowering.transform(imProg);
+            imTranslator.assertProperties();
+            timeTaker.endPhase();
+
             beginPhase(5, "inlining");
             optimizer.doInlining();
             imTranslator2.assertProperties();

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstio/WurstCompilerJassImpl.java
@@ -905,6 +905,13 @@ public class WurstCompilerJassImpl implements WurstCompiler {
         imTranslator.assertProperties();
         timeTaker.endPhase();
 
+        // Expose calls which cannot dispatch anywhere else to the ordinary function inliner.
+        // The Lua emitter already applies this exact direct-call rule when optimization is off.
+        beginPhase(4, "lower monomorphic Lua method calls");
+        LuaMethodCallLowering.transform(imProg);
+        imTranslator.assertProperties();
+        timeTaker.endPhase();
+
         ImTranslator imTranslator2 = getImTranslator();
         ImOptimizer optimizer = new ImOptimizer(timeTaker, imTranslator2);
 

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/LuaMethodCallLowering.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/LuaMethodCallLowering.java
@@ -6,11 +6,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Lowers method calls with exactly one possible implementation to ordinary function calls on Lua.
+ * Lowers loop-local method calls with exactly one possible implementation to ordinary function
+ * calls on Lua.
  *
  * <p>The Lua emitter has always used the same direct-call fast path. Performing the lowering before
- * optimization exposes these calls to the ordinary inliner without guessing about receiver types or
- * generated method names. Calls which can participate in virtual dispatch remain untouched.
+ * optimization exposes hot calls to the ordinary inliner without guessing about receiver types or
+ * generated method names. Calls outside loops, and calls which can participate in virtual dispatch,
+ * remain untouched to avoid broad code-shape churn for a speculative gain.
  */
 public final class LuaMethodCallLowering {
 
@@ -23,7 +25,7 @@ public final class LuaMethodCallLowering {
             @Override
             public void visit(ImMethodCall call) {
                 super.visit(call);
-                if (canLowerDirectly(call.getMethod())) {
+                if (isInsideLoop(call) && canLowerDirectly(call.getMethod())) {
                     calls.add(call);
                 }
             }
@@ -33,6 +35,17 @@ public final class LuaMethodCallLowering {
             lower(call);
         }
         return calls.size();
+    }
+
+    private static boolean isInsideLoop(ImMethodCall call) {
+        Element owner = call.getParent();
+        while (owner != null && !(owner instanceof ImFunction)) {
+            if (owner instanceof ImLoop || owner instanceof ImVarargLoop) {
+                return true;
+            }
+            owner = owner.getParent();
+        }
+        return false;
     }
 
     public static boolean canLowerDirectly(ImMethod method) {

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/LuaMethodCallLowering.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/LuaMethodCallLowering.java
@@ -1,0 +1,54 @@
+package de.peeeq.wurstscript.translation.imtranslation;
+
+import de.peeeq.wurstscript.jassIm.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Lowers method calls with exactly one possible implementation to ordinary function calls on Lua.
+ *
+ * <p>The Lua emitter has always used the same direct-call fast path. Performing the lowering before
+ * optimization exposes these calls to the ordinary inliner without guessing about receiver types or
+ * generated method names. Calls which can participate in virtual dispatch remain untouched.
+ */
+public final class LuaMethodCallLowering {
+
+    private LuaMethodCallLowering() {
+    }
+
+    public static int transform(ImProg prog) {
+        List<ImMethodCall> calls = new ArrayList<>();
+        prog.accept(new ImProg.DefaultVisitor() {
+            @Override
+            public void visit(ImMethodCall call) {
+                super.visit(call);
+                if (canLowerDirectly(call.getMethod())) {
+                    calls.add(call);
+                }
+            }
+        });
+
+        for (ImMethodCall call : calls) {
+            lower(call);
+        }
+        return calls.size();
+    }
+
+    public static boolean canLowerDirectly(ImMethod method) {
+        return method != null
+            && !method.getIsAbstract()
+            && method.getImplementation() != null
+            && method.getSubMethods().isEmpty();
+    }
+
+    private static void lower(ImMethodCall call) {
+        ImExpr receiver = call.getReceiver();
+        receiver.setParent(null);
+        ImExprs arguments = JassIm.ImExprs(receiver);
+        arguments.addAll(call.getArguments().removeAll());
+        call.replaceBy(JassIm.ImFunctionCall(call.getTrace(), call.getMethod().getImplementation(),
+            JassIm.ImTypeArguments(call.getTypeArguments().removeAll()), arguments,
+            call.getTuplesEliminated(), CallType.NORMAL));
+    }
+}

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/VarargEliminator.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/VarargEliminator.java
@@ -148,8 +148,8 @@ public class VarargEliminator {
             public void visit(ImMethodCall c) {
                 super.visit(c);
                 ImMethod method = c.getMethod();
-                if (method != null && !method.getIsAbstract() && method.getImplementation() != null
-                    && method.getSubMethods().isEmpty() && method.getImplementation().hasFlag(IS_VARARG)) {
+                if (LuaMethodCallLowering.canLowerDirectly(method)
+                    && method.getImplementation().hasFlag(IS_VARARG)) {
                     calls.add(c);
                 }
             }

--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/lua/translation/ExprTranslation.java
@@ -5,6 +5,7 @@ import de.peeeq.wurstscript.attributes.CompileError;
 import de.peeeq.wurstscript.jassIm.*;
 import de.peeeq.wurstscript.luaAst.*;
 import de.peeeq.wurstscript.translation.imtranslation.ImTranslator;
+import de.peeeq.wurstscript.translation.imtranslation.LuaMethodCallLowering;
 import de.peeeq.wurstscript.types.TypesHelper;
 
 import java.util.Optional;
@@ -187,9 +188,7 @@ public class ExprTranslation {
 
     public static LuaExpr translate(ImMethodCall e, LuaTranslator tr) {
         ImMethod method = e.getMethod();
-        if (!method.getIsAbstract()
-            && method.getImplementation() != null
-            && method.getSubMethods().isEmpty()) {
+        if (LuaMethodCallLowering.canLowerDirectly(method)) {
             LuaExprlist args = LuaAst.LuaExprlist();
             args.add(e.getReceiver().translateToLua(tr));
             for (ImExpr arg : e.getArguments()) {

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -2016,6 +2016,105 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             compiled.contains("arithmetic("));
     }
 
+    @Test
+    public void tinyMonomorphicMethodsInlineOnLua() {
+        String compiled = compileOptimizedLua(
+            "tinyMonomorphicMethodsInlineOnLua",
+            "package Test",
+            "native consume(int value)",
+            "class Accumulator",
+            "    int offset",
+            "    construct(int offset)",
+            "        this.offset = offset",
+            "    function add(int value) returns int",
+            "        return value + offset",
+            "abstract class Operation",
+            "    abstract function apply(int value) returns int",
+            "class DoubleOperation extends Operation",
+            "    override function apply(int value) returns int",
+            "        return value * 2",
+            "@noinline function hotLoop(Accumulator accumulator)",
+            "    var i = 0",
+            "    while i < 16",
+            "        consume(accumulator.add(i))",
+            "        i++",
+            "@noinline function dynamicCall(Operation operation)",
+            "    consume(operation.apply(3))",
+            "init",
+            "    hotLoop(new Accumulator(2))",
+            "    dynamicCall(new DoubleOperation())"
+        );
+
+        String body = topLevelFunctionBodyWithPrefix(compiled, "hotLoop");
+        assertFalse("a tiny method with exactly one implementation must inline in optimized Lua:\n" + body,
+            body.contains("Accumulator_add("));
+        assertTrue("the inlined method must retain its field read:\n" + body,
+            body.contains("Accumulator_offset_storage["));
+        String dynamicBody = topLevelFunctionBodyWithPrefix(compiled, "dynamicCall");
+        assertTrue("a genuinely virtual method call must retain dispatch:\n" + dynamicBody,
+            dynamicBody.contains("dispatch_"));
+    }
+
+    @Test
+    public void monomorphicMethodInliningEvaluatesReceiverOnce() {
+        test().testLua(true).luaOnly(false).optimize().executeProg().lines(
+            "package Test",
+            "native testSuccess()",
+            "int receiverEvaluations = 0",
+            "class Accumulator",
+            "    int offset",
+            "    construct(int offset)",
+            "        this.offset = offset",
+            "    function add(int value) returns int",
+            "        return value + offset",
+            "function makeAccumulator() returns Accumulator",
+            "    receiverEvaluations++",
+            "    return new Accumulator(2)",
+            "init",
+            "    if makeAccumulator().add(5) == 7 and receiverEvaluations == 1",
+            "        testSuccess()"
+        );
+    }
+
+    @Test
+    public void monomorphicMethodInliningKeepsCallbackBoundary() {
+        String compiled = compileOptimizedLua(
+            "monomorphicMethodInliningKeepsCallbackBoundary",
+            "package Test",
+            "native consume(code callback)",
+            "function callback()",
+            "class Registrar",
+            "    function install()",
+            "        consume(function callback)",
+            "@noinline function hotPath(Registrar registrar)",
+            "    registrar.install()",
+            "init",
+            "    hotPath(new Registrar())"
+        );
+
+        assertFunctionBodyContains(compiled, "hotPath", "Registrar_install(", true);
+    }
+
+    @Test
+    public void monomorphicMethodInliningKeepsLocalPlayerBoundary() {
+        String compiled = compileOptimizedLua(
+            "monomorphicMethodInliningKeepsLocalPlayerBoundary",
+            "type player extends handle",
+            "package Test",
+            "@extern native GetLocalPlayer() returns player",
+            "native consume(bool value)",
+            "class Probe",
+            "    function isLocal() returns bool",
+            "        return GetLocalPlayer() != null",
+            "@noinline function hotPath(Probe probe)",
+            "    consume(probe.isLocal())",
+            "init",
+            "    hotPath(new Probe())"
+        );
+
+        assertFunctionBodyContains(compiled, "hotPath", "Probe_isLocal(", true);
+    }
+
     /**
      * Measured after Lua native lowering: unit_getX = 59 IM nodes,
      * unit_getAbilityLevel = 63, real_floor = 35, and __wurst_intDiv = 31. Each helper is called
@@ -2050,14 +2149,19 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             "    query(vec2(0., 0.))"
         );
 
-        // The spatial-index helpers each have one call site, so the optimizer folds the whole
-        // query chain into our retained entry point. Inspect that surviving hot-loop owner.
+        // Register-pressure-aware inlining may keep the range helper as the hot-loop owner instead
+        // of folding it into query. Inspect whichever function actually retains the loop.
         String body = topLevelFunctionBodyWithPrefix(compiled, "query");
-        assertTrue("query loop must read the next-link array directly:\n" + body,
+        if (!body.contains("UnitSpatialIndex_nextInCell[")) {
+            assertTrue("query must call the retained range helper:\n" + body,
+                body.contains("addRangeMatches("));
+            body = topLevelFunctionBodyWithPrefix(compiled, "addRangeMatches");
+        }
+        assertTrue("spatial-index hot loop must read the next-link array directly:\n" + body,
             body.contains("UnitSpatialIndex_nextInCell["));
-        assertTrue("query loop must read cached X directly:\n" + body,
+        assertTrue("spatial-index hot loop must read cached X directly:\n" + body,
             body.contains("UnitSpatialIndex_lastX["));
-        assertTrue("query loop must read cached Y directly:\n" + body,
+        assertTrue("spatial-index hot loop must read cached Y directly:\n" + body,
             body.contains("UnitSpatialIndex_lastY["));
         assertFalse("typed array reads must not retain assurance calls:\n" + body,
             body.contains("__wurst_ensure"));

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -2070,8 +2070,15 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             "function makeAccumulator() returns Accumulator",
             "    receiverEvaluations++",
             "    return new Accumulator(2)",
+            "function evaluate() returns int",
+            "    var result = 0",
+            "    var i = 0",
+            "    while i < 1",
+            "        result = makeAccumulator().add(5)",
+            "        i++",
+            "    return result",
             "init",
-            "    if makeAccumulator().add(5) == 7 and receiverEvaluations == 1",
+            "    if evaluate() == 7 and receiverEvaluations == 1",
             "        testSuccess()"
         );
     }
@@ -2087,7 +2094,10 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             "    function install()",
             "        consume(function callback)",
             "@noinline function hotPath(Registrar registrar)",
-            "    registrar.install()",
+            "    var i = 0",
+            "    while i < 1",
+            "        registrar.install()",
+            "        i++",
             "init",
             "    hotPath(new Registrar())"
         );
@@ -2107,7 +2117,10 @@ public class LuaBackendAuditTests extends WurstScriptTest {
             "    function isLocal() returns bool",
             "        return GetLocalPlayer() != null",
             "@noinline function hotPath(Probe probe)",
-            "    consume(probe.isLocal())",
+            "    var i = 0",
+            "    while i < 1",
+            "        consume(probe.isLocal())",
+            "        i++",
             "init",
             "    hotPath(new Probe())"
         );


### PR DESCRIPTION
## Summary

- lower monomorphic method calls inside Lua hot loops to ordinary IM function calls before inlining
- reuse the backend's existing direct-call predicate in vararg lowering and final emission
- preserve callback, local-player, recursion, register-pressure, and genuine virtual-dispatch boundaries
- keep calls outside loops in their established representation to avoid broad code-shape churn

## Acceptance criteria

- tiny monomorphic methods disappear from optimized Lua hot loops
- receivers are evaluated exactly once
- callback/function-reference and local-player-sensitive methods keep their call boundaries
- abstract/overridden and virtually dispatched vararg methods retain dispatch
- the existing UnitSpatialIndex loop still emits raw table accesses without assurance, vararg-pack, or arithmetic-helper overhead

## Checks

- PASS: focused 10-test `LuaBackendAuditTests` matrix covering the new behavior, Jass/Lua receiver parity, callback and local-player barriers, fixed and dynamic varargs, virtual dispatch, and UnitSpatialIndex emitted shape
- PASS: complete `LuaTranslationTests` class (114 tests)
- PASS: GitHub Actions full Gradle build and test suite
- PASS: `git diff --check`

## Review

- Codex review completed cleanly on head `4da675e9dc` with no inline findings or unresolved threads.
