### PR TITLE
Avoid materializing unused tuple fields

### DIFF
--- a/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateTuples.java
+++ b/de.peeeq.wurstscript/src/main/java/de/peeeq/wurstscript/translation/imtranslation/EliminateTuples.java
@@ -412,6 +412,17 @@ public class EliminateTuples {
         Replacer replacer = new Replacer();
         body.accept(new Element.DefaultVisitor() {
             @Override
+            public void visit(ImTupleSelection selection) {
+                ImExpr selectedStorage = selectTupleStorageComponent(selection, translator, f);
+                if (selectedStorage != null) {
+                    replacer.replace(selection, selectedStorage);
+                    selectedStorage.accept(this);
+                    return;
+                }
+                super.visit(selection);
+            }
+
+            @Override
             public void visit(ImNull n) {
                 // Expand null<⦅T1, T2, ...⦆>  ==>  <null<T1>, null<T2>, ...>
                 ImType t = n.getType(); // or n.attrTyp() if that's the established source of truth
@@ -564,6 +575,86 @@ public class EliminateTuples {
             }
 
         });
+    }
+
+    /**
+     * Select tuple storage before expanding it. Expanding first turns one array/member read into
+     * reads of every scalar backing variable, which then have to be preserved through discard
+     * calls because those reads can fail. A source-level field read only needs the selected
+     * backing component.
+     */
+    private static @org.eclipse.jdt.annotation.Nullable ImExpr selectTupleStorageComponent(
+            ImTupleSelection selection, ImTranslator translator, ImFunction f) {
+        List<Integer> componentPath = new ArrayList<>();
+        ImExpr storage = selection;
+        while (storage instanceof ImTupleSelection current) {
+            if (current.isUsedAsLValue()) {
+                return null;
+            }
+            componentPath.add(current.getTupleIndex());
+            storage = current.getTupleExpr();
+        }
+        Collections.reverse(componentPath);
+
+        ImExpr expanded;
+        ImStmts prelude = JassIm.ImStmts();
+        if (storage instanceof ImVarAccess access && access.attrTyp() instanceof ImTupleType) {
+            VarsForTupleResult selected = selectTupleComponent(
+                translator.getVarsForTuple(access.getVar()), componentPath);
+            if (selected == null) {
+                return null;
+            }
+            expanded = selected.<ImExpr>map(
+                parts -> JassIm.ImTupleExpr(parts.collect(Collectors.toCollection(JassIm::ImExprs))),
+                JassIm::ImVarAccess);
+        } else if (storage instanceof ImVarArrayAccess access
+                && access.attrTyp() instanceof ImTupleType) {
+            ImExprs indexes = captureIndexesOnceIfNeeded(access.getIndexes(), prelude, f);
+            VarsForTupleResult selected = selectTupleComponent(
+                translator.getVarsForTuple(access.getVar()), componentPath);
+            if (selected == null) {
+                return null;
+            }
+            expanded = selected.<ImExpr>map(
+                parts -> JassIm.ImTupleExpr(parts.collect(Collectors.toCollection(JassIm::ImExprs))),
+                var -> JassIm.ImVarArrayAccess(access.getTrace(), var, indexes.copy()));
+        } else if (storage instanceof ImMemberAccess access
+                && access.attrTyp() instanceof ImTupleType) {
+            boolean indexesAreEffectful = access.getIndexes().stream()
+                .anyMatch(SideEffectAnalyzer::quickcheckHasSideeffects);
+            ImExpr receiver = captureOnceIfNeeded(access.getReceiver(), "tupleReceiver", prelude,
+                f, indexesAreEffectful);
+            ImExprs indexes = captureIndexesOnceIfNeeded(access.getIndexes(), prelude, f);
+            VarsForTupleResult selected = selectTupleComponent(
+                translator.getVarsForTuple(access.getVar()), componentPath);
+            if (selected == null) {
+                return null;
+            }
+            expanded = selected.<ImExpr>map(
+                parts -> JassIm.ImTupleExpr(parts.collect(Collectors.toCollection(JassIm::ImExprs))),
+                var -> JassIm.ImMemberAccess(access.getTrace(), receiver.copy(),
+                    access.getTypeArguments().copy(), var, indexes.copy()));
+        } else {
+            return null;
+        }
+
+        if (prelude.isEmpty()) {
+            return expanded;
+        }
+        return JassIm.ImStatementExpr(prelude, expanded);
+    }
+
+    private static @org.eclipse.jdt.annotation.Nullable VarsForTupleResult selectTupleComponent(
+            VarsForTupleResult tuple, List<Integer> componentPath) {
+        VarsForTupleResult selected = tuple;
+        for (int index : componentPath) {
+            if (!(selected instanceof ImTranslator.TupleResult tupleResult)
+                    || index < 0 || index >= tupleResult.getItems().size()) {
+                return null;
+            }
+            selected = tupleResult.getItems().get(index);
+        }
+        return selected;
     }
 
     private static ImExpr captureOnceIfNeeded(ImExpr expr, String name, ImStmts stmts, ImFunction f,

--- a/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
+++ b/de.peeeq.wurstscript/src/test/java/tests/wurstscript/tests/LuaBackendAuditTests.java
@@ -43,6 +43,16 @@ public class LuaBackendAuditTests extends WurstScriptTest {
         return Files.toString(new File("test-output/lua/LuaBackendAuditTests_" + testName + ".lua"), Charsets.UTF_8);
     }
 
+    private String luaFunctionBody(String compiled, String functionName) {
+        java.util.regex.Matcher matcher = java.util.regex.Pattern.compile(
+                "function " + java.util.regex.Pattern.quote(functionName)
+                    + "\\([^)]*\\)\\s*\\R(.*?)\\Rend",
+                java.util.regex.Pattern.DOTALL)
+            .matcher(compiled);
+        assertTrue("expected generated Lua function " + functionName, matcher.find());
+        return matcher.group(1);
+    }
+
     private String compileOptimizedLua(String testName, String... lines) {
         RunArgs runArgs = new RunArgs().with("-lua", "-inline", "-localOptimizations");
         return compileLuaWithRunArgs(testName, runArgs, false, lines);
@@ -207,6 +217,69 @@ public class LuaBackendAuditTests extends WurstScriptTest {
         assertFalse("tuple assignment must not allocate through a copy helper", compiled.contains("tupleCopy"));
         assertFalse("tuple comparison must be lowered to scalar comparisons", compiled.contains("tupleEquals"));
         assertFalse("tuple arrays must be split into scalar arrays", compiled.contains("__wurst_arrIndex("));
+    }
+
+    @Test
+    public void tupleFieldReadsOnlyLoadTheSelectedStorageComponent() throws IOException {
+        String[] source = {
+            "package Test",
+            "native testSuccess()",
+            "tuple vec3(real x, real y, real z)",
+            "tuple segment(vec3 start, vec3 finish)",
+            "vec3 array points",
+            "segment array segments",
+            "int indexCalls",
+            "@noinline function nextIndex() returns int",
+            "    indexCalls++",
+            "    return 2",
+            "@noinline function readAt(int index) returns real",
+            "    return points[index].z",
+            "@noinline function readAtNext() returns real",
+            "    return points[nextIndex()].z",
+            "@noinline function readNested(int index) returns real",
+            "    return segments[index].finish.y",
+            "class Entity",
+            "    vec3 pos",
+            "@noinline function readPos(Entity entity) returns real",
+            "    return entity.pos.z",
+            "init",
+            "    points[2] = vec3(1., 2., 3.)",
+            "    segments[2] = segment(vec3(4., 5., 6.), vec3(7., 8., 9.))",
+            "    let entity = new Entity()",
+            "    entity.pos = vec3(4., 5., 6.)",
+            "    if readAt(2) == 3. and readAtNext() == 3. and indexCalls == 1",
+            "        and readNested(2) == 8. and readPos(entity) == 6.",
+            "        testSuccess()"
+        };
+        test().testLua(true).executeProg().lines(source);
+
+        String compiled = compileOptimizedLua(
+            "tupleFieldReadsOnlyLoadTheSelectedStorageComponentOptimized", source);
+        String plainArrayRead = luaFunctionBody(compiled, "readAt");
+        String effectfulArrayRead = luaFunctionBody(compiled, "readAtNext");
+        String nestedArrayRead = luaFunctionBody(compiled, "readNested");
+        String memberRead = luaFunctionBody(compiled, "readPos");
+
+        assertTrue(plainArrayRead.contains("points_z["));
+        assertFalse(plainArrayRead.contains("points_x["));
+        assertFalse(plainArrayRead.contains("points_y["));
+        assertTrue(effectfulArrayRead.contains("points_z["));
+        assertFalse(effectfulArrayRead.contains("points_x["));
+        assertFalse(effectfulArrayRead.contains("points_y["));
+        assertEquals("a selected tuple-array field must evaluate its index exactly once",
+            1, effectfulArrayRead.split("nextIndex\\(", -1).length - 1);
+        assertTrue(nestedArrayRead.contains("segments_finish_y["));
+        assertFalse(nestedArrayRead.contains("segments_start_"));
+        assertFalse(nestedArrayRead.contains("segments_finish_x["));
+        assertFalse(nestedArrayRead.contains("segments_finish_z["));
+        assertTrue(memberRead.contains("Entity_pos_z_storage["));
+        assertFalse(memberRead.contains("Entity_pos_x_storage["));
+        assertFalse(memberRead.contains("Entity_pos_y_storage["));
+        assertFalse("selected tuple storage reads must not need discard helpers",
+            plainArrayRead.contains("__wurst_tuple_discard_")
+                || effectfulArrayRead.contains("__wurst_tuple_discard_")
+                || nestedArrayRead.contains("__wurst_tuple_discard_")
+                || memberRead.contains("__wurst_tuple_discard_"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- resolve tuple selection against scalarized storage before expanding array or member reads
- follow nested tuple component paths so only the selected scalar leaf (or selected subtree) is materialized
- preserve one-time evaluation and source order for effectful receivers and indexes
- add optimized-Lua coverage for plain, effectful, nested, and class-field tuple reads

## Verification

- `./gradlew test --tests "tests.wurstscript.tests.LuaBackendAuditTests.tuplesAreScalarizedWithoutLuaAllocations" --tests "tests.wurstscript.tests.LuaBackendAuditTests.tupleMemberArrayAssignmentCapturesIndex" --tests "tests.wurstscript.tests.LuaBackendAuditTests.tupleSelectionPreservesLeftToRightEvaluation" --tests "tests.wurstscript.tests.LuaBackendAuditTests.unreadTupleReturnSlotsAreRemoved" --tests "tests.wurstscript.tests.LuaBackendAuditTests.discardedTupleComponentsThatCanFailAreStillEvaluated" --tests "tests.wurstscript.tests.LuaBackendAuditTests.tupleFieldReadsOnlyLoadTheSelectedStorageComponent"`
- `./gradlew test --tests "tests.wurstscript.tests.TupleTests"`
- the new regression failed on the parent commit with `points_x/y` and `Entity_pos_x/y` discard calls, then passed with only the selected backing reads

## Scope

- tuple-return selection remains covered by the existing unread-return-slot regression
- no inliner, register-budget, spill fallback, assurance, or integer arithmetic lowering changes
- production-map counts and performance remain to be measured against a fresh parent-commit baseline
